### PR TITLE
Add deploy script for heroku

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,6 @@ FROM python:3.6.3-slim-stretch
 
 RUN mkdir /app /deploy
 
-EXPOSE 80
-
 WORKDIR /app
 
 COPY /deploy/requirements.txt /deploy/requirements.txt
@@ -16,5 +14,8 @@ COPY "$PWD/fixtures" /app/fixtures
 COPY "$PWD/docker-entrypoint.sh" /app/docker-entrypoint.sh
 COPY "$PWD/joplin" /app/joplin
 
+ENV PORT ${PORT:-80}
+EXPOSE $PORT
+
 ENTRYPOINT ["./docker-entrypoint.sh"]
-CMD ["./joplin/manage.py", "runserver", "0.0.0.0:80"]
+CMD ./joplin/manage.py runserver 0.0.0.0:$PORT

--- a/joplin/settings.py
+++ b/joplin/settings.py
@@ -146,6 +146,10 @@ MEDIA_URL = '/media/'
 AUTH_USER_MODEL = 'users.User'
 
 CORS_ORIGIN_ALLOW_ALL = True
+ALLOWED_HOSTS = [
+    'localhost',
+    '.herokuapp.com',
+]
 
 
 # Wagtail settings

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -o errexit
+
+APP='joplin-staging'
+
+CURRENT_CONFIG=$(heroku config --app "$APP")
+
+if [[ $CURRENT_CONFIG != *"JANIS_URL"* ]]; then
+    heroku config:set LOAD_DATA=on JANIS_URL=https://janis-staging.herokuapp.com --app "$APP"
+fi
+
+heroku container:push web --app "$APP"


### PR DESCRIPTION
Little deets:
- Add necessary `ALLOWED_HOSTS` so django doesn't cry when a request comes from heroku
- Modify Dockerfile to support `PORT` environment variable, which is required by heroku