### PR TITLE
Serialize StreamField snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You can access the admin at `localhost:800/admin` with the credentials `admin@au
 
 #### Access the API
 
-You can access the API at `localhost:8000/api`. You can see e.g. service pages by visiting `http://localhost:8000/api/pages/?format=json&type=base.ServicePage&fields=content,extra_content,theme`.
+You can access the API at `localhost:8000/api`. You can see e.g. service pages by visiting `http://localhost:8000/api/pages/?format=json&type=base.ServicePage&fields=content,extra_content,theme(text)`.
 
 
 ## Create migrations

--- a/joplin/base/blocks.py
+++ b/joplin/base/blocks.py
@@ -1,0 +1,6 @@
+from wagtail.wagtailsnippets.blocks import SnippetChooserBlock
+
+
+class SnippetChooserBlockWithAPIGoodness(SnippetChooserBlock):
+    def get_api_representation(self, model_instance, context=None):
+        return model_instance.serializable_data()

--- a/joplin/base/models.py
+++ b/joplin/base/models.py
@@ -1,16 +1,15 @@
 from django.db import models
 
-from modelcluster.fields import ParentalKey
 from modelcluster.models import ClusterableModel
 
 from wagtail.api import APIField
-from wagtail.wagtailadmin.edit_handlers import FieldPanel, InlinePanel, StreamFieldPanel
+from wagtail.wagtailadmin.edit_handlers import FieldPanel, StreamFieldPanel
 from wagtail.wagtailcore import blocks
 from wagtail.wagtailcore.fields import StreamField, RichTextField
 from wagtail.wagtailcore.models import Page
-from wagtail.wagtailsnippets.blocks import SnippetChooserBlock
-from wagtail.wagtailsnippets.edit_handlers import SnippetChooserPanel
 from wagtail.wagtailsnippets.models import register_snippet
+
+from . import blocks as custom_blocks
 
 
 class HomePage(Page):
@@ -29,9 +28,9 @@ class ServicePage(Page):
     extra_content = StreamField(
         [
             ('content', blocks.RichTextBlock(features=WYSIWYG_FEATURES, help_text='Write any additional content describing the service')),
-            ('application_block', SnippetChooserBlock('base.ApplicationBlock')),
+            ('application_block', custom_blocks.SnippetChooserBlockWithAPIGoodness('base.ApplicationBlock')),
         ],
-        verbose_name='Add any forms, maps, apps, or content that will help the resident use the service'
+        verbose_name='Add any forms, maps, apps, or content that will help the resident use the service',
     )
     theme = models.ForeignKey(
         'base.Theme',
@@ -59,6 +58,8 @@ class ServicePage(Page):
 @register_snippet
 class Theme(ClusterableModel):
     text = models.CharField(max_length=DEFAULT_MAX_LENGTH)
+
+    api_fields = ['text']
 
     def __str__(self):
         return self.text


### PR DESCRIPTION
The [wagtail docs recommend custom serializers](http://docs.wagtail.io/en/v1.13.1/advanced_topics/api/v2/configuration.html#custom-serialisers) if you need to have
a custom representation.

However, this doesn't work for StreamField blocks. They [have to be handled
separately](https://stackoverflow.com/questions/41956709/custom-representation-of-streamfield-in-rest-api) by overriding `get_api_representation` for the block.
This approach seems kinda weird but is the only way it'll work currently.

With this change you'll see both the `extra_content.application_block` values as well as `theme.text`

```sh
curl -Ss 'http://localhost:8000/api/pages/4/?fields=content,extra_content,theme(text)'  | jq '{theme:.theme,extra_content:.extra_content[0]}'
```

```json
{
  "theme": {
    "id": 1,
    "meta": {
      "type": "base.Theme"
    },
    "text": "Keeping Austin Beautiful"
  },
  "extra_content": {
    "type": "application_block",
    "value": {
      "pk": 3,
      "url": "http://www.austintexas.gov/sites/default/files/files/Resource_Recovery/ZilkerMap_ButtonArtwork.png",
      "description": "Map for Christmas Tree Dropoff"
    },
    "id": "f3154cf7-22c1-4d88-89f9-ee3f834f6ec7"
  }
}
```