### PR TITLE
Format fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,17 @@ docker exec --interactive --tty joplin python joplin/manage.py migrate
 
 Run the following to dump the latest page data. You might need to add other items from `base` or another package if you want other page types or snippets dumped.
 
+#### To export new content
+
+To export data changed in the CMS, run the following command:
+
 ```
 docker exec --interactive --tty joplin python joplin/manage.py dumpdata --indent 2 --natural-primary --natural-foreign base wagtailcore.Page wagtailcore.PageRevision > fixtures/pages.json
 ```
+
+#### To export internal data
+
+After you add or change a model, you might also need to export the internal CMS data. Run the above command to export content data. Then run:
 
 ```
 docker exec --interactive --tty joplin python joplin/manage.py dumpdata --indent 2 --natural-foreign wagtailcore.site wagtailcore.collection wagtailcore.grouppagepermission wagtailcore.groupcollectionpermission contenttypes auth.group > fixtures/base.json

--- a/fixtures/base.json
+++ b/fixtures/base.json
@@ -1,567 +1,609 @@
 [
-  {
-    "model": "wagtailcore.site",
-    "fields": {
-      "hostname": "localhost",
-      "port": 80,
-      "site_name": null,
-      "root_page": 3,
-      "is_default_site": true
-    }
-  },
-  {
-    "model": "wagtailcore.collection",
-    "pk": 1,
-    "fields": {
-      "path": "0001",
-      "depth": 1,
-      "numchild": 0,
-      "name": "Root"
-    }
-  },
-  {
-    "model": "contenttypes.contenttype",
-    "fields": {
-      "app_label": "wagtailcore",
-      "model": "page"
-    }
-  },
-  {
-    "model": "contenttypes.contenttype",
-    "fields": {
-      "app_label": "base",
-      "model": "homepage"
-    }
-  },
-  {
-    "model": "contenttypes.contenttype",
-    "fields": {
-      "app_label": "wagtailadmin",
-      "model": "admin"
-    }
-  },
-  {
-    "model": "contenttypes.contenttype",
-    "fields": {
-      "app_label": "wagtaildocs",
-      "model": "document"
-    }
-  },
-  {
-    "model": "contenttypes.contenttype",
-    "fields": {
-      "app_label": "wagtailimages",
-      "model": "image"
-    }
-  },
-  {
-    "model": "contenttypes.contenttype",
-    "fields": {
-      "app_label": "base",
-      "model": "applicationblock"
-    }
-  },
-  {
-    "model": "contenttypes.contenttype",
-    "fields": {
-      "app_label": "base",
-      "model": "contact"
-    }
-  },
-  {
-    "model": "contenttypes.contenttype",
-    "fields": {
-      "app_label": "base",
-      "model": "department"
-    }
-  },
-  {
-    "model": "contenttypes.contenttype",
-    "fields": {
-      "app_label": "base",
-      "model": "director"
-    }
-  },
-  {
-    "model": "contenttypes.contenttype",
-    "fields": {
-      "app_label": "base",
-      "model": "event"
-    }
-  },
-  {
-    "model": "contenttypes.contenttype",
-    "fields": {
-      "app_label": "base",
-      "model": "location"
-    }
-  },
-  {
-    "model": "contenttypes.contenttype",
-    "fields": {
-      "app_label": "base",
-      "model": "servicepage"
-    }
-  },
-  {
-    "model": "contenttypes.contenttype",
-    "fields": {
-      "app_label": "base",
-      "model": "topic"
-    }
-  },
-  {
-    "model": "contenttypes.contenttype",
-    "fields": {
-      "app_label": "users",
-      "model": "user"
-    }
-  },
-  {
-    "model": "contenttypes.contenttype",
-    "fields": {
-      "app_label": "wagtailforms",
-      "model": "formsubmission"
-    }
-  },
-  {
-    "model": "contenttypes.contenttype",
-    "fields": {
-      "app_label": "wagtailredirects",
-      "model": "redirect"
-    }
-  },
-  {
-    "model": "contenttypes.contenttype",
-    "fields": {
-      "app_label": "wagtailembeds",
-      "model": "embed"
-    }
-  },
-  {
-    "model": "contenttypes.contenttype",
-    "fields": {
-      "app_label": "wagtailusers",
-      "model": "userprofile"
-    }
-  },
-  {
-    "model": "contenttypes.contenttype",
-    "fields": {
-      "app_label": "wagtailimages",
-      "model": "rendition"
-    }
-  },
-  {
-    "model": "contenttypes.contenttype",
-    "fields": {
-      "app_label": "wagtailsearch",
-      "model": "query"
-    }
-  },
-  {
-    "model": "contenttypes.contenttype",
-    "fields": {
-      "app_label": "wagtailsearch",
-      "model": "querydailyhits"
-    }
-  },
-  {
-    "model": "contenttypes.contenttype",
-    "fields": {
-      "app_label": "wagtailcore",
-      "model": "grouppagepermission"
-    }
-  },
-  {
-    "model": "contenttypes.contenttype",
-    "fields": {
-      "app_label": "wagtailcore",
-      "model": "pagerevision"
-    }
-  },
-  {
-    "model": "contenttypes.contenttype",
-    "fields": {
-      "app_label": "wagtailcore",
-      "model": "pageviewrestriction"
-    }
-  },
-  {
-    "model": "contenttypes.contenttype",
-    "fields": {
-      "app_label": "wagtailcore",
-      "model": "site"
-    }
-  },
-  {
-    "model": "contenttypes.contenttype",
-    "fields": {
-      "app_label": "wagtailcore",
-      "model": "collection"
-    }
-  },
-  {
-    "model": "contenttypes.contenttype",
-    "fields": {
-      "app_label": "wagtailcore",
-      "model": "groupcollectionpermission"
-    }
-  },
-  {
-    "model": "contenttypes.contenttype",
-    "fields": {
-      "app_label": "wagtailcore",
-      "model": "collectionviewrestriction"
-    }
-  },
-  {
-    "model": "contenttypes.contenttype",
-    "fields": {
-      "app_label": "taggit",
-      "model": "tag"
-    }
-  },
-  {
-    "model": "contenttypes.contenttype",
-    "fields": {
-      "app_label": "taggit",
-      "model": "taggeditem"
-    }
-  },
-  {
-    "model": "contenttypes.contenttype",
-    "fields": {
-      "app_label": "admin",
-      "model": "logentry"
-    }
-  },
-  {
-    "model": "contenttypes.contenttype",
-    "fields": {
-      "app_label": "auth",
-      "model": "permission"
-    }
-  },
-  {
-    "model": "contenttypes.contenttype",
-    "fields": {
-      "app_label": "auth",
-      "model": "group"
-    }
-  },
-  {
-    "model": "contenttypes.contenttype",
-    "fields": {
-      "app_label": "contenttypes",
-      "model": "contenttype"
-    }
-  },
-  {
-    "model": "contenttypes.contenttype",
-    "fields": {
-      "app_label": "sessions",
-      "model": "session"
-    }
-  },
-  {
-    "model": "contenttypes.contenttype",
-    "fields": {
-      "app_label": "base",
-      "model": "dayandduration"
-    }
-  },
-  {
-    "model": "contenttypes.contenttype",
-    "fields": {
-      "app_label": "base",
-      "model": "servicepagecontact"
-    }
-  },
-  {
-    "model": "contenttypes.contenttype",
-    "fields": {
-      "app_label": "base",
-      "model": "departmentcontact"
-    }
-  },
-  {
-    "model": "contenttypes.contenttype",
-    "fields": {
-      "app_label": "base",
-      "model": "contactdayandduration"
-    }
-  },
-  {
-    "model": "auth.group",
-    "fields": {
-      "name": "Moderators",
-      "permissions": [
-        [
-          "access_admin",
-          "wagtailadmin",
-          "admin"
-        ],
-        [
-          "add_document",
-          "wagtaildocs",
-          "document"
-        ],
-        [
-          "change_document",
-          "wagtaildocs",
-          "document"
-        ],
-        [
-          "delete_document",
-          "wagtaildocs",
-          "document"
-        ],
-        [
-          "add_image",
-          "wagtailimages",
-          "image"
-        ],
-        [
-          "change_image",
-          "wagtailimages",
-          "image"
-        ],
-        [
-          "delete_image",
-          "wagtailimages",
-          "image"
-        ]
-      ]
-    }
-  },
-  {
-    "model": "auth.group",
-    "fields": {
-      "name": "Editors",
-      "permissions": [
-        [
-          "access_admin",
-          "wagtailadmin",
-          "admin"
-        ],
-        [
-          "add_document",
-          "wagtaildocs",
-          "document"
-        ],
-        [
-          "change_document",
-          "wagtaildocs",
-          "document"
-        ],
-        [
-          "delete_document",
-          "wagtaildocs",
-          "document"
-        ],
-        [
-          "add_image",
-          "wagtailimages",
-          "image"
-        ],
-        [
-          "change_image",
-          "wagtailimages",
-          "image"
-        ],
-        [
-          "delete_image",
-          "wagtailimages",
-          "image"
-        ]
-      ]
-    }
-  },
-  {
-    "model": "wagtailcore.groupcollectionpermission",
-    "pk": 1,
-    "fields": {
-      "group": [
-        "Editors"
-      ],
-      "collection": 1,
-      "permission": [
-        "add_document",
-        "wagtaildocs",
-        "document"
-      ]
-    }
-  },
-  {
-    "model": "wagtailcore.groupcollectionpermission",
-    "pk": 2,
-    "fields": {
-      "group": [
-        "Moderators"
-      ],
-      "collection": 1,
-      "permission": [
-        "add_document",
-        "wagtaildocs",
-        "document"
-      ]
-    }
-  },
-  {
-    "model": "wagtailcore.groupcollectionpermission",
-    "pk": 3,
-    "fields": {
-      "group": [
-        "Editors"
-      ],
-      "collection": 1,
-      "permission": [
-        "change_document",
-        "wagtaildocs",
-        "document"
-      ]
-    }
-  },
-  {
-    "model": "wagtailcore.groupcollectionpermission",
-    "pk": 4,
-    "fields": {
-      "group": [
-        "Moderators"
-      ],
-      "collection": 1,
-      "permission": [
-        "change_document",
-        "wagtaildocs",
-        "document"
-      ]
-    }
-  },
-  {
-    "model": "wagtailcore.groupcollectionpermission",
-    "pk": 5,
-    "fields": {
-      "group": [
-        "Editors"
-      ],
-      "collection": 1,
-      "permission": [
-        "add_image",
-        "wagtailimages",
-        "image"
-      ]
-    }
-  },
-  {
-    "model": "wagtailcore.groupcollectionpermission",
-    "pk": 6,
-    "fields": {
-      "group": [
-        "Moderators"
-      ],
-      "collection": 1,
-      "permission": [
-        "add_image",
-        "wagtailimages",
-        "image"
-      ]
-    }
-  },
-  {
-    "model": "wagtailcore.groupcollectionpermission",
-    "pk": 7,
-    "fields": {
-      "group": [
-        "Editors"
-      ],
-      "collection": 1,
-      "permission": [
-        "change_image",
-        "wagtailimages",
-        "image"
-      ]
-    }
-  },
-  {
-    "model": "wagtailcore.groupcollectionpermission",
-    "pk": 8,
-    "fields": {
-      "group": [
-        "Moderators"
-      ],
-      "collection": 1,
-      "permission": [
-        "change_image",
-        "wagtailimages",
-        "image"
-      ]
-    }
-  },
-  {
-    "model": "wagtailcore.grouppagepermission",
-    "pk": 1,
-    "fields": {
-      "group": [
-        "Moderators"
-      ],
-      "page": 1,
-      "permission_type": "add"
-    }
-  },
-  {
-    "model": "wagtailcore.grouppagepermission",
-    "pk": 2,
-    "fields": {
-      "group": [
-        "Moderators"
-      ],
-      "page": 1,
-      "permission_type": "edit"
-    }
-  },
-  {
-    "model": "wagtailcore.grouppagepermission",
-    "pk": 3,
-    "fields": {
-      "group": [
-        "Moderators"
-      ],
-      "page": 1,
-      "permission_type": "publish"
-    }
-  },
-  {
-    "model": "wagtailcore.grouppagepermission",
-    "pk": 4,
-    "fields": {
-      "group": [
-        "Editors"
-      ],
-      "page": 1,
-      "permission_type": "add"
-    }
-  },
-  {
-    "model": "wagtailcore.grouppagepermission",
-    "pk": 5,
-    "fields": {
-      "group": [
-        "Editors"
-      ],
-      "page": 1,
-      "permission_type": "edit"
-    }
-  },
-  {
-    "model": "wagtailcore.grouppagepermission",
-    "pk": 6,
-    "fields": {
-      "group": [
-        "Moderators"
-      ],
-      "page": 1,
-      "permission_type": "lock"
-    }
+{
+  "model": "wagtailcore.site",
+  "pk": 2,
+  "fields": {
+    "hostname": "localhost",
+    "port": 80,
+    "site_name": null,
+    "root_page": 3,
+    "is_default_site": true
   }
+},
+{
+  "model": "wagtailcore.collection",
+  "pk": 1,
+  "fields": {
+    "path": "0001",
+    "depth": 1,
+    "numchild": 0,
+    "name": "Root"
+  }
+},
+{
+  "model": "contenttypes.contenttype",
+  "pk": 1,
+  "fields": {
+    "app_label": "wagtailcore",
+    "model": "page"
+  }
+},
+{
+  "model": "contenttypes.contenttype",
+  "pk": 2,
+  "fields": {
+    "app_label": "base",
+    "model": "homepage"
+  }
+},
+{
+  "model": "contenttypes.contenttype",
+  "pk": 3,
+  "fields": {
+    "app_label": "wagtailadmin",
+    "model": "admin"
+  }
+},
+{
+  "model": "contenttypes.contenttype",
+  "pk": 4,
+  "fields": {
+    "app_label": "wagtaildocs",
+    "model": "document"
+  }
+},
+{
+  "model": "contenttypes.contenttype",
+  "pk": 5,
+  "fields": {
+    "app_label": "wagtailimages",
+    "model": "image"
+  }
+},
+{
+  "model": "contenttypes.contenttype",
+  "pk": 6,
+  "fields": {
+    "app_label": "base",
+    "model": "applicationblock"
+  }
+},
+{
+  "model": "contenttypes.contenttype",
+  "pk": 7,
+  "fields": {
+    "app_label": "base",
+    "model": "contact"
+  }
+},
+{
+  "model": "contenttypes.contenttype",
+  "pk": 8,
+  "fields": {
+    "app_label": "base",
+    "model": "dayandduration"
+  }
+},
+{
+  "model": "contenttypes.contenttype",
+  "pk": 9,
+  "fields": {
+    "app_label": "base",
+    "model": "location"
+  }
+},
+{
+  "model": "contenttypes.contenttype",
+  "pk": 10,
+  "fields": {
+    "app_label": "base",
+    "model": "servicepage"
+  }
+},
+{
+  "model": "contenttypes.contenttype",
+  "pk": 11,
+  "fields": {
+    "app_label": "base",
+    "model": "servicepagecontact"
+  }
+},
+{
+  "model": "contenttypes.contenttype",
+  "pk": 12,
+  "fields": {
+    "app_label": "base",
+    "model": "topic"
+  }
+},
+{
+  "model": "contenttypes.contenttype",
+  "pk": 13,
+  "fields": {
+    "app_label": "base",
+    "model": "contactdayandduration"
+  }
+},
+{
+  "model": "contenttypes.contenttype",
+  "pk": 14,
+  "fields": {
+    "app_label": "base",
+    "model": "department"
+  }
+},
+{
+  "model": "contenttypes.contenttype",
+  "pk": 15,
+  "fields": {
+    "app_label": "base",
+    "model": "departmentcontact"
+  }
+},
+{
+  "model": "contenttypes.contenttype",
+  "pk": 16,
+  "fields": {
+    "app_label": "users",
+    "model": "user"
+  }
+},
+{
+  "model": "contenttypes.contenttype",
+  "pk": 17,
+  "fields": {
+    "app_label": "wagtailforms",
+    "model": "formsubmission"
+  }
+},
+{
+  "model": "contenttypes.contenttype",
+  "pk": 18,
+  "fields": {
+    "app_label": "wagtailredirects",
+    "model": "redirect"
+  }
+},
+{
+  "model": "contenttypes.contenttype",
+  "pk": 19,
+  "fields": {
+    "app_label": "wagtailembeds",
+    "model": "embed"
+  }
+},
+{
+  "model": "contenttypes.contenttype",
+  "pk": 20,
+  "fields": {
+    "app_label": "wagtailusers",
+    "model": "userprofile"
+  }
+},
+{
+  "model": "contenttypes.contenttype",
+  "pk": 21,
+  "fields": {
+    "app_label": "wagtailimages",
+    "model": "rendition"
+  }
+},
+{
+  "model": "contenttypes.contenttype",
+  "pk": 22,
+  "fields": {
+    "app_label": "wagtailsearch",
+    "model": "query"
+  }
+},
+{
+  "model": "contenttypes.contenttype",
+  "pk": 23,
+  "fields": {
+    "app_label": "wagtailsearch",
+    "model": "querydailyhits"
+  }
+},
+{
+  "model": "contenttypes.contenttype",
+  "pk": 24,
+  "fields": {
+    "app_label": "wagtailcore",
+    "model": "grouppagepermission"
+  }
+},
+{
+  "model": "contenttypes.contenttype",
+  "pk": 25,
+  "fields": {
+    "app_label": "wagtailcore",
+    "model": "pagerevision"
+  }
+},
+{
+  "model": "contenttypes.contenttype",
+  "pk": 26,
+  "fields": {
+    "app_label": "wagtailcore",
+    "model": "pageviewrestriction"
+  }
+},
+{
+  "model": "contenttypes.contenttype",
+  "pk": 27,
+  "fields": {
+    "app_label": "wagtailcore",
+    "model": "site"
+  }
+},
+{
+  "model": "contenttypes.contenttype",
+  "pk": 28,
+  "fields": {
+    "app_label": "wagtailcore",
+    "model": "collection"
+  }
+},
+{
+  "model": "contenttypes.contenttype",
+  "pk": 29,
+  "fields": {
+    "app_label": "wagtailcore",
+    "model": "groupcollectionpermission"
+  }
+},
+{
+  "model": "contenttypes.contenttype",
+  "pk": 30,
+  "fields": {
+    "app_label": "wagtailcore",
+    "model": "collectionviewrestriction"
+  }
+},
+{
+  "model": "contenttypes.contenttype",
+  "pk": 31,
+  "fields": {
+    "app_label": "taggit",
+    "model": "tag"
+  }
+},
+{
+  "model": "contenttypes.contenttype",
+  "pk": 32,
+  "fields": {
+    "app_label": "taggit",
+    "model": "taggeditem"
+  }
+},
+{
+  "model": "contenttypes.contenttype",
+  "pk": 33,
+  "fields": {
+    "app_label": "admin",
+    "model": "logentry"
+  }
+},
+{
+  "model": "contenttypes.contenttype",
+  "pk": 34,
+  "fields": {
+    "app_label": "auth",
+    "model": "permission"
+  }
+},
+{
+  "model": "contenttypes.contenttype",
+  "pk": 35,
+  "fields": {
+    "app_label": "auth",
+    "model": "group"
+  }
+},
+{
+  "model": "contenttypes.contenttype",
+  "pk": 36,
+  "fields": {
+    "app_label": "contenttypes",
+    "model": "contenttype"
+  }
+},
+{
+  "model": "contenttypes.contenttype",
+  "pk": 37,
+  "fields": {
+    "app_label": "sessions",
+    "model": "session"
+  }
+},
+{
+  "model": "contenttypes.contenttype",
+  "pk": 38,
+  "fields": {
+    "app_label": "base",
+    "model": "director"
+  }
+},
+{
+  "model": "contenttypes.contenttype",
+  "pk": 39,
+  "fields": {
+    "app_label": "base",
+    "model": "event"
+  }
+},
+{
+  "model": "auth.group",
+  "pk": 1,
+  "fields": {
+    "name": "Moderators",
+    "permissions": [
+      [
+        "access_admin",
+        "wagtailadmin",
+        "admin"
+      ],
+      [
+        "add_document",
+        "wagtaildocs",
+        "document"
+      ],
+      [
+        "change_document",
+        "wagtaildocs",
+        "document"
+      ],
+      [
+        "delete_document",
+        "wagtaildocs",
+        "document"
+      ],
+      [
+        "add_image",
+        "wagtailimages",
+        "image"
+      ],
+      [
+        "change_image",
+        "wagtailimages",
+        "image"
+      ],
+      [
+        "delete_image",
+        "wagtailimages",
+        "image"
+      ]
+    ]
+  }
+},
+{
+  "model": "auth.group",
+  "pk": 2,
+  "fields": {
+    "name": "Editors",
+    "permissions": [
+      [
+        "access_admin",
+        "wagtailadmin",
+        "admin"
+      ],
+      [
+        "add_document",
+        "wagtaildocs",
+        "document"
+      ],
+      [
+        "change_document",
+        "wagtaildocs",
+        "document"
+      ],
+      [
+        "delete_document",
+        "wagtaildocs",
+        "document"
+      ],
+      [
+        "add_image",
+        "wagtailimages",
+        "image"
+      ],
+      [
+        "change_image",
+        "wagtailimages",
+        "image"
+      ],
+      [
+        "delete_image",
+        "wagtailimages",
+        "image"
+      ]
+    ]
+  }
+},
+{
+  "model": "wagtailcore.groupcollectionpermission",
+  "pk": 1,
+  "fields": {
+    "group": [
+      "Editors"
+    ],
+    "collection": 1,
+    "permission": [
+      "add_document",
+      "wagtaildocs",
+      "document"
+    ]
+  }
+},
+{
+  "model": "wagtailcore.groupcollectionpermission",
+  "pk": 2,
+  "fields": {
+    "group": [
+      "Moderators"
+    ],
+    "collection": 1,
+    "permission": [
+      "add_document",
+      "wagtaildocs",
+      "document"
+    ]
+  }
+},
+{
+  "model": "wagtailcore.groupcollectionpermission",
+  "pk": 3,
+  "fields": {
+    "group": [
+      "Editors"
+    ],
+    "collection": 1,
+    "permission": [
+      "change_document",
+      "wagtaildocs",
+      "document"
+    ]
+  }
+},
+{
+  "model": "wagtailcore.groupcollectionpermission",
+  "pk": 4,
+  "fields": {
+    "group": [
+      "Moderators"
+    ],
+    "collection": 1,
+    "permission": [
+      "change_document",
+      "wagtaildocs",
+      "document"
+    ]
+  }
+},
+{
+  "model": "wagtailcore.groupcollectionpermission",
+  "pk": 5,
+  "fields": {
+    "group": [
+      "Editors"
+    ],
+    "collection": 1,
+    "permission": [
+      "add_image",
+      "wagtailimages",
+      "image"
+    ]
+  }
+},
+{
+  "model": "wagtailcore.groupcollectionpermission",
+  "pk": 6,
+  "fields": {
+    "group": [
+      "Moderators"
+    ],
+    "collection": 1,
+    "permission": [
+      "add_image",
+      "wagtailimages",
+      "image"
+    ]
+  }
+},
+{
+  "model": "wagtailcore.groupcollectionpermission",
+  "pk": 7,
+  "fields": {
+    "group": [
+      "Editors"
+    ],
+    "collection": 1,
+    "permission": [
+      "change_image",
+      "wagtailimages",
+      "image"
+    ]
+  }
+},
+{
+  "model": "wagtailcore.groupcollectionpermission",
+  "pk": 8,
+  "fields": {
+    "group": [
+      "Moderators"
+    ],
+    "collection": 1,
+    "permission": [
+      "change_image",
+      "wagtailimages",
+      "image"
+    ]
+  }
+},
+{
+  "model": "wagtailcore.grouppagepermission",
+  "pk": 1,
+  "fields": {
+    "group": [
+      "Moderators"
+    ],
+    "page": 1,
+    "permission_type": "add"
+  }
+},
+{
+  "model": "wagtailcore.grouppagepermission",
+  "pk": 2,
+  "fields": {
+    "group": [
+      "Moderators"
+    ],
+    "page": 1,
+    "permission_type": "edit"
+  }
+},
+{
+  "model": "wagtailcore.grouppagepermission",
+  "pk": 3,
+  "fields": {
+    "group": [
+      "Moderators"
+    ],
+    "page": 1,
+    "permission_type": "publish"
+  }
+},
+{
+  "model": "wagtailcore.grouppagepermission",
+  "pk": 4,
+  "fields": {
+    "group": [
+      "Editors"
+    ],
+    "page": 1,
+    "permission_type": "add"
+  }
+},
+{
+  "model": "wagtailcore.grouppagepermission",
+  "pk": 5,
+  "fields": {
+    "group": [
+      "Editors"
+    ],
+    "page": 1,
+    "permission_type": "edit"
+  }
+},
+{
+  "model": "wagtailcore.grouppagepermission",
+  "pk": 6,
+  "fields": {
+    "group": [
+      "Moderators"
+    ],
+    "page": 1,
+    "permission_type": "lock"
+  }
+}
 ]

--- a/fixtures/pages.json
+++ b/fixtures/pages.json
@@ -1,736 +1,736 @@
 [
-  {
-    "model": "base.homepage",
-    "pk": 3,
-    "fields": {}
-  },
-  {
-    "model": "base.servicepage",
-    "pk": 4,
-    "fields": {
-      "created_at": "2017-12-06T17:09:43.155Z",
-      "updated_at": "2018-01-02T21:21:54.922Z",
-      "content": "",
-      "content_ar": null,
-      "content_en": "<ol><li><p>All residents can drop-off their trees to be recycled into mulch. To drop your tree off at Zilker Park, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Drop your tree off between 10am and 2pm on one of the following days:</p></li><ol><li><p>Saturday, December 30, 2017</p></li><li><p>Sunday, December 31, 2017</p></li><li><p>Saturday, January 6, 2018</p></li><li><p>Sunday, January 7, 2018</p></li></ol><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li><li><p>Do you live in a house? Skip ahead and read about recycling your Christmas tree at the curb.</p></li></ol>",
-      "content_es": "",
-      "content_ko": null,
-      "content_my": null,
-      "content_ur": null,
-      "content_vi": null,
-      "content_zh_hans": null,
-      "content_zh_hant": null,
-      "extra_content": "[{\"type\": \"application_block\", \"value\": 3, \"id\": \"f3154cf7-22c1-4d88-89f9-ee3f834f6ec7\"}, {\"type\": \"content\", \"value\": \"<h2>Free Drop-Off Locations</h2><p>Trees will be accepted free of cost at the locations listed below. However, a contamination fee will be added to any trees with tags, decorations, and/or plastic remaining.</p><br/><p><a href=\\\"http://www.texasdisposal.com/contact/\\\">Texas Disposal Systems</a><br/>TDS Landfill: 3016 FM 1327, Creedmoor, Texas<br/>Eco Depot: 4001 RR 620 South, Bee Cave, Texas</p><p><a href=\\\"http://www.organicsbygosh.com/drop-off-collection/\\\">Organics By Gosh</a><br/>13602 FM 969, Austin, TX 78724\\u2028 | (512) 276-1211</p><p><a href=\\\"http://www.daisyworksdirt.com/\\\">Walker Aero Environmental (JV Dirt)</a><br/>3600 FM 973 North Austin, Texas 78725</p><p><a href=\\\"http://www.989rock.com/\\\">Whittlesey Landscape Supplies</a><br/>3219 S IH 35 Round Rock, Texas 78664<br/>629 Dalton Lane, Austin, Texas 78742</p><p><a href=\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\">Travis County Transfer Station</a><br/>2625 Woodall Dr. Leander, Texas 78641</p><p><a href=\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\">Travis County Service Center</a><br/>6013 Blue Bluff Rd Austin, Texas 78724</p><p><a href=\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\">Del Valle Softball Complex (Behind the Southwest Rural Center)</a><br/>3614 FM 973 Del Valle, Texas 78617</p><br/><h2>Drop-Off Locations with a Fee</h2><p>Locations listed below have varying fees. Call the location for more information. \\u00a0</p><p><a href=\\\"http://firewoodandmulchaustintx.com/\\\">Kinser Ranch LLC.</a><br/>Starts at $1.00/per tree to $20/per load.<br/>For more information: 512-748-0800<br/>10701 Kinser Lane, Austin, Texas 78736</p><p><a href=\\\"http://www.sidmourningtreeservice.com/\\\">Sid Mourning Tree Service</a><br/>Pricing varies.<br/>Call for fee information: 512-420-0733<br/>3810 Medical Parkway Austin, TX 78756</p><p><a href=\\\"http://www.austinwoodrecycling.com/\\\">Austin Wood Recycling</a><br/>$5.00/per tree.<br/>For more information: 512-259-7430<br/>3875 E. Whitestone Blvd., Cedar Park, TX 78613</p><p><a href=\\\"http://www.goodguystreeservice.com/\\\">Good Guys Tree Service</a><br/>Prices vary.<br/>For more information: 512-743-3909<br/>11601 Anderson Mill Rd., Austin, TX 78750</p><h1>Do you live in a house? You can recycle your Christmas tree at the curb</h1><br/><ol><li><p>If you are a City of Austin curbside customer, and you would like to have your tree picked up and turned into mulch, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Cut the tree in half if it is longer than 6 feet.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Set your tree out on the curb by 6:30 am on your regular collection day.</p></li><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li></ol>\", \"id\": \"b748924c-4c94-4a4f-a3b2-3730684980f8\"}]",
-      "topic": 1
-    }
-  },
-  {
-    "model": "base.servicepage",
-    "pk": 5,
-    "fields": {
-      "created_at": "2017-12-06T21:02:34.149Z",
-      "updated_at": "2018-01-04T23:46:35.212Z",
-      "content": "",
-      "content_ar": null,
-      "content_en": "<ol><li><p>Visit the ReUse Store in the Recycle &amp; Reuse Drop-Off Center at 2514 Business Center Dr, Austin, TX 78744.</p></li><li><p>Many materials that are dropped off at the Recycle &amp; Reuse Drop-Off Center are in usable condition. These items go to the ReUse Store. Pick up these items for free:</p></li><ol><li><p>House paint</p></li><li><p>Art supplies</p></li><li><p>Cleaning products</p></li><li><p>Household chemicals</p></li><li><p>Automotive fluids</p></li><li><p>Mulch</p></li></ol></ol>",
-      "content_es": "<p>This is a spanish version<br/></p>",
-      "content_ko": null,
-      "content_my": null,
-      "content_ur": null,
-      "content_vi": "<p>This is a vietnamese version<br/></p>",
-      "content_zh_hans": null,
-      "content_zh_hant": null,
-      "extra_content": "[{\"type\": \"application_block\", \"value\": 4, \"id\": \"003658b6-170d-4baf-9c61-848d26511e5f\"}, {\"type\": \"content\", \"value\": \"<h1>Learn About Austin ReBlend Paint</h1><p>Paint dropped off by customers is inspected before it is chosen to be used in Austin ReBlend. It is then consolidated, blended, filtered and packed by trained personnel to ensure a quality product.</p><p>Austin ReBlend paint is free for individuals and nonprofits, and can save residents money when refurbishing their homes. The paint is not available to businesses.</p><p>It is available in 3.5 gallon containers and three colors:</p><ul><li><p>Texas Limestone (beige)</p></li><li><p>Balcones Canyonland (dark beige)</p></li><li><p>Barton Creek Greenbelt (dark green)</p></li></ul><h1>Pick Up Free Mulch</h1><p>You can pick up mulch for free; however, you must load it yourself. Bring a pitchfork or shovel, work gloves and containers.</p>\", \"id\": \"fff2155d-fc2b-411d-8c3a-1dcef2fff99c\"}]",
-      "topic": 1
-    }
-  },
-  {
-    "model": "base.servicepage",
-    "pk": 6,
-    "fields": {
-      "created_at": "2017-12-06T21:04:17.978Z",
-      "updated_at": "2017-12-13T22:40:28.196Z",
-      "content": "",
-      "content_ar": null,
-      "content_en": "<ol><li><p>Type your address, without apartment or unit number, in the box below.</p></li><li><p>Press the search button to view your curbside pickup schedule. </p></li><li><p>Use <a href=\"https://austintexas.gov/page/my-collection-schedule\">My Schedule</a> to get your personalized collection calendar.</p></li><li><p>(Optional) Click the icon to add your pickup days to your Google, iCal, or Microsoft calendar or print a copy of your schedule.</p></li></ol>",
-      "content_es": "",
-      "content_ko": null,
-      "content_my": null,
-      "content_ur": null,
-      "content_vi": null,
-      "content_zh_hans": null,
-      "content_zh_hant": null,
-      "extra_content": "[{\"type\": \"application_block\", \"value\": 1, \"id\": \"31dfdd2f-162c-4523-a4a5-ea6dced160f8\"}, {\"type\": \"content\", \"value\": \"<p>If your pickup day falls on Thanksgiving Day, Christmas Day or New Year's Day\\u2014or if it falls after the holiday in the same week\\u2014it slides to one day later. If the holiday falls on a Sunday, your pickup day will not slide.</p><br/>We will pick up your trash, compost, and yard trimmings every week. Every other week, we will pick up recycling, clothing, and housewares. All curbside pick-ups happen on the same day of the week unless it is a holiday. Use <a href=\\\"https://austintexas.gov/page/my-collection-schedule\\\">My Schedule</a> to get your personalized collection calendar.\", \"id\": \"975a8966-601c-4940-a306-4a53ff01b85b\"}]",
-      "topic": 1
-    }
-  },
-  {
-    "model": "base.servicepage",
-    "pk": 7,
-    "fields": {
-      "created_at": "2017-12-06T21:05:44.483Z",
-      "updated_at": "2017-12-13T22:07:17.819Z",
-      "content": "",
-      "content_ar": null,
-      "content_en": "<ol><li><p>Place appliances, furniture, carpet and other bulk items on your curb. Use the <a href=\"http://austintexas.gov/what-do-i-do\">\u201cWhat do I do with\u201d tool</a> to find out what you can bulk pick-up below. </p></li><li><p>Look up your twice-a-year bulk pick-up weeks with <a href=\"http://www.austintexas.gov/page/my-collection-schedule\">My Collection Schedule</a>. We only collect bulk items from Austin residential trash and recycling customers. </p></li><li><p>Place bulk items at the curb in front of your house by 6:30 a.m. on the first day of your scheduled collection week.</p></li><li><p>Separate items into three piles. </p></li><ol><li><p>Metal - includes appliances, doors must be removed</p></li><li><p>Passenger car tires - limit of eight tires per household, rims must be removed, no truck or tractor tires </p></li><li><p>Non-metal items - includes carpeting and nail-free lumber</p></li></ol></ol>",
-      "content_es": "",
-      "content_ko": null,
-      "content_my": null,
-      "content_ur": null,
-      "content_vi": null,
-      "content_zh_hans": null,
-      "content_zh_hant": null,
-      "extra_content": "[{\"type\": \"application_block\", \"value\": 2, \"id\": \"ac2d7108-e0ee-4887-b454-b0cdc4886b06\"}, {\"type\": \"application_block\", \"value\": 1, \"id\": \"cb0fc00e-5811-4117-b369-72d9222000ac\"}, {\"type\": \"content\", \"value\": \"<p>Do not put bulk items in bags, boxes or other containers. Bags will be treated as extra trash and are subject to extra trash fees.</p><br/><p>Items will not be picked up if they are in an alley in any area, including Hyde Park, in front of a vacant lot or in front of a business</p><br/><p>To prevent damage to your property, keep bulk items 5 feet away from your:</p><ol><ol><li><p>trash cart</p></li><li><p>Mailbox</p></li><li><p>fences or walls</p></li><li><p>water meter</p></li><li><p>telephone connection box</p></li><li><p>parked cars. </p></li></ol></ol><br/><p>Do not place any items under low hanging tree limbs or power lines.</p><br/><p>The three separate piles are collected by different trucks and may be collected at different times throughout the week.</p>\", \"id\": \"60dacf8d-e0c9-4248-9252-d3a438ba58a3\"}]",
-      "topic": 1
-    }
-  },
-  {
-    "model": "base.topic",
-    "pk": 1,
-    "fields": {
-      "text": "Manage recycling, compost, trash, energy, and water",
-      "description": "The City of Austin provides hundreds of services to residents to help them manage things like recycling, trash, energy, and water. This is a short list of services that will grow over time."
-    }
-  },
-  {
-    "model": "base.applicationblock",
-    "pk": 1,
-    "fields": {
-      "url": "http://www.austintexas.gov/page/my-collection-schedule",
-      "description": "Collection Schedule Lookup"
-    }
-  },
-  {
-    "model": "base.applicationblock",
-    "pk": 2,
-    "fields": {
-      "url": "http://austintexas.gov/what-do-i-do",
-      "description": "What do I do with..."
-    }
-  },
-  {
-    "model": "base.applicationblock",
-    "pk": 3,
-    "fields": {
-      "url": "http://www.austintexas.gov/sites/default/files/files/Resource_Recovery/ZilkerMap_ButtonArtwork.png",
-      "description": "Map for Christmas Tree Dropoff"
-    }
-  },
-  {
-    "model": "base.applicationblock",
-    "pk": 4,
-    "fields": {
-      "url": "https://www.google.com/maps/place/2514+Business+Center+Dr,+Austin,+TX+78744/@30.2131997,-97.739937,17z",
-      "description": "Map for Hazardous Waste Dropoff Center"
-    }
-  },
-  {
-    "model": "base.location",
-    "pk": 1,
-    "fields": {
-      "name": "Austin Recycle and Reuse Drop-off Center",
-      "street": "2514 Business Center Dr",
-      "city": "Austin",
-      "state": "TX",
-      "country": "United States",
-      "zip": "78744"
-    }
-  },
-  {
-    "model": "base.dayandduration",
-    "pk": 1,
-    "fields": {
-      "day_of_week": "Monday",
-      "start_time": "08:00:00",
-      "end_time": "16:00:00"
-    }
-  },
-  {
-    "model": "base.dayandduration",
-    "pk": 2,
-    "fields": {
-      "day_of_week": "Monday",
-      "start_time": "10:00:00",
-      "end_time": "18:00:00"
-    }
-  },
-  {
-    "model": "base.dayandduration",
-    "pk": 3,
-    "fields": {
-      "day_of_week": "Monday",
-      "start_time": "12:00:00",
-      "end_time": "15:00:00"
-    }
-  },
-  {
-    "model": "base.contact",
-    "pk": 1,
-    "fields": {
-      "name": "Francine Hammerschmidt",
-      "email": "fran@gmail.com",
-      "phone": "5553941212",
-      "location": 1
-    }
-  },
-  {
-    "model": "base.contact",
-    "pk": 2,
-    "fields": {
-      "name": "\ud83e\udd8f",
-      "email": "rhinos@austintexas.io",
-      "phone": "5551211212",
-      "location": 1
-    }
-  },
-  {
-    "model": "base.contactdayandduration",
-    "pk": 2,
-    "fields": {
-      "sort_order": 0,
-      "contact": 1
-    }
-  },
-  {
-    "model": "base.contactdayandduration",
-    "pk": 3,
-    "fields": {
-      "sort_order": 0,
-      "contact": 2
-    }
-  },
-  {
-    "model": "base.servicepagecontact",
-    "pk": 1,
-    "fields": {
-      "page": 5,
-      "contact": 1
-    }
-  },
-  {
-    "model": "base.servicepagecontact",
-    "pk": 3,
-    "fields": {
-      "page": 4,
-      "contact": 2
-    }
-  },
-  {
-    "model": "base.department",
-    "pk": 1,
-    "fields": {
-      "name": "Rhino Recovery Resources",
-      "mission": "We recover rhinos for the City of Austin. Got rhino problems? We're here to help."
-    }
-  },
-  {
-    "model": "base.departmentcontact",
-    "pk": 1,
-    "fields": {
-      "department": 1,
-      "contact": 2
-    }
-  },
-  {
-    "model": "wagtailcore.page",
-    "pk": 1,
-    "fields": {
-      "path": "0001",
-      "depth": 1,
-      "numchild": 1,
-      "title": "Root",
-      "draft_title": "Root",
-      "slug": "root",
-      "content_type": [
-        "wagtailcore",
-        "page"
-      ],
-      "live": true,
-      "has_unpublished_changes": false,
-      "url_path": "/",
-      "owner": null,
-      "seo_title": "",
-      "show_in_menus": false,
-      "search_description": "",
-      "go_live_at": null,
-      "expire_at": null,
-      "expired": false,
-      "locked": false,
-      "first_published_at": null,
-      "last_published_at": null,
-      "latest_revision_created_at": null,
-      "live_revision": null
-    }
-  },
-  {
-    "model": "wagtailcore.page",
-    "pk": 3,
-    "fields": {
-      "path": "00010001",
-      "depth": 2,
-      "numchild": 4,
-      "title": "Home",
-      "draft_title": "Home",
-      "slug": "home",
-      "content_type": [
-        "base",
-        "homepage"
-      ],
-      "live": true,
-      "has_unpublished_changes": false,
-      "url_path": "/home/",
-      "owner": null,
-      "seo_title": "",
-      "show_in_menus": false,
-      "search_description": "",
-      "go_live_at": null,
-      "expire_at": null,
-      "expired": false,
-      "locked": false,
-      "first_published_at": null,
-      "last_published_at": null,
-      "latest_revision_created_at": null,
-      "live_revision": null
-    }
-  },
-  {
-    "model": "wagtailcore.page",
-    "pk": 4,
-    "fields": {
-      "path": "000100010001",
-      "depth": 3,
-      "numchild": 0,
-      "title": "Recycle your Christmas tree",
-      "draft_title": "Recycle your Christmas tree",
-      "slug": "holiday-tree-recycling",
-      "content_type": [
-        "base",
-        "servicepage"
-      ],
-      "live": true,
-      "has_unpublished_changes": false,
-      "url_path": "/home/holiday-tree-recycling/",
-      "owner": [
-        "admin@austintexas.io"
-      ],
-      "seo_title": "",
-      "show_in_menus": false,
-      "search_description": "",
-      "go_live_at": null,
-      "expire_at": null,
-      "expired": false,
-      "locked": false,
-      "first_published_at": "2017-12-06T17:09:43.276Z",
-      "last_published_at": "2018-01-02T21:21:54.865Z",
-      "latest_revision_created_at": "2018-01-02T21:21:54.628Z",
-      "live_revision": 20
-    }
-  },
-  {
-    "model": "wagtailcore.page",
-    "pk": 5,
-    "fields": {
-      "path": "000100010002",
-      "depth": 3,
-      "numchild": 0,
-      "title": "Pick Up Free Household Items from the ReUse Store",
-      "draft_title": "Pick Up Free Household Items from the ReUse Store",
-      "slug": "dropoff",
-      "content_type": [
-        "base",
-        "servicepage"
-      ],
-      "live": true,
-      "has_unpublished_changes": false,
-      "url_path": "/home/dropoff/",
-      "owner": [
-        "admin@austintexas.io"
-      ],
-      "seo_title": "",
-      "show_in_menus": false,
-      "search_description": "",
-      "go_live_at": null,
-      "expire_at": null,
-      "expired": false,
-      "locked": false,
-      "first_published_at": "2017-12-06T21:02:34.309Z",
-      "last_published_at": "2018-01-04T23:46:35.175Z",
-      "latest_revision_created_at": "2018-01-04T23:46:35.052Z",
-      "live_revision": 22
-    }
-  },
-  {
-    "model": "wagtailcore.page",
-    "pk": 6,
-    "fields": {
-      "path": "000100010003",
-      "depth": 3,
-      "numchild": 0,
-      "title": "Look up your Trash, Recycling, and Compost Days",
-      "draft_title": "Look up your Trash, Recycling, and Compost Days",
-      "slug": "residential-curbside-collection-schedule",
-      "content_type": [
-        "base",
-        "servicepage"
-      ],
-      "live": true,
-      "has_unpublished_changes": false,
-      "url_path": "/home/residential-curbside-collection-schedule/",
-      "owner": [
-        "admin@austintexas.io"
-      ],
-      "seo_title": "",
-      "show_in_menus": false,
-      "search_description": "",
-      "go_live_at": null,
-      "expire_at": null,
-      "expired": false,
-      "locked": false,
-      "first_published_at": "2017-12-06T21:04:18.098Z",
-      "last_published_at": "2017-12-13T22:40:28.138Z",
-      "latest_revision_created_at": "2017-12-13T22:40:27.871Z",
-      "live_revision": 10
-    }
-  },
-  {
-    "model": "wagtailcore.page",
-    "pk": 7,
-    "fields": {
-      "path": "000100010004",
-      "depth": 3,
-      "numchild": 0,
-      "title": "Get Ready for Bulk Item Pick-up",
-      "draft_title": "Get Ready for Bulk Item Pick-up",
-      "slug": "residential-bulk-collection",
-      "content_type": [
-        "base",
-        "servicepage"
-      ],
-      "live": true,
-      "has_unpublished_changes": false,
-      "url_path": "/home/residential-bulk-collection/",
-      "owner": [
-        "admin@austintexas.io"
-      ],
-      "seo_title": "",
-      "show_in_menus": false,
-      "search_description": "",
-      "go_live_at": null,
-      "expire_at": null,
-      "expired": false,
-      "locked": false,
-      "first_published_at": "2017-12-06T21:05:44.625Z",
-      "last_published_at": "2017-12-13T22:07:17.788Z",
-      "latest_revision_created_at": "2017-12-13T22:07:17.667Z",
-      "live_revision": 8
-    }
-  },
-  {
-    "model": "wagtailcore.pagerevision",
-    "pk": 1,
-    "fields": {
-      "page": 4,
-      "submitted_for_moderation": false,
-      "created_at": "2017-12-06T17:09:43.202Z",
-      "user": [
-        "admin@austintexas.io"
-      ],
-      "content_json": "{\"pk\": 4, \"path\": \"000100010001\", \"depth\": 3, \"numchild\": 0, \"title\": \"Recycle your Christmas tree\", \"draft_title\": \"Recycle your Christmas tree\", \"slug\": \"holiday-tree-recycling\", \"content_type\": 12, \"live\": true, \"has_unpublished_changes\": false, \"url_path\": \"/home/holiday-tree-recycling/\", \"owner\": 1, \"seo_title\": \"\", \"show_in_menus\": false, \"search_description\": \"\", \"go_live_at\": null, \"expire_at\": null, \"expired\": false, \"locked\": false, \"first_published_at\": null, \"last_published_at\": null, \"latest_revision_created_at\": null, \"live_revision\": null, \"created_at\": \"2017-12-06T17:09:43.155Z\", \"updated_at\": \"2017-12-06T17:09:43.200Z\", \"content\": \"<ol><li><p>All residents can drop-off their trees to be recycled into mulch. To drop your tree off at Zilker Park, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Drop your tree off between 10am and 2pm on one of the following days:</p></li><ol><li><p>Saturday, December 30, 2017</p></li><li><p>Sunday, December 31, 2017</p></li><li><p>Saturday, January 6, 2018</p></li><li><p>Sunday, January 7, 2018</p></li></ol><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li></ol><br/><ol><li><p>If you are a City of Austin curbside customer, and you would like to have your tree picked up and turned into mulch, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Cut the tree in half if it is longer than 6 feet.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Set your tree out on the curb by 6:30 am on your regular collection day.</p></li><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li></ol>\", \"extra_content\": \"[{\\\"type\\\": \\\"application_block\\\", \\\"value\\\": 3, \\\"id\\\": \\\"f3154cf7-22c1-4d88-89f9-ee3f834f6ec7\\\"}, {\\\"type\\\": \\\"content\\\", \\\"value\\\": \\\"<h2>Free Drop-Off Locations</h2><p>Trees will be accepted free of cost at the locations listed below. However, a contamination fee will be added to any trees with tags, decorations, and/or plastic remaining.</p><br/><p><a href=\\\\\\\"http://www.texasdisposal.com/contact/\\\\\\\">Texas Disposal Systems</a></p><ul><li><p>TDS Landfill: 3016 FM 1327, Creedmoor, Texas</p></li><li><p>Eco Depot: 4001 RR 620 South, Bee Cave, Texas</p></li></ul><p><a href=\\\\\\\"http://www.organicsbygosh.com/drop-off-collection/\\\\\\\">Organics By Gosh</a></p><ul><li><p>13602 FM 969, Austin, TX 78724\\\\u2028 | (512) 276-1211</p></li></ul><p><a href=\\\\\\\"http://www.daisyworksdirt.com/\\\\\\\">Walker Aero Environmental (JV Dirt) </a></p><ul><li><p>3600 FM 973 North Austin, Texas 78725</p></li></ul><p><a href=\\\\\\\"http://www.989rock.com/\\\\\\\">Whittlesey Landscape Supplies</a></p><ul><li><p>3219 S IH 35 Round Rock, Texas 78664</p></li><li><p>629 Dalton Lane, Austin, Texas 78742</p></li></ul><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Travis County Transfer Station</a></p><ul><li><p>2625 Woodall Dr. Leander, Texas 78641</p></li></ul><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Travis County Service Center</a></p><ul><li><p>6013 Blue Bluff Rd Austin, Texas 78724</p></li></ul><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Del Valle Softball Complex (Behind the Southwest Rural Center)</a></p><ul><li><p>3614 FM 973 Del Valle, Texas 78617</p></li></ul><br/><h2>Drop-Off Locations with a Fee</h2><p>Locations listed below have varying fees. Call the location for more information. \\\\u00a0</p><p><a href=\\\\\\\"http://firewoodandmulchaustintx.com/\\\\\\\">Kinser Ranch LLC.</a></p><p>Starts at $1.00/per tree to $20/per load.</p><p>For more information: 512-748-0800</p><p>10701 Kinser Lane, Austin, Texas 78736</p><p><a href=\\\\\\\"http://www.sidmourningtreeservice.com/\\\\\\\">Sid Mourning Tree Service</a></p><p>Pricing varies. </p><p>Call for fee information: 512-420-0733</p><p>3810 Medical Parkway Austin, TX 78756</p><p><a href=\\\\\\\"http://www.austinwoodrecycling.com/\\\\\\\">Austin Wood Recycling</a></p><p>$5.00/per tree.</p><p>For more information: 512-259-7430</p><p>3875 E. Whitestone Blvd., Cedar Park, TX 78613</p><p><a href=\\\\\\\"http://www.goodguystreeservice.com/\\\\\\\">Good Guys Tree Service</a></p><p>Prices vary.</p><p>For more information: 512-743-3909</p><p>11601 Anderson Mill Rd., Austin, TX 78750</p>\\\", \\\"id\\\": \\\"b748924c-4c94-4a4f-a3b2-3730684980f8\\\"}]\", \"topic\": 1}",
-      "approved_go_live_at": null
-    }
-  },
-  {
-    "model": "wagtailcore.pagerevision",
-    "pk": 2,
-    "fields": {
-      "page": 5,
-      "submitted_for_moderation": false,
-      "created_at": "2017-12-06T21:02:34.221Z",
-      "user": [
-        "admin@austintexas.io"
-      ],
-      "content_json": "{\"pk\": 5, \"path\": \"000100010002\", \"depth\": 3, \"numchild\": 0, \"title\": \"Visit the Recycle and Reuse Drop-off Center\", \"draft_title\": \"Visit the Recycle and Reuse Drop-off Center\", \"slug\": \"dropoff\", \"content_type\": 12, \"live\": true, \"has_unpublished_changes\": false, \"url_path\": \"/home/dropoff/\", \"owner\": 1, \"seo_title\": \"\", \"show_in_menus\": false, \"search_description\": \"\", \"go_live_at\": null, \"expire_at\": null, \"expired\": false, \"locked\": false, \"first_published_at\": null, \"last_published_at\": null, \"latest_revision_created_at\": null, \"live_revision\": null, \"created_at\": \"2017-12-06T21:02:34.149Z\", \"updated_at\": \"2017-12-06T21:02:34.220Z\", \"content\": \"<ol><li><p>Check below to find out what hazardous waste items are accepted. Some items are free to drop off and some items, like tires, require a fee.</p></li><li><p>Drop off your household hazardous waste or visit the ReUse Store at 2514 Business Center Dr, Austin, TX 78744.</p></li><li><p>Be sure to bring products in original containers; do not mix, bring items in 5-gallon (or smaller) containers and put small containers upright in sturdy boxes.</p></li><li><p>If something is leaking, put it in a container and absorb the spill with cat litter.</p></li></ol>\", \"extra_content\": \"[{\\\"type\\\": \\\"application_block\\\", \\\"value\\\": 2, \\\"id\\\": \\\"2d3602e3-251a-49ef-9493-132c945fde38\\\"}, {\\\"type\\\": \\\"application_block\\\", \\\"value\\\": 4, \\\"id\\\": \\\"003658b6-170d-4baf-9c61-848d26511e5f\\\"}, {\\\"type\\\": \\\"content\\\", \\\"value\\\": \\\"<h2>Household Hazardous Waste</h2><p>Throwing household hazardous waste in the trash or pouring it down the drain is dangerous and harmful to the environment. Austin and Travis County residents can drop off hazardous waste for free, up to 30 gallons annually. Large truck or trailer loads will not be accepted after 4:45PM.</p><br/><p>Businesses are not eligible to drop off hazardous waste. For information about how businesses can dispose of hazardous waste, call 512-974-4336.</p><h2>ReUse Store</h2><p>Many materials that are dropped off at the center are in usable condition. These items go to the ReUse Store, where everyone can pick them up for free. Store items often include: </p><ul><li><p>Art supplies</p></li><li><p>Cleaning products</p></li><li><p>Household chemicals</p></li><li><p>Automotive fluids</p></li><li><p><a href=\\\\\\\"http://www.austintexas.gov/department/austin-reblend\\\\\\\">Austin ReBlend paint</a> (link to austintexas.gov page)</p></li><li><p>Mulch</p></li></ul><br/><p>Austin ReBlend paint is free for individuals and nonprofits. It is not available to businesses.</p><p>Mulch is free for everyone, but you must load it yourself. Bring a pitchfork or shovel, work gloves and containers. </p>\\\", \\\"id\\\": \\\"fff2155d-fc2b-411d-8c3a-1dcef2fff99c\\\"}]\", \"topic\": 1}",
-      "approved_go_live_at": null
-    }
-  },
-  {
-    "model": "wagtailcore.pagerevision",
-    "pk": 3,
-    "fields": {
-      "page": 6,
-      "submitted_for_moderation": false,
-      "created_at": "2017-12-06T21:04:18.025Z",
-      "user": [
-        "admin@austintexas.io"
-      ],
-      "content_json": "{\"pk\": 6, \"path\": \"000100010003\", \"depth\": 3, \"numchild\": 0, \"title\": \"Look up your Trash, Recycling, and Compost Days\", \"draft_title\": \"Look up your Trash, Recycling, and Compost Days\", \"slug\": \"residential-curbside-collection-schedule\", \"content_type\": 12, \"live\": true, \"has_unpublished_changes\": false, \"url_path\": \"/home/residential-curbside-collection-schedule/\", \"owner\": 1, \"seo_title\": \"\", \"show_in_menus\": false, \"search_description\": \"\", \"go_live_at\": null, \"expire_at\": null, \"expired\": false, \"locked\": false, \"first_published_at\": null, \"last_published_at\": null, \"latest_revision_created_at\": null, \"live_revision\": null, \"created_at\": \"2017-12-06T21:04:17.978Z\", \"updated_at\": \"2017-12-06T21:04:18.024Z\", \"content\": \"<ol><li>Type your address, without apartment or unit number, in the box below.</li><li>Press the search button to view your pickup schedule.</li><li>(Optional) Click the icon to add your pickup days to your Google, iCal, or Microsoft calendar or print a copy of your schedule.</li></ol>\", \"extra_content\": \"[{\\\"type\\\": \\\"application_block\\\", \\\"value\\\": 1, \\\"id\\\": \\\"31dfdd2f-162c-4523-a4a5-ea6dced160f8\\\"}, {\\\"type\\\": \\\"content\\\", \\\"value\\\": \\\"<p>If your pickup day falls on Thanksgiving Day, Christmas Day or New Year's Day\\\\u2014or if it falls after the holiday in the same week\\\\u2014it slides to one day later. If the holiday falls on a Sunday, your pickup day will not slide.</p><br/>We will pick up your trash, compost, and yard trimmings every week. Every other week, we will pick up recycling, clothing, and housewares. All curbside pick-ups happen on the same day of the week unless it is a holiday. Use <a href=\\\\\\\"https://austintexas.gov/page/my-collection-schedule\\\\\\\">My Schedule</a> to get your personalized collection calendar.\\\", \\\"id\\\": \\\"975a8966-601c-4940-a306-4a53ff01b85b\\\"}]\", \"topic\": 1}",
-      "approved_go_live_at": null
-    }
-  },
-  {
-    "model": "wagtailcore.pagerevision",
-    "pk": 4,
-    "fields": {
-      "page": 7,
-      "submitted_for_moderation": false,
-      "created_at": "2017-12-06T21:05:44.529Z",
-      "user": [
-        "admin@austintexas.io"
-      ],
-      "content_json": "{\"pk\": 7, \"path\": \"000100010004\", \"depth\": 3, \"numchild\": 0, \"title\": \"Get Ready for Bulk Item Pick-up\", \"draft_title\": \"Get Ready for Bulk Item Pick-up\", \"slug\": \"residential-bulk-collection\", \"content_type\": 12, \"live\": true, \"has_unpublished_changes\": false, \"url_path\": \"/home/residential-bulk-collection/\", \"owner\": 1, \"seo_title\": \"\", \"show_in_menus\": false, \"search_description\": \"\", \"go_live_at\": null, \"expire_at\": null, \"expired\": false, \"locked\": false, \"first_published_at\": null, \"last_published_at\": null, \"latest_revision_created_at\": null, \"live_revision\": null, \"created_at\": \"2017-12-06T21:05:44.483Z\", \"updated_at\": \"2017-12-06T21:05:44.527Z\", \"content\": \"<ol><li><p>Check what items are accepted for bulk pick-up below. </p></li><li><p>Look up your twice-a-year bulk pick-up weeks below. We only collect bulk items from residential trash and recycling customers. </p></li><li><p>Place bulk items at the curb in front of your house by 6:30 a.m. on the first day of your scheduled collection week</p></li><li><p>Separate items into three piles. </p></li><ol><li><p>Metal - includes appliances, doors must be removed</p></li><li><p>Passenger car tires - limit of eight tires per household, rims must be removed, no truck or tractor tires </p></li><li><p>Non-metal items - includes carpeting and nail-free lumber</p></li></ol></ol>\", \"extra_content\": \"[{\\\"type\\\": \\\"application_block\\\", \\\"value\\\": 2, \\\"id\\\": \\\"ac2d7108-e0ee-4887-b454-b0cdc4886b06\\\"}, {\\\"type\\\": \\\"application_block\\\", \\\"value\\\": 1, \\\"id\\\": \\\"cb0fc00e-5811-4117-b369-72d9222000ac\\\"}, {\\\"type\\\": \\\"content\\\", \\\"value\\\": \\\"<p>Do not put bulk items in bags, boxes or other containers. Bags will be treated as extra trash and are subject to extra trash fees.</p><br/><p>Items will not be picked up if they are in an alley in any area, including Hyde Park, in front of a vacant lot or in front of a business</p><br/><p>To prevent damage to your property, keep bulk items 5 feet away from your:</p><ol><ol><li><p>trash cart</p></li><li><p>Mailbox</p></li><li><p>fences or walls</p></li><li><p>water meter</p></li><li><p>telephone connection box</p></li><li><p>parked cars. </p></li></ol></ol><br/><p>Do not place any items under low hanging tree limbs or power lines.</p><br/><p>The three separate piles are collected by different trucks and may be collected at different times throughout the week.</p>\\\", \\\"id\\\": \\\"60dacf8d-e0c9-4248-9252-d3a438ba58a3\\\"}]\", \"topic\": 1}",
-      "approved_go_live_at": null
-    }
-  },
-  {
-    "model": "wagtailcore.pagerevision",
-    "pk": 5,
-    "fields": {
-      "page": 5,
-      "submitted_for_moderation": false,
-      "created_at": "2017-12-13T22:00:09.263Z",
-      "user": [
-        "admin@austintexas.io"
-      ],
-      "content_json": "{\"pk\": 5, \"path\": \"000100010002\", \"depth\": 3, \"numchild\": 0, \"title\": \"Pick Up Free Household Items from the ReUse Store\", \"draft_title\": \"Visit the Recycle and Reuse Drop-off Center\", \"slug\": \"dropoff\", \"content_type\": 12, \"live\": true, \"has_unpublished_changes\": false, \"url_path\": \"/home/dropoff/\", \"owner\": 1, \"seo_title\": \"\", \"show_in_menus\": false, \"search_description\": \"\", \"go_live_at\": null, \"expire_at\": null, \"expired\": false, \"locked\": false, \"first_published_at\": \"2017-12-06T21:02:34.309Z\", \"last_published_at\": \"2017-12-06T21:02:34.309Z\", \"latest_revision_created_at\": \"2017-12-06T21:02:34.221Z\", \"live_revision\": 2, \"created_at\": \"2017-12-06T21:02:34.149Z\", \"updated_at\": \"2017-12-13T22:00:09.262Z\", \"content\": \"<ol><li><p>Visit the ReUse Store in the Recycle &amp; Reuse Drop-Off Center at 2514 Business Center Dr, Austin, TX 78744.</p></li><li><p>Many materials that are dropped off at the Recycle &amp; Reuse Drop-Off Center are in usable condition. These items go to the ReUse Store. Pick up these items for free:</p></li><ol><li><p>House paint</p></li><li><p>Art supplies</p></li><li><p>Cleaning products</p></li><li><p>Household chemicals</p></li><li><p>Automotive fluids</p></li><li><p>Mulch</p></li></ol></ol>\", \"content_en\": \"<ol><li><p>Visit the ReUse Store in the Recycle &amp; Reuse Drop-Off Center at 2514 Business Center Dr, Austin, TX 78744.</p></li><li><p>Many materials that are dropped off at the Recycle &amp; Reuse Drop-Off Center are in usable condition. These items go to the ReUse Store. Pick up these items for free:</p></li><ol><li><p>House paint</p></li><li><p>Art supplies</p></li><li><p>Cleaning products</p></li><li><p>Household chemicals</p></li><li><p>Automotive fluids</p></li><li><p>Mulch</p></li></ol></ol>\", \"content_pt\": null, \"content_es\": \"\", \"content_fr\": null, \"extra_content\": \"[{\\\"type\\\": \\\"application_block\\\", \\\"value\\\": 4, \\\"id\\\": \\\"003658b6-170d-4baf-9c61-848d26511e5f\\\"}, {\\\"type\\\": \\\"content\\\", \\\"value\\\": \\\"<h1>Learn About Austin ReBlend Paint</h1><p>Paint dropped off by customers is inspected before it is chosen to be used in Austin ReBlend. It is then consolidated, blended, filtered and packed by trained personnel to ensure a quality product.</p><br/><p>Austin ReBlend paint is free for individuals and nonprofits, and can save residents money when refurbishing their homes. The paint is not available to businesses.</p><br/><p>It is available in 3.5 gallon containers and three colors:</p><ul><li><p>Texas Limestone (beige)</p></li><li><p>Balcones Canyonland (dark beige)</p></li><li><p>Barton Creek Greenbelt (dark green)</p></li></ul><h1>Pick Up Free Mulch</h1><p>You can pick up mulch for free; however, you must load it yourself. Bring a pitchfork or shovel, work gloves and containers.</p><br/><p>Notes from Laura: transferred content to wagtail 12/13/17</p>\\\", \\\"id\\\": \\\"fff2155d-fc2b-411d-8c3a-1dcef2fff99c\\\"}]\", \"topic\": 1, \"locations\": [], \"contacts\": []}",
-      "approved_go_live_at": null
-    }
-  },
-  {
-    "model": "wagtailcore.pagerevision",
-    "pk": 6,
-    "fields": {
-      "page": 4,
-      "submitted_for_moderation": false,
-      "created_at": "2017-12-13T22:02:14.706Z",
-      "user": [
-        "admin@austintexas.io"
-      ],
-      "content_json": "{\"pk\": 4, \"path\": \"000100010001\", \"depth\": 3, \"numchild\": 0, \"title\": \"Recycle your Christmas tree\", \"draft_title\": \"Recycle your Christmas tree\", \"slug\": \"holiday-tree-recycling\", \"content_type\": 12, \"live\": true, \"has_unpublished_changes\": false, \"url_path\": \"/home/holiday-tree-recycling/\", \"owner\": 1, \"seo_title\": \"\", \"show_in_menus\": false, \"search_description\": \"\", \"go_live_at\": null, \"expire_at\": null, \"expired\": false, \"locked\": false, \"first_published_at\": \"2017-12-06T17:09:43.276Z\", \"last_published_at\": \"2017-12-06T17:09:43.276Z\", \"latest_revision_created_at\": \"2017-12-06T17:09:43.202Z\", \"live_revision\": 1, \"created_at\": \"2017-12-06T17:09:43.155Z\", \"updated_at\": \"2017-12-13T22:02:14.704Z\", \"content\": \"<ol><li><p>All residents can drop-off their trees to be recycled into mulch. To drop your tree off at Zilker Park, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Drop your tree off between 10am and 2pm on one of the following days:</p></li><ol><li><p>Saturday, December 30, 2017</p></li><li><p>Sunday, December 31, 2017</p></li><li><p>Saturday, January 6, 2018</p></li><li><p>Sunday, January 7, 2018</p></li></ol><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li><li><p>Do you live in a house? Skip ahead and read about recycling your Christmas tree at the curb.</p></li></ol>\", \"content_en\": \"<ol><li><p>All residents can drop-off their trees to be recycled into mulch. To drop your tree off at Zilker Park, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Drop your tree off between 10am and 2pm on one of the following days:</p></li><ol><li><p>Saturday, December 30, 2017</p></li><li><p>Sunday, December 31, 2017</p></li><li><p>Saturday, January 6, 2018</p></li><li><p>Sunday, January 7, 2018</p></li></ol><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li><li><p>Do you live in a house? Skip ahead and read about recycling your Christmas tree at the curb.</p></li></ol>\", \"content_pt\": null, \"content_es\": \"\", \"content_fr\": null, \"extra_content\": \"[{\\\"type\\\": \\\"application_block\\\", \\\"value\\\": 3, \\\"id\\\": \\\"f3154cf7-22c1-4d88-89f9-ee3f834f6ec7\\\"}, {\\\"type\\\": \\\"content\\\", \\\"value\\\": \\\"<h2>Free Drop-Off Locations</h2><p>Trees will be accepted free of cost at the locations listed below. However, a contamination fee will be added to any trees with tags, decorations, and/or plastic remaining.</p><br/><p><a href=\\\\\\\"http://www.texasdisposal.com/contact/\\\\\\\">Texas Disposal Systems</a></p><ul><li><p>TDS Landfill: 3016 FM 1327, Creedmoor, Texas</p></li><li><p>Eco Depot: 4001 RR 620 South, Bee Cave, Texas</p></li></ul><p><a href=\\\\\\\"http://www.organicsbygosh.com/drop-off-collection/\\\\\\\">Organics By Gosh</a></p><ul><li><p>13602 FM 969, Austin, TX 78724\\\\u2028 | (512) 276-1211</p></li></ul><p><a href=\\\\\\\"http://www.daisyworksdirt.com/\\\\\\\">Walker Aero Environmental (JV Dirt) </a></p><ul><li><p>3600 FM 973 North Austin, Texas 78725</p></li></ul><p><a href=\\\\\\\"http://www.989rock.com/\\\\\\\">Whittlesey Landscape Supplies</a></p><ul><li><p>3219 S IH 35 Round Rock, Texas 78664</p></li><li><p>629 Dalton Lane, Austin, Texas 78742</p></li></ul><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Travis County Transfer Station</a></p><ul><li><p>2625 Woodall Dr. Leander, Texas 78641</p></li></ul><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Travis County Service Center</a></p><ul><li><p>6013 Blue Bluff Rd Austin, Texas 78724</p></li></ul><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Del Valle Softball Complex (Behind the Southwest Rural Center)</a></p><ul><li><p>3614 FM 973 Del Valle, Texas 78617</p></li></ul><br/><h2>Drop-Off Locations with a Fee</h2><p>Locations listed below have varying fees. Call the location for more information. \\\\u00a0</p><p><a href=\\\\\\\"http://firewoodandmulchaustintx.com/\\\\\\\">Kinser Ranch LLC.</a></p><p>Starts at $1.00/per tree to $20/per load.</p><p>For more information: 512-748-0800</p><p>10701 Kinser Lane, Austin, Texas 78736</p><p><a href=\\\\\\\"http://www.sidmourningtreeservice.com/\\\\\\\">Sid Mourning Tree Service</a></p><p>Pricing varies. </p><p>Call for fee information: 512-420-0733</p><p>3810 Medical Parkway Austin, TX 78756</p><p><a href=\\\\\\\"http://www.austinwoodrecycling.com/\\\\\\\">Austin Wood Recycling</a></p><p>$5.00/per tree.</p><p>For more information: 512-259-7430</p><p>3875 E. Whitestone Blvd., Cedar Park, TX 78613</p><p><a href=\\\\\\\"http://www.goodguystreeservice.com/\\\\\\\">Good Guys Tree Service</a></p><p>Prices vary.</p><p>For more information: 512-743-3909</p><p>11601 Anderson Mill Rd., Austin, TX 78750</p><h1>Do you live in a house? You can recycle your Christmas tree at the curb</h1><br/><ol><li><p>If you are a City of Austin curbside customer, and you would like to have your tree picked up and turned into mulch, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Cut the tree in half if it is longer than 6 feet.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Set your tree out on the curb by 6:30 am on your regular collection day.</p></li><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li></ol>\\\", \\\"id\\\": \\\"b748924c-4c94-4a4f-a3b2-3730684980f8\\\"}]\", \"topic\": 1, \"locations\": [], \"contacts\": []}",
-      "approved_go_live_at": null
-    }
-  },
-  {
-    "model": "wagtailcore.pagerevision",
-    "pk": 7,
-    "fields": {
-      "page": 4,
-      "submitted_for_moderation": false,
-      "created_at": "2017-12-13T22:04:09.245Z",
-      "user": [
-        "admin@austintexas.io"
-      ],
-      "content_json": "{\"pk\": 4, \"path\": \"000100010001\", \"depth\": 3, \"numchild\": 0, \"title\": \"Recycle your Christmas tree\", \"draft_title\": \"Recycle your Christmas tree\", \"slug\": \"holiday-tree-recycling\", \"content_type\": 12, \"live\": true, \"has_unpublished_changes\": false, \"url_path\": \"/home/holiday-tree-recycling/\", \"owner\": 1, \"seo_title\": \"\", \"show_in_menus\": false, \"search_description\": \"\", \"go_live_at\": null, \"expire_at\": null, \"expired\": false, \"locked\": false, \"first_published_at\": \"2017-12-06T17:09:43.276Z\", \"last_published_at\": \"2017-12-13T22:02:14.801Z\", \"latest_revision_created_at\": \"2017-12-13T22:02:14.706Z\", \"live_revision\": 6, \"created_at\": \"2017-12-06T17:09:43.155Z\", \"updated_at\": \"2017-12-13T22:04:09.243Z\", \"content\": \"<ol><li><p>All residents can drop-off their trees to be recycled into mulch. To drop your tree off at Zilker Park, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Drop your tree off between 10am and 2pm on one of the following days:</p></li><ol><li><p>Saturday, December 30, 2017</p></li><li><p>Sunday, December 31, 2017</p></li><li><p>Saturday, January 6, 2018</p></li><li><p>Sunday, January 7, 2018</p></li></ol><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li><li><p>Do you live in a house? Skip ahead and read about recycling your Christmas tree at the curb.</p></li></ol>\", \"content_en\": \"<ol><li><p>All residents can drop-off their trees to be recycled into mulch. To drop your tree off at Zilker Park, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Drop your tree off between 10am and 2pm on one of the following days:</p></li><ol><li><p>Saturday, December 30, 2017</p></li><li><p>Sunday, December 31, 2017</p></li><li><p>Saturday, January 6, 2018</p></li><li><p>Sunday, January 7, 2018</p></li></ol><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li><li><p>Do you live in a house? Skip ahead and read about recycling your Christmas tree at the curb.</p></li></ol>\", \"content_pt\": null, \"content_es\": \"\", \"content_fr\": null, \"extra_content\": \"[{\\\"type\\\": \\\"application_block\\\", \\\"value\\\": 3, \\\"id\\\": \\\"f3154cf7-22c1-4d88-89f9-ee3f834f6ec7\\\"}, {\\\"type\\\": \\\"content\\\", \\\"value\\\": \\\"<h2>Free Drop-Off Locations</h2><p>Trees will be accepted free of cost at the locations listed below. However, a contamination fee will be added to any trees with tags, decorations, and/or plastic remaining.</p><br/><p><a href=\\\\\\\"http://www.texasdisposal.com/contact/\\\\\\\">Texas Disposal Systems</a></p><ul><li><p>TDS Landfill: 3016 FM 1327, Creedmoor, Texas</p></li><li><p>Eco Depot: 4001 RR 620 South, Bee Cave, Texas</p></li></ul><p><a href=\\\\\\\"http://www.organicsbygosh.com/drop-off-collection/\\\\\\\">Organics By Gosh</a></p><ul><li><p>13602 FM 969, Austin, TX 78724\\\\u2028 | (512) 276-1211</p></li></ul><p><a href=\\\\\\\"http://www.daisyworksdirt.com/\\\\\\\">Walker Aero Environmental (JV Dirt) </a></p><ul><li><p>3600 FM 973 North Austin, Texas 78725</p></li></ul><p><a href=\\\\\\\"http://www.989rock.com/\\\\\\\">Whittlesey Landscape Supplies</a></p><ul><li><p>3219 S IH 35 Round Rock, Texas 78664</p></li><li><p>629 Dalton Lane, Austin, Texas 78742</p></li></ul><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Travis County Transfer Station</a></p><ul><li><p>2625 Woodall Dr. Leander, Texas 78641</p></li></ul><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Travis County Service Center</a></p><ul><li><p>6013 Blue Bluff Rd Austin, Texas 78724</p></li></ul><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Del Valle Softball Complex (Behind the Southwest Rural Center)</a></p><ul><li><p>3614 FM 973 Del Valle, Texas 78617</p></li></ul><br/><h2>Drop-Off Locations with a Fee</h2><p>Locations listed below have varying fees. Call the location for more information. \\\\u00a0</p><p><a href=\\\\\\\"http://firewoodandmulchaustintx.com/\\\\\\\">Kinser Ranch LLC.</a></p><p>Starts at $1.00/per tree to $20/per load.</p><p>For more information: 512-748-0800</p><p>10701 Kinser Lane, Austin, Texas 78736</p><p><a href=\\\\\\\"http://www.sidmourningtreeservice.com/\\\\\\\">Sid Mourning Tree Service</a></p><p>Pricing varies. </p><p>Call for fee information: 512-420-0733</p><p>3810 Medical Parkway Austin, TX 78756</p><p><a href=\\\\\\\"http://www.austinwoodrecycling.com/\\\\\\\">Austin Wood Recycling</a></p><p>$5.00/per tree.</p><p>For more information: 512-259-7430</p><p>3875 E. Whitestone Blvd., Cedar Park, TX 78613</p><p><a href=\\\\\\\"http://www.goodguystreeservice.com/\\\\\\\">Good Guys Tree Service</a></p><p>Prices vary.</p><p>For more information: 512-743-3909</p><p>11601 Anderson Mill Rd., Austin, TX 78750</p><h1>Do you live in a house? You can recycle your Christmas tree at the curb</h1><br/><ol><li><p>If you are a City of Austin curbside customer, and you would like to have your tree picked up and turned into mulch, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Cut the tree in half if it is longer than 6 feet.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Set your tree out on the curb by 6:30 am on your regular collection day.</p></li><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li></ol>\\\", \\\"id\\\": \\\"b748924c-4c94-4a4f-a3b2-3730684980f8\\\"}]\", \"topic\": 1, \"locations\": [], \"contacts\": []}",
-      "approved_go_live_at": null
-    }
-  },
-  {
-    "model": "wagtailcore.pagerevision",
-    "pk": 8,
-    "fields": {
-      "page": 7,
-      "submitted_for_moderation": false,
-      "created_at": "2017-12-13T22:07:17.667Z",
-      "user": [
-        "admin@austintexas.io"
-      ],
-      "content_json": "{\"pk\": 7, \"path\": \"000100010004\", \"depth\": 3, \"numchild\": 0, \"title\": \"Get Ready for Bulk Item Pick-up\", \"draft_title\": \"Get Ready for Bulk Item Pick-up\", \"slug\": \"residential-bulk-collection\", \"content_type\": 12, \"live\": true, \"has_unpublished_changes\": false, \"url_path\": \"/home/residential-bulk-collection/\", \"owner\": 1, \"seo_title\": \"\", \"show_in_menus\": false, \"search_description\": \"\", \"go_live_at\": null, \"expire_at\": null, \"expired\": false, \"locked\": false, \"first_published_at\": \"2017-12-06T21:05:44.625Z\", \"last_published_at\": \"2017-12-06T21:05:44.625Z\", \"latest_revision_created_at\": \"2017-12-06T21:05:44.529Z\", \"live_revision\": 4, \"created_at\": \"2017-12-06T21:05:44.483Z\", \"updated_at\": \"2017-12-13T22:07:17.666Z\", \"content\": \"<ol><li><p>Place appliances, furniture, carpet and other bulk items on your curb. Use the <a href=\\\"http://austintexas.gov/what-do-i-do\\\">\\u201cWhat do I do with\\u201d tool</a> to find out what you can bulk pick-up below. </p></li><li><p>Look up your twice-a-year bulk pick-up weeks with <a href=\\\"http://www.austintexas.gov/page/my-collection-schedule\\\">My Collection Schedule</a>. We only collect bulk items from Austin residential trash and recycling customers. </p></li><li><p>Place bulk items at the curb in front of your house by 6:30 a.m. on the first day of your scheduled collection week.</p></li><li><p>Separate items into three piles. </p></li><ol><li><p>Metal - includes appliances, doors must be removed</p></li><li><p>Passenger car tires - limit of eight tires per household, rims must be removed, no truck or tractor tires </p></li><li><p>Non-metal items - includes carpeting and nail-free lumber</p></li></ol></ol>\", \"content_en\": \"<ol><li><p>Place appliances, furniture, carpet and other bulk items on your curb. Use the <a href=\\\"http://austintexas.gov/what-do-i-do\\\">\\u201cWhat do I do with\\u201d tool</a> to find out what you can bulk pick-up below. </p></li><li><p>Look up your twice-a-year bulk pick-up weeks with <a href=\\\"http://www.austintexas.gov/page/my-collection-schedule\\\">My Collection Schedule</a>. We only collect bulk items from Austin residential trash and recycling customers. </p></li><li><p>Place bulk items at the curb in front of your house by 6:30 a.m. on the first day of your scheduled collection week.</p></li><li><p>Separate items into three piles. </p></li><ol><li><p>Metal - includes appliances, doors must be removed</p></li><li><p>Passenger car tires - limit of eight tires per household, rims must be removed, no truck or tractor tires </p></li><li><p>Non-metal items - includes carpeting and nail-free lumber</p></li></ol></ol>\", \"content_pt\": null, \"content_es\": \"\", \"content_fr\": null, \"extra_content\": \"[{\\\"type\\\": \\\"application_block\\\", \\\"value\\\": 2, \\\"id\\\": \\\"ac2d7108-e0ee-4887-b454-b0cdc4886b06\\\"}, {\\\"type\\\": \\\"application_block\\\", \\\"value\\\": 1, \\\"id\\\": \\\"cb0fc00e-5811-4117-b369-72d9222000ac\\\"}, {\\\"type\\\": \\\"content\\\", \\\"value\\\": \\\"<p>Do not put bulk items in bags, boxes or other containers. Bags will be treated as extra trash and are subject to extra trash fees.</p><br/><p>Items will not be picked up if they are in an alley in any area, including Hyde Park, in front of a vacant lot or in front of a business</p><br/><p>To prevent damage to your property, keep bulk items 5 feet away from your:</p><ol><ol><li><p>trash cart</p></li><li><p>Mailbox</p></li><li><p>fences or walls</p></li><li><p>water meter</p></li><li><p>telephone connection box</p></li><li><p>parked cars. </p></li></ol></ol><br/><p>Do not place any items under low hanging tree limbs or power lines.</p><br/><p>The three separate piles are collected by different trucks and may be collected at different times throughout the week.</p>\\\", \\\"id\\\": \\\"60dacf8d-e0c9-4248-9252-d3a438ba58a3\\\"}]\", \"topic\": 1, \"locations\": [], \"contacts\": []}",
-      "approved_go_live_at": null
-    }
-  },
-  {
-    "model": "wagtailcore.pagerevision",
-    "pk": 9,
-    "fields": {
-      "page": 5,
-      "submitted_for_moderation": false,
-      "created_at": "2017-12-13T22:36:06.288Z",
-      "user": [
-        "admin@austintexas.io"
-      ],
-      "content_json": "{\"pk\": 5, \"path\": \"000100010002\", \"depth\": 3, \"numchild\": 0, \"title\": \"Pick Up Free Household Items from the ReUse Store\", \"draft_title\": \"Pick Up Free Household Items from the ReUse Store\", \"slug\": \"dropoff\", \"content_type\": 12, \"live\": true, \"has_unpublished_changes\": false, \"url_path\": \"/home/dropoff/\", \"owner\": 1, \"seo_title\": \"\", \"show_in_menus\": false, \"search_description\": \"\", \"go_live_at\": null, \"expire_at\": null, \"expired\": false, \"locked\": false, \"first_published_at\": \"2017-12-06T21:02:34.309Z\", \"last_published_at\": \"2017-12-13T22:00:09.375Z\", \"latest_revision_created_at\": \"2017-12-13T22:00:09.263Z\", \"live_revision\": 5, \"created_at\": \"2017-12-06T21:02:34.149Z\", \"updated_at\": \"2017-12-13T22:36:06.287Z\", \"content\": \"<ol><li><p>Visit the ReUse Store in the Recycle &amp; Reuse Drop-Off Center at 2514 Business Center Dr, Austin, TX 78744.</p></li><li><p>Many materials that are dropped off at the Recycle &amp; Reuse Drop-Off Center are in usable condition. These items go to the ReUse Store. Pick up these items for free:</p></li><ol><li><p>House paint</p></li><li><p>Art supplies</p></li><li><p>Cleaning products</p></li><li><p>Household chemicals</p></li><li><p>Automotive fluids</p></li><li><p>Mulch</p></li></ol></ol>\", \"content_en\": \"<ol><li><p>Visit the ReUse Store in the Recycle &amp; Reuse Drop-Off Center at 2514 Business Center Dr, Austin, TX 78744.</p></li><li><p>Many materials that are dropped off at the Recycle &amp; Reuse Drop-Off Center are in usable condition. These items go to the ReUse Store. Pick up these items for free:</p></li><ol><li><p>House paint</p></li><li><p>Art supplies</p></li><li><p>Cleaning products</p></li><li><p>Household chemicals</p></li><li><p>Automotive fluids</p></li><li><p>Mulch</p></li></ol></ol>\", \"content_pt\": null, \"content_es\": \"\", \"content_fr\": null, \"extra_content\": \"[{\\\"type\\\": \\\"application_block\\\", \\\"value\\\": 4, \\\"id\\\": \\\"003658b6-170d-4baf-9c61-848d26511e5f\\\"}, {\\\"type\\\": \\\"content\\\", \\\"value\\\": \\\"<h1>Learn About Austin ReBlend Paint</h1><p>Paint dropped off by customers is inspected before it is chosen to be used in Austin ReBlend. It is then consolidated, blended, filtered and packed by trained personnel to ensure a quality product.</p><br/><p>Austin ReBlend paint is free for individuals and nonprofits, and can save residents money when refurbishing their homes. The paint is not available to businesses.</p><br/><p>It is available in 3.5 gallon containers and three colors:</p><ul><li><p>Texas Limestone (beige)</p></li><li><p>Balcones Canyonland (dark beige)</p></li><li><p>Barton Creek Greenbelt (dark green)</p></li></ul><h1>Pick Up Free Mulch</h1><p>You can pick up mulch for free; however, you must load it yourself. Bring a pitchfork or shovel, work gloves and containers.</p>\\\", \\\"id\\\": \\\"fff2155d-fc2b-411d-8c3a-1dcef2fff99c\\\"}]\", \"topic\": 1, \"locations\": [], \"contacts\": []}",
-      "approved_go_live_at": null
-    }
-  },
-  {
-    "model": "wagtailcore.pagerevision",
-    "pk": 10,
-    "fields": {
-      "page": 6,
-      "submitted_for_moderation": false,
-      "created_at": "2017-12-13T22:40:27.871Z",
-      "user": [
-        "admin@austintexas.io"
-      ],
-      "content_json": "{\"pk\": 6, \"path\": \"000100010003\", \"depth\": 3, \"numchild\": 0, \"title\": \"Look up your Trash, Recycling, and Compost Days\", \"draft_title\": \"Look up your Trash, Recycling, and Compost Days\", \"slug\": \"residential-curbside-collection-schedule\", \"content_type\": 12, \"live\": true, \"has_unpublished_changes\": false, \"url_path\": \"/home/residential-curbside-collection-schedule/\", \"owner\": 1, \"seo_title\": \"\", \"show_in_menus\": false, \"search_description\": \"\", \"go_live_at\": null, \"expire_at\": null, \"expired\": false, \"locked\": false, \"first_published_at\": \"2017-12-06T21:04:18.098Z\", \"last_published_at\": \"2017-12-06T21:04:18.098Z\", \"latest_revision_created_at\": \"2017-12-06T21:04:18.025Z\", \"live_revision\": 3, \"created_at\": \"2017-12-06T21:04:17.978Z\", \"updated_at\": \"2017-12-13T22:40:27.866Z\", \"content\": \"<ol><li><p>Type your address, without apartment or unit number, in the box below.</p></li><li><p>Press the search button to view your curbside pickup schedule. </p></li><li><p>Use <a href=\\\"https://austintexas.gov/page/my-collection-schedule\\\">My Schedule</a> to get your personalized collection calendar.</p></li><li><p>(Optional) Click the icon to add your pickup days to your Google, iCal, or Microsoft calendar or print a copy of your schedule.</p></li></ol>\", \"content_en\": \"<ol><li><p>Type your address, without apartment or unit number, in the box below.</p></li><li><p>Press the search button to view your curbside pickup schedule. </p></li><li><p>Use <a href=\\\"https://austintexas.gov/page/my-collection-schedule\\\">My Schedule</a> to get your personalized collection calendar.</p></li><li><p>(Optional) Click the icon to add your pickup days to your Google, iCal, or Microsoft calendar or print a copy of your schedule.</p></li></ol>\", \"content_pt\": null, \"content_es\": \"\", \"content_fr\": null, \"extra_content\": \"[{\\\"type\\\": \\\"application_block\\\", \\\"value\\\": 1, \\\"id\\\": \\\"31dfdd2f-162c-4523-a4a5-ea6dced160f8\\\"}, {\\\"type\\\": \\\"content\\\", \\\"value\\\": \\\"<p>If your pickup day falls on Thanksgiving Day, Christmas Day or New Year's Day\\\\u2014or if it falls after the holiday in the same week\\\\u2014it slides to one day later. If the holiday falls on a Sunday, your pickup day will not slide.</p><br/>We will pick up your trash, compost, and yard trimmings every week. Every other week, we will pick up recycling, clothing, and housewares. All curbside pick-ups happen on the same day of the week unless it is a holiday. Use <a href=\\\\\\\"https://austintexas.gov/page/my-collection-schedule\\\\\\\">My Schedule</a> to get your personalized collection calendar.\\\", \\\"id\\\": \\\"975a8966-601c-4940-a306-4a53ff01b85b\\\"}]\", \"topic\": 1, \"locations\": [], \"contacts\": []}",
-      "approved_go_live_at": null
-    }
-  },
-  {
-    "model": "wagtailcore.pagerevision",
-    "pk": 11,
-    "fields": {
-      "page": 4,
-      "submitted_for_moderation": false,
-      "created_at": "2017-12-13T22:43:34.605Z",
-      "user": [
-        "admin@austintexas.io"
-      ],
-      "content_json": "{\"pk\": 4, \"path\": \"000100010001\", \"depth\": 3, \"numchild\": 0, \"title\": \"Recycle your Christmas tree\", \"draft_title\": \"Recycle your Christmas tree\", \"slug\": \"holiday-tree-recycling\", \"content_type\": 12, \"live\": true, \"has_unpublished_changes\": false, \"url_path\": \"/home/holiday-tree-recycling/\", \"owner\": 1, \"seo_title\": \"\", \"show_in_menus\": false, \"search_description\": \"\", \"go_live_at\": null, \"expire_at\": null, \"expired\": false, \"locked\": false, \"first_published_at\": \"2017-12-06T17:09:43.276Z\", \"last_published_at\": \"2017-12-13T22:04:09.364Z\", \"latest_revision_created_at\": \"2017-12-13T22:04:09.245Z\", \"live_revision\": 7, \"created_at\": \"2017-12-06T17:09:43.155Z\", \"updated_at\": \"2017-12-13T22:43:34.603Z\", \"content\": \"<ol><li><p>All residents can drop-off their trees to be recycled into mulch. To drop your tree off at Zilker Park, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Drop your tree off between 10am and 2pm on one of the following days:</p></li><ol><li><p>Saturday, December 30, 2017</p></li><li><p>Sunday, December 31, 2017</p></li><li><p>Saturday, January 6, 2018</p></li><li><p>Sunday, January 7, 2018</p></li></ol><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li><li><p>Do you live in a house? Skip ahead and read about recycling your Christmas tree at the curb.</p></li></ol>\", \"content_en\": \"<ol><li><p>All residents can drop-off their trees to be recycled into mulch. To drop your tree off at Zilker Park, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Drop your tree off between 10am and 2pm on one of the following days:</p></li><ol><li><p>Saturday, December 30, 2017</p></li><li><p>Sunday, December 31, 2017</p></li><li><p>Saturday, January 6, 2018</p></li><li><p>Sunday, January 7, 2018</p></li></ol><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li><li><p>Do you live in a house? Skip ahead and read about recycling your Christmas tree at the curb.</p></li></ol>\", \"content_pt\": null, \"content_es\": \"\", \"content_fr\": null, \"extra_content\": \"[{\\\"type\\\": \\\"application_block\\\", \\\"value\\\": 3, \\\"id\\\": \\\"f3154cf7-22c1-4d88-89f9-ee3f834f6ec7\\\"}, {\\\"type\\\": \\\"content\\\", \\\"value\\\": \\\"<h2>Free Drop-Off Locations</h2><p>Trees will be accepted free of cost at the locations listed below. However, a contamination fee will be added to any trees with tags, decorations, and/or plastic remaining.</p><br/><p><a href=\\\\\\\"http://www.texasdisposal.com/contact/\\\\\\\">Texas Disposal Systems</a><br/>TDS Landfill: 3016 FM 1327, Creedmoor, Texas<br/>Eco Depot: 4001 RR 620 South, Bee Cave, Texas</p><p><a href=\\\\\\\"http://www.organicsbygosh.com/drop-off-collection/\\\\\\\">Organics By Gosh</a><br/>13602 FM 969, Austin, TX 78724\\\\u2028 | (512) 276-1211</p><p><a href=\\\\\\\"http://www.daisyworksdirt.com/\\\\\\\">Walker Aero Environmental (JV Dirt)</a><br/>3600 FM 973 North Austin, Texas 78725</p><p><a href=\\\\\\\"http://www.989rock.com/\\\\\\\">Whittlesey Landscape Supplies</a><br/>3219 S IH 35 Round Rock, Texas 78664<br/>629 Dalton Lane, Austin, Texas 78742</p><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Travis County Transfer Station</a><br/>2625 Woodall Dr. Leander, Texas 78641</p><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Travis County Service Center</a><br/>6013 Blue Bluff Rd Austin, Texas 78724</p><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Del Valle Softball Complex (Behind the Southwest Rural Center)</a><br/>3614 FM 973 Del Valle, Texas 78617</p><br/><h2>Drop-Off Locations with a Fee</h2><p>Locations listed below have varying fees. Call the location for more information. \\\\u00a0</p><p><a href=\\\\\\\"http://firewoodandmulchaustintx.com/\\\\\\\">Kinser Ranch LLC.</a><br/>Starts at $1.00/per tree to $20/per load.<br/>For more information: 512-748-0800<br/>10701 Kinser Lane, Austin, Texas 78736</p><p><a href=\\\\\\\"http://www.sidmourningtreeservice.com/\\\\\\\">Sid Mourning Tree Service</a><br/>Pricing varies.<br/>Call for fee information: 512-420-0733<br/>3810 Medical Parkway Austin, TX 78756</p><p><a href=\\\\\\\"http://www.austinwoodrecycling.com/\\\\\\\">Austin Wood Recycling</a><br/>$5.00/per tree.<br/>For more information: 512-259-7430<br/>3875 E. Whitestone Blvd., Cedar Park, TX 78613</p><p><a href=\\\\\\\"http://www.goodguystreeservice.com/\\\\\\\">Good Guys Tree Service</a><br/>Prices vary.<br/>For more information: 512-743-3909<br/>11601 Anderson Mill Rd., Austin, TX 78750</p><h1>Do you live in a house? You can recycle your Christmas tree at the curb</h1><br/><ol><li><p>If you are a City of Austin curbside customer, and you would like to have your tree picked up and turned into mulch, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Cut the tree in half if it is longer than 6 feet.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Set your tree out on the curb by 6:30 am on your regular collection day.</p></li><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li></ol>\\\", \\\"id\\\": \\\"b748924c-4c94-4a4f-a3b2-3730684980f8\\\"}]\", \"topic\": 1, \"locations\": [], \"contacts\": []}",
-      "approved_go_live_at": null
-    }
-  },
-  {
-    "model": "wagtailcore.pagerevision",
-    "pk": 12,
-    "fields": {
-      "page": 5,
-      "submitted_for_moderation": false,
-      "created_at": "2017-12-13T22:44:02.325Z",
-      "user": [
-        "admin@austintexas.io"
-      ],
-      "content_json": "{\"pk\": 5, \"path\": \"000100010002\", \"depth\": 3, \"numchild\": 0, \"title\": \"Pick Up Free Household Items from the ReUse Store\", \"draft_title\": \"Pick Up Free Household Items from the ReUse Store\", \"slug\": \"dropoff\", \"content_type\": 12, \"live\": true, \"has_unpublished_changes\": false, \"url_path\": \"/home/dropoff/\", \"owner\": 1, \"seo_title\": \"\", \"show_in_menus\": false, \"search_description\": \"\", \"go_live_at\": null, \"expire_at\": null, \"expired\": false, \"locked\": false, \"first_published_at\": \"2017-12-06T21:02:34.309Z\", \"last_published_at\": \"2017-12-13T22:36:06.399Z\", \"latest_revision_created_at\": \"2017-12-13T22:36:06.288Z\", \"live_revision\": 9, \"created_at\": \"2017-12-06T21:02:34.149Z\", \"updated_at\": \"2017-12-13T22:44:02.323Z\", \"content\": \"<ol><li><p>Visit the ReUse Store in the Recycle &amp; Reuse Drop-Off Center at 2514 Business Center Dr, Austin, TX 78744.</p></li><li><p>Many materials that are dropped off at the Recycle &amp; Reuse Drop-Off Center are in usable condition. These items go to the ReUse Store. Pick up these items for free:</p></li><ol><li><p>House paint</p></li><li><p>Art supplies</p></li><li><p>Cleaning products</p></li><li><p>Household chemicals</p></li><li><p>Automotive fluids</p></li><li><p>Mulch</p></li></ol></ol>\", \"content_en\": \"<ol><li><p>Visit the ReUse Store in the Recycle &amp; Reuse Drop-Off Center at 2514 Business Center Dr, Austin, TX 78744.</p></li><li><p>Many materials that are dropped off at the Recycle &amp; Reuse Drop-Off Center are in usable condition. These items go to the ReUse Store. Pick up these items for free:</p></li><ol><li><p>House paint</p></li><li><p>Art supplies</p></li><li><p>Cleaning products</p></li><li><p>Household chemicals</p></li><li><p>Automotive fluids</p></li><li><p>Mulch</p></li></ol></ol>\", \"content_pt\": null, \"content_es\": \"\", \"content_fr\": null, \"extra_content\": \"[{\\\"type\\\": \\\"application_block\\\", \\\"value\\\": 4, \\\"id\\\": \\\"003658b6-170d-4baf-9c61-848d26511e5f\\\"}, {\\\"type\\\": \\\"content\\\", \\\"value\\\": \\\"<h1>Learn About Austin ReBlend Paint</h1><p>Paint dropped off by customers is inspected before it is chosen to be used in Austin ReBlend. It is then consolidated, blended, filtered and packed by trained personnel to ensure a quality product.</p><p>Austin ReBlend paint is free for individuals and nonprofits, and can save residents money when refurbishing their homes. The paint is not available to businesses.</p><p>It is available in 3.5 gallon containers and three colors:</p><ul><li><p>Texas Limestone (beige)</p></li><li><p>Balcones Canyonland (dark beige)</p></li><li><p>Barton Creek Greenbelt (dark green)</p></li></ul><h1>Pick Up Free Mulch</h1><p>You can pick up mulch for free; however, you must load it yourself. Bring a pitchfork or shovel, work gloves and containers.</p>\\\", \\\"id\\\": \\\"fff2155d-fc2b-411d-8c3a-1dcef2fff99c\\\"}]\", \"topic\": 1, \"locations\": [], \"contacts\": []}",
-      "approved_go_live_at": null
-    }
-  },
-  {
-    "model": "wagtailcore.pagerevision",
-    "pk": 13,
-    "fields": {
-      "page": 5,
-      "submitted_for_moderation": false,
-      "created_at": "2017-12-15T16:26:52.483Z",
-      "user": [
-        "admin@austintexas.io"
-      ],
-      "content_json": "{\"pk\": 5, \"path\": \"000100010002\", \"depth\": 3, \"numchild\": 0, \"title\": \"Pick Up Free Household Items from the ReUse Store\", \"draft_title\": \"Pick Up Free Household Items from the ReUse Store\", \"slug\": \"dropoff\", \"content_type\": 12, \"live\": true, \"has_unpublished_changes\": false, \"url_path\": \"/home/dropoff/\", \"owner\": 1, \"seo_title\": \"\", \"show_in_menus\": false, \"search_description\": \"\", \"go_live_at\": null, \"expire_at\": null, \"expired\": false, \"locked\": false, \"first_published_at\": \"2017-12-06T21:02:34.309Z\", \"last_published_at\": \"2017-12-13T22:44:02.435Z\", \"latest_revision_created_at\": \"2017-12-13T22:44:02.325Z\", \"live_revision\": 12, \"created_at\": \"2017-12-06T21:02:34.149Z\", \"updated_at\": \"2017-12-15T16:26:52.481Z\", \"content\": \"<ol><li><p>Visit the ReUse Store in the Recycle &amp; Reuse Drop-Off Center at 2514 Business Center Dr, Austin, TX 78744.</p></li><li><p>Many materials that are dropped off at the Recycle &amp; Reuse Drop-Off Center are in usable condition. These items go to the ReUse Store. Pick up these items for free:</p></li><ol><li><p>House paint</p></li><li><p>Art supplies</p></li><li><p>Cleaning products</p></li><li><p>Household chemicals</p></li><li><p>Automotive fluids</p></li><li><p>Mulch</p></li></ol></ol>\", \"content_en\": \"<ol><li><p>Visit the ReUse Store in the Recycle &amp; Reuse Drop-Off Center at 2514 Business Center Dr, Austin, TX 78744.</p></li><li><p>Many materials that are dropped off at the Recycle &amp; Reuse Drop-Off Center are in usable condition. These items go to the ReUse Store. Pick up these items for free:</p></li><ol><li><p>House paint</p></li><li><p>Art supplies</p></li><li><p>Cleaning products</p></li><li><p>Household chemicals</p></li><li><p>Automotive fluids</p></li><li><p>Mulch</p></li></ol></ol>\", \"content_pt\": null, \"content_es\": \"\", \"content_fr\": null, \"extra_content\": \"[{\\\"type\\\": \\\"application_block\\\", \\\"value\\\": 4, \\\"id\\\": \\\"003658b6-170d-4baf-9c61-848d26511e5f\\\"}, {\\\"type\\\": \\\"content\\\", \\\"value\\\": \\\"<h1>Learn About Austin ReBlend Paint</h1><p>Paint dropped off by customers is inspected before it is chosen to be used in Austin ReBlend. It is then consolidated, blended, filtered and packed by trained personnel to ensure a quality product.</p><p>Austin ReBlend paint is free for individuals and nonprofits, and can save residents money when refurbishing their homes. The paint is not available to businesses.</p><p>It is available in 3.5 gallon containers and three colors:</p><ul><li><p>Texas Limestone (beige)</p></li><li><p>Balcones Canyonland (dark beige)</p></li><li><p>Barton Creek Greenbelt (dark green)</p></li></ul><h1>Pick Up Free Mulch</h1><p>You can pick up mulch for free; however, you must load it yourself. Bring a pitchfork or shovel, work gloves and containers.</p>\\\", \\\"id\\\": \\\"fff2155d-fc2b-411d-8c3a-1dcef2fff99c\\\"}]\", \"topic\": 1, \"locations\": [{\"pk\": null, \"page\": 5, \"location\": 1}], \"contacts\": [{\"pk\": null, \"page\": 5, \"contact\": 1}]}",
-      "approved_go_live_at": null
-    }
-  },
-  {
-    "model": "wagtailcore.pagerevision",
-    "pk": 14,
-    "fields": {
-      "page": 4,
-      "submitted_for_moderation": false,
-      "created_at": "2017-12-29T04:42:20.565Z",
-      "user": [
-        "admin@austintexas.io"
-      ],
-      "content_json": "{\"pk\": 4, \"path\": \"000100010001\", \"depth\": 3, \"numchild\": 0, \"title\": \"Recycle your Christmas tree\", \"draft_title\": \"Recycle your Christmas tree\", \"slug\": \"holiday-tree-recycling\", \"content_type\": 12, \"live\": true, \"has_unpublished_changes\": false, \"url_path\": \"/home/holiday-tree-recycling/\", \"owner\": 1, \"seo_title\": \"\", \"show_in_menus\": false, \"search_description\": \"\", \"go_live_at\": null, \"expire_at\": null, \"expired\": false, \"locked\": false, \"first_published_at\": \"2017-12-06T17:09:43.276Z\", \"last_published_at\": \"2017-12-13T22:43:34.715Z\", \"latest_revision_created_at\": \"2017-12-13T22:43:34.605Z\", \"live_revision\": 11, \"created_at\": \"2017-12-06T17:09:43.155Z\", \"updated_at\": \"2017-12-29T04:42:20.559Z\", \"content\": \"<ol><li><p>All residents can drop-off their trees to be recycled into mulch. To drop your tree off at Zilker Park, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Drop your tree off between 10am and 2pm on one of the following days:</p></li><ol><li><p>Saturday, December 30, 2017</p></li><li><p>Sunday, December 31, 2017</p></li><li><p>Saturday, January 6, 2018</p></li><li><p>Sunday, January 7, 2018</p></li></ol><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li><li><p>Do you live in a house? Skip ahead and read about recycling your Christmas tree at the curb.</p></li></ol>\", \"content_en\": \"<ol><li><p>All residents can drop-off their trees to be recycled into mulch. To drop your tree off at Zilker Park, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Drop your tree off between 10am and 2pm on one of the following days:</p></li><ol><li><p>Saturday, December 30, 2017</p></li><li><p>Sunday, December 31, 2017</p></li><li><p>Saturday, January 6, 2018</p></li><li><p>Sunday, January 7, 2018</p></li></ol><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li><li><p>Do you live in a house? Skip ahead and read about recycling your Christmas tree at the curb.</p></li></ol>\", \"content_pt\": null, \"content_es\": \"\", \"content_fr\": null, \"extra_content\": \"[{\\\"type\\\": \\\"application_block\\\", \\\"value\\\": 3, \\\"id\\\": \\\"f3154cf7-22c1-4d88-89f9-ee3f834f6ec7\\\"}, {\\\"type\\\": \\\"content\\\", \\\"value\\\": \\\"<h2>Free Drop-Off Locations</h2><p>Trees will be accepted free of cost at the locations listed below. However, a contamination fee will be added to any trees with tags, decorations, and/or plastic remaining.</p><br/><p><a href=\\\\\\\"http://www.texasdisposal.com/contact/\\\\\\\">Texas Disposal Systems</a><br/>TDS Landfill: 3016 FM 1327, Creedmoor, Texas<br/>Eco Depot: 4001 RR 620 South, Bee Cave, Texas</p><p><a href=\\\\\\\"http://www.organicsbygosh.com/drop-off-collection/\\\\\\\">Organics By Gosh</a><br/>13602 FM 969, Austin, TX 78724\\\\u2028 | (512) 276-1211</p><p><a href=\\\\\\\"http://www.daisyworksdirt.com/\\\\\\\">Walker Aero Environmental (JV Dirt)</a><br/>3600 FM 973 North Austin, Texas 78725</p><p><a href=\\\\\\\"http://www.989rock.com/\\\\\\\">Whittlesey Landscape Supplies</a><br/>3219 S IH 35 Round Rock, Texas 78664<br/>629 Dalton Lane, Austin, Texas 78742</p><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Travis County Transfer Station</a><br/>2625 Woodall Dr. Leander, Texas 78641</p><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Travis County Service Center</a><br/>6013 Blue Bluff Rd Austin, Texas 78724</p><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Del Valle Softball Complex (Behind the Southwest Rural Center)</a><br/>3614 FM 973 Del Valle, Texas 78617</p><br/><h2>Drop-Off Locations with a Fee</h2><p>Locations listed below have varying fees. Call the location for more information. \\\\u00a0</p><p><a href=\\\\\\\"http://firewoodandmulchaustintx.com/\\\\\\\">Kinser Ranch LLC.</a><br/>Starts at $1.00/per tree to $20/per load.<br/>For more information: 512-748-0800<br/>10701 Kinser Lane, Austin, Texas 78736</p><p><a href=\\\\\\\"http://www.sidmourningtreeservice.com/\\\\\\\">Sid Mourning Tree Service</a><br/>Pricing varies.<br/>Call for fee information: 512-420-0733<br/>3810 Medical Parkway Austin, TX 78756</p><p><a href=\\\\\\\"http://www.austinwoodrecycling.com/\\\\\\\">Austin Wood Recycling</a><br/>$5.00/per tree.<br/>For more information: 512-259-7430<br/>3875 E. Whitestone Blvd., Cedar Park, TX 78613</p><p><a href=\\\\\\\"http://www.goodguystreeservice.com/\\\\\\\">Good Guys Tree Service</a><br/>Prices vary.<br/>For more information: 512-743-3909<br/>11601 Anderson Mill Rd., Austin, TX 78750</p><h1>Do you live in a house? You can recycle your Christmas tree at the curb</h1><br/><ol><li><p>If you are a City of Austin curbside customer, and you would like to have your tree picked up and turned into mulch, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Cut the tree in half if it is longer than 6 feet.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Set your tree out on the curb by 6:30 am on your regular collection day.</p></li><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li></ol>\\\", \\\"id\\\": \\\"b748924c-4c94-4a4f-a3b2-3730684980f8\\\"}]\", \"topic\": 1, \"contacts\": [{\"pk\": null, \"page\": 4, \"contact\": 1}]}",
-      "approved_go_live_at": null
-    }
-  },
-  {
-    "model": "wagtailcore.pagerevision",
-    "pk": 15,
-    "fields": {
-      "page": 4,
-      "submitted_for_moderation": false,
-      "created_at": "2017-12-29T04:43:18.522Z",
-      "user": [
-        "admin@austintexas.io"
-      ],
-      "content_json": "{\"pk\": 4, \"path\": \"000100010001\", \"depth\": 3, \"numchild\": 0, \"title\": \"Recycle your Christmas tree\", \"draft_title\": \"Recycle your Christmas tree\", \"slug\": \"holiday-tree-recycling\", \"content_type\": 12, \"live\": true, \"has_unpublished_changes\": true, \"url_path\": \"/home/holiday-tree-recycling/\", \"owner\": 1, \"seo_title\": \"\", \"show_in_menus\": false, \"search_description\": \"\", \"go_live_at\": null, \"expire_at\": null, \"expired\": false, \"locked\": false, \"first_published_at\": \"2017-12-06T17:09:43.276Z\", \"last_published_at\": \"2017-12-13T22:43:34.715Z\", \"latest_revision_created_at\": \"2017-12-29T04:42:20.565Z\", \"live_revision\": 11, \"created_at\": \"2017-12-06T17:09:43.155Z\", \"updated_at\": \"2017-12-29T04:43:18.519Z\", \"content\": \"<ol><li><p>All residents can drop-off their trees to be recycled into mulch. To drop your tree off at Zilker Park, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Drop your tree off between 10am and 2pm on one of the following days:</p></li><ol><li><p>Saturday, December 30, 2017</p></li><li><p>Sunday, December 31, 2017</p></li><li><p>Saturday, January 6, 2018</p></li><li><p>Sunday, January 7, 2018</p></li></ol><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li><li><p>Do you live in a house? Skip ahead and read about recycling your Christmas tree at the curb.</p></li></ol>\", \"content_en\": \"<ol><li><p>All residents can drop-off their trees to be recycled into mulch. To drop your tree off at Zilker Park, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Drop your tree off between 10am and 2pm on one of the following days:</p></li><ol><li><p>Saturday, December 30, 2017</p></li><li><p>Sunday, December 31, 2017</p></li><li><p>Saturday, January 6, 2018</p></li><li><p>Sunday, January 7, 2018</p></li></ol><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li><li><p>Do you live in a house? Skip ahead and read about recycling your Christmas tree at the curb.</p></li></ol>\", \"content_pt\": null, \"content_es\": \"\", \"content_fr\": null, \"extra_content\": \"[{\\\"type\\\": \\\"application_block\\\", \\\"value\\\": 3, \\\"id\\\": \\\"f3154cf7-22c1-4d88-89f9-ee3f834f6ec7\\\"}, {\\\"type\\\": \\\"content\\\", \\\"value\\\": \\\"<h2>Free Drop-Off Locations</h2><p>Trees will be accepted free of cost at the locations listed below. However, a contamination fee will be added to any trees with tags, decorations, and/or plastic remaining.</p><br/><p><a href=\\\\\\\"http://www.texasdisposal.com/contact/\\\\\\\">Texas Disposal Systems</a><br/>TDS Landfill: 3016 FM 1327, Creedmoor, Texas<br/>Eco Depot: 4001 RR 620 South, Bee Cave, Texas</p><p><a href=\\\\\\\"http://www.organicsbygosh.com/drop-off-collection/\\\\\\\">Organics By Gosh</a><br/>13602 FM 969, Austin, TX 78724\\\\u2028 | (512) 276-1211</p><p><a href=\\\\\\\"http://www.daisyworksdirt.com/\\\\\\\">Walker Aero Environmental (JV Dirt)</a><br/>3600 FM 973 North Austin, Texas 78725</p><p><a href=\\\\\\\"http://www.989rock.com/\\\\\\\">Whittlesey Landscape Supplies</a><br/>3219 S IH 35 Round Rock, Texas 78664<br/>629 Dalton Lane, Austin, Texas 78742</p><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Travis County Transfer Station</a><br/>2625 Woodall Dr. Leander, Texas 78641</p><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Travis County Service Center</a><br/>6013 Blue Bluff Rd Austin, Texas 78724</p><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Del Valle Softball Complex (Behind the Southwest Rural Center)</a><br/>3614 FM 973 Del Valle, Texas 78617</p><br/><h2>Drop-Off Locations with a Fee</h2><p>Locations listed below have varying fees. Call the location for more information. \\\\u00a0</p><p><a href=\\\\\\\"http://firewoodandmulchaustintx.com/\\\\\\\">Kinser Ranch LLC.</a><br/>Starts at $1.00/per tree to $20/per load.<br/>For more information: 512-748-0800<br/>10701 Kinser Lane, Austin, Texas 78736</p><p><a href=\\\\\\\"http://www.sidmourningtreeservice.com/\\\\\\\">Sid Mourning Tree Service</a><br/>Pricing varies.<br/>Call for fee information: 512-420-0733<br/>3810 Medical Parkway Austin, TX 78756</p><p><a href=\\\\\\\"http://www.austinwoodrecycling.com/\\\\\\\">Austin Wood Recycling</a><br/>$5.00/per tree.<br/>For more information: 512-259-7430<br/>3875 E. Whitestone Blvd., Cedar Park, TX 78613</p><p><a href=\\\\\\\"http://www.goodguystreeservice.com/\\\\\\\">Good Guys Tree Service</a><br/>Prices vary.<br/>For more information: 512-743-3909<br/>11601 Anderson Mill Rd., Austin, TX 78750</p><h1>Do you live in a house? You can recycle your Christmas tree at the curb</h1><br/><ol><li><p>If you are a City of Austin curbside customer, and you would like to have your tree picked up and turned into mulch, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Cut the tree in half if it is longer than 6 feet.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Set your tree out on the curb by 6:30 am on your regular collection day.</p></li><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li></ol>\\\", \\\"id\\\": \\\"b748924c-4c94-4a4f-a3b2-3730684980f8\\\"}]\", \"topic\": 1, \"contacts\": [{\"pk\": null, \"page\": 4, \"contact\": 1}]}",
-      "approved_go_live_at": null
-    }
-  },
-  {
-    "model": "wagtailcore.pagerevision",
-    "pk": 16,
-    "fields": {
-      "page": 4,
-      "submitted_for_moderation": false,
-      "created_at": "2017-12-29T04:48:15.808Z",
-      "user": [
-        "admin@austintexas.io"
-      ],
-      "content_json": "{\"pk\": 4, \"path\": \"000100010001\", \"depth\": 3, \"numchild\": 0, \"title\": \"Recycle your Christmas tree\", \"draft_title\": \"Recycle your Christmas tree\", \"slug\": \"holiday-tree-recycling\", \"content_type\": 12, \"live\": true, \"has_unpublished_changes\": false, \"url_path\": \"/home/holiday-tree-recycling/\", \"owner\": 1, \"seo_title\": \"\", \"show_in_menus\": false, \"search_description\": \"\", \"go_live_at\": null, \"expire_at\": null, \"expired\": false, \"locked\": false, \"first_published_at\": \"2017-12-06T17:09:43.276Z\", \"last_published_at\": \"2017-12-29T04:43:18.837Z\", \"latest_revision_created_at\": \"2017-12-29T04:43:18.522Z\", \"live_revision\": 15, \"created_at\": \"2017-12-06T17:09:43.155Z\", \"updated_at\": \"2017-12-29T04:48:15.806Z\", \"content\": \"<ol><li><p>All residents can drop-off their trees to be recycled into mulch. To drop your tree off at Zilker Park, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Drop your tree off between 10am and 2pm on one of the following days:</p></li><ol><li><p>Saturday, December 30, 2017</p></li><li><p>Sunday, December 31, 2017</p></li><li><p>Saturday, January 6, 2018</p></li><li><p>Sunday, January 7, 2018</p></li></ol><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li><li><p>Do you live in a house? Skip ahead and read about recycling your Christmas tree at the curb.</p></li></ol>\", \"content_en\": \"<ol><li><p>All residents can drop-off their trees to be recycled into mulch. To drop your tree off at Zilker Park, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Drop your tree off between 10am and 2pm on one of the following days:</p></li><ol><li><p>Saturday, December 30, 2017</p></li><li><p>Sunday, December 31, 2017</p></li><li><p>Saturday, January 6, 2018</p></li><li><p>Sunday, January 7, 2018</p></li></ol><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li><li><p>Do you live in a house? Skip ahead and read about recycling your Christmas tree at the curb.</p></li></ol>\", \"content_pt\": null, \"content_es\": \"\", \"content_fr\": null, \"extra_content\": \"[{\\\"type\\\": \\\"application_block\\\", \\\"value\\\": 3, \\\"id\\\": \\\"f3154cf7-22c1-4d88-89f9-ee3f834f6ec7\\\"}, {\\\"type\\\": \\\"content\\\", \\\"value\\\": \\\"<h2>Free Drop-Off Locations</h2><p>Trees will be accepted free of cost at the locations listed below. However, a contamination fee will be added to any trees with tags, decorations, and/or plastic remaining.</p><br/><p><a href=\\\\\\\"http://www.texasdisposal.com/contact/\\\\\\\">Texas Disposal Systems</a><br/>TDS Landfill: 3016 FM 1327, Creedmoor, Texas<br/>Eco Depot: 4001 RR 620 South, Bee Cave, Texas</p><p><a href=\\\\\\\"http://www.organicsbygosh.com/drop-off-collection/\\\\\\\">Organics By Gosh</a><br/>13602 FM 969, Austin, TX 78724\\\\u2028 | (512) 276-1211</p><p><a href=\\\\\\\"http://www.daisyworksdirt.com/\\\\\\\">Walker Aero Environmental (JV Dirt)</a><br/>3600 FM 973 North Austin, Texas 78725</p><p><a href=\\\\\\\"http://www.989rock.com/\\\\\\\">Whittlesey Landscape Supplies</a><br/>3219 S IH 35 Round Rock, Texas 78664<br/>629 Dalton Lane, Austin, Texas 78742</p><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Travis County Transfer Station</a><br/>2625 Woodall Dr. Leander, Texas 78641</p><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Travis County Service Center</a><br/>6013 Blue Bluff Rd Austin, Texas 78724</p><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Del Valle Softball Complex (Behind the Southwest Rural Center)</a><br/>3614 FM 973 Del Valle, Texas 78617</p><br/><h2>Drop-Off Locations with a Fee</h2><p>Locations listed below have varying fees. Call the location for more information. \\\\u00a0</p><p><a href=\\\\\\\"http://firewoodandmulchaustintx.com/\\\\\\\">Kinser Ranch LLC.</a><br/>Starts at $1.00/per tree to $20/per load.<br/>For more information: 512-748-0800<br/>10701 Kinser Lane, Austin, Texas 78736</p><p><a href=\\\\\\\"http://www.sidmourningtreeservice.com/\\\\\\\">Sid Mourning Tree Service</a><br/>Pricing varies.<br/>Call for fee information: 512-420-0733<br/>3810 Medical Parkway Austin, TX 78756</p><p><a href=\\\\\\\"http://www.austinwoodrecycling.com/\\\\\\\">Austin Wood Recycling</a><br/>$5.00/per tree.<br/>For more information: 512-259-7430<br/>3875 E. Whitestone Blvd., Cedar Park, TX 78613</p><p><a href=\\\\\\\"http://www.goodguystreeservice.com/\\\\\\\">Good Guys Tree Service</a><br/>Prices vary.<br/>For more information: 512-743-3909<br/>11601 Anderson Mill Rd., Austin, TX 78750</p><h1>Do you live in a house? You can recycle your Christmas tree at the curb</h1><br/><ol><li><p>If you are a City of Austin curbside customer, and you would like to have your tree picked up and turned into mulch, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Cut the tree in half if it is longer than 6 feet.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Set your tree out on the curb by 6:30 am on your regular collection day.</p></li><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li></ol>\\\", \\\"id\\\": \\\"b748924c-4c94-4a4f-a3b2-3730684980f8\\\"}]\", \"topic\": 1, \"contacts\": []}",
-      "approved_go_live_at": null
-    }
-  },
-  {
-    "model": "wagtailcore.pagerevision",
-    "pk": 17,
-    "fields": {
-      "page": 4,
-      "submitted_for_moderation": false,
-      "created_at": "2017-12-29T04:56:27.169Z",
-      "user": [
-        "admin@austintexas.io"
-      ],
-      "content_json": "{\"pk\": 4, \"path\": \"000100010001\", \"depth\": 3, \"numchild\": 0, \"title\": \"Recycle your Christmas tree\", \"draft_title\": \"Recycle your Christmas tree\", \"slug\": \"holiday-tree-recycling\", \"content_type\": 12, \"live\": true, \"has_unpublished_changes\": true, \"url_path\": \"/home/holiday-tree-recycling/\", \"owner\": 1, \"seo_title\": \"\", \"show_in_menus\": false, \"search_description\": \"\", \"go_live_at\": null, \"expire_at\": null, \"expired\": false, \"locked\": false, \"first_published_at\": \"2017-12-06T17:09:43.276Z\", \"last_published_at\": \"2017-12-29T04:43:18.837Z\", \"latest_revision_created_at\": \"2017-12-29T04:48:15.808Z\", \"live_revision\": 15, \"created_at\": \"2017-12-06T17:09:43.155Z\", \"updated_at\": \"2017-12-29T04:56:27.168Z\", \"content\": \"<ol><li><p>All residents can drop-off their trees to be recycled into mulch. To drop your tree off at Zilker Park, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Drop your tree off between 10am and 2pm on one of the following days:</p></li><ol><li><p>Saturday, December 30, 2017</p></li><li><p>Sunday, December 31, 2017</p></li><li><p>Saturday, January 6, 2018</p></li><li><p>Sunday, January 7, 2018</p></li></ol><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li><li><p>Do you live in a house? Skip ahead and read about recycling your Christmas tree at the curb.</p></li></ol>\", \"content_en\": \"<ol><li><p>All residents can drop-off their trees to be recycled into mulch. To drop your tree off at Zilker Park, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Drop your tree off between 10am and 2pm on one of the following days:</p></li><ol><li><p>Saturday, December 30, 2017</p></li><li><p>Sunday, December 31, 2017</p></li><li><p>Saturday, January 6, 2018</p></li><li><p>Sunday, January 7, 2018</p></li></ol><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li><li><p>Do you live in a house? Skip ahead and read about recycling your Christmas tree at the curb.</p></li></ol>\", \"content_pt\": null, \"content_es\": \"\", \"content_fr\": null, \"extra_content\": \"[{\\\"type\\\": \\\"application_block\\\", \\\"value\\\": 3, \\\"id\\\": \\\"f3154cf7-22c1-4d88-89f9-ee3f834f6ec7\\\"}, {\\\"type\\\": \\\"content\\\", \\\"value\\\": \\\"<h2>Free Drop-Off Locations</h2><p>Trees will be accepted free of cost at the locations listed below. However, a contamination fee will be added to any trees with tags, decorations, and/or plastic remaining.</p><br/><p><a href=\\\\\\\"http://www.texasdisposal.com/contact/\\\\\\\">Texas Disposal Systems</a><br/>TDS Landfill: 3016 FM 1327, Creedmoor, Texas<br/>Eco Depot: 4001 RR 620 South, Bee Cave, Texas</p><p><a href=\\\\\\\"http://www.organicsbygosh.com/drop-off-collection/\\\\\\\">Organics By Gosh</a><br/>13602 FM 969, Austin, TX 78724\\\\u2028 | (512) 276-1211</p><p><a href=\\\\\\\"http://www.daisyworksdirt.com/\\\\\\\">Walker Aero Environmental (JV Dirt)</a><br/>3600 FM 973 North Austin, Texas 78725</p><p><a href=\\\\\\\"http://www.989rock.com/\\\\\\\">Whittlesey Landscape Supplies</a><br/>3219 S IH 35 Round Rock, Texas 78664<br/>629 Dalton Lane, Austin, Texas 78742</p><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Travis County Transfer Station</a><br/>2625 Woodall Dr. Leander, Texas 78641</p><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Travis County Service Center</a><br/>6013 Blue Bluff Rd Austin, Texas 78724</p><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Del Valle Softball Complex (Behind the Southwest Rural Center)</a><br/>3614 FM 973 Del Valle, Texas 78617</p><br/><h2>Drop-Off Locations with a Fee</h2><p>Locations listed below have varying fees. Call the location for more information. \\\\u00a0</p><p><a href=\\\\\\\"http://firewoodandmulchaustintx.com/\\\\\\\">Kinser Ranch LLC.</a><br/>Starts at $1.00/per tree to $20/per load.<br/>For more information: 512-748-0800<br/>10701 Kinser Lane, Austin, Texas 78736</p><p><a href=\\\\\\\"http://www.sidmourningtreeservice.com/\\\\\\\">Sid Mourning Tree Service</a><br/>Pricing varies.<br/>Call for fee information: 512-420-0733<br/>3810 Medical Parkway Austin, TX 78756</p><p><a href=\\\\\\\"http://www.austinwoodrecycling.com/\\\\\\\">Austin Wood Recycling</a><br/>$5.00/per tree.<br/>For more information: 512-259-7430<br/>3875 E. Whitestone Blvd., Cedar Park, TX 78613</p><p><a href=\\\\\\\"http://www.goodguystreeservice.com/\\\\\\\">Good Guys Tree Service</a><br/>Prices vary.<br/>For more information: 512-743-3909<br/>11601 Anderson Mill Rd., Austin, TX 78750</p><h1>Do you live in a house? You can recycle your Christmas tree at the curb</h1><br/><ol><li><p>If you are a City of Austin curbside customer, and you would like to have your tree picked up and turned into mulch, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Cut the tree in half if it is longer than 6 feet.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Set your tree out on the curb by 6:30 am on your regular collection day.</p></li><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li></ol>\\\", \\\"id\\\": \\\"b748924c-4c94-4a4f-a3b2-3730684980f8\\\"}]\", \"topic\": 1, \"contacts\": []}",
-      "approved_go_live_at": null
-    }
-  },
-  {
-    "model": "wagtailcore.pagerevision",
-    "pk": 18,
-    "fields": {
-      "page": 4,
-      "submitted_for_moderation": false,
-      "created_at": "2017-12-29T05:15:16.075Z",
-      "user": [
-        "admin@austintexas.io"
-      ],
-      "content_json": "{\"pk\": 4, \"path\": \"000100010001\", \"depth\": 3, \"numchild\": 0, \"title\": \"Recycle your Christmas treeeeeeeeeeee\", \"draft_title\": \"Recycle your Christmas tree\", \"slug\": \"holiday-tree-recycling\", \"content_type\": 12, \"live\": true, \"has_unpublished_changes\": true, \"url_path\": \"/home/holiday-tree-recycling/\", \"owner\": 1, \"seo_title\": \"\", \"show_in_menus\": false, \"search_description\": \"\", \"go_live_at\": null, \"expire_at\": null, \"expired\": false, \"locked\": false, \"first_published_at\": \"2017-12-06T17:09:43.276Z\", \"last_published_at\": \"2017-12-29T04:43:18.837Z\", \"latest_revision_created_at\": \"2017-12-29T04:56:27.169Z\", \"live_revision\": 15, \"created_at\": \"2017-12-06T17:09:43.155Z\", \"updated_at\": \"2017-12-29T05:15:16.073Z\", \"content\": \"<ol><li><p>All residents can drop-off their trees to be recycled into mulch. To drop your tree off at Zilker Park, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Drop your tree off between 10am and 2pm on one of the following days:</p></li><ol><li><p>Saturday, December 30, 2017</p></li><li><p>Sunday, December 31, 2017</p></li><li><p>Saturday, January 6, 2018</p></li><li><p>Sunday, January 7, 2018</p></li></ol><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li><li><p>Do you live in a house? Skip ahead and read about recycling your Christmas tree at the curb.</p></li></ol>\", \"content_en\": \"<ol><li><p>All residents can drop-off their trees to be recycled into mulch. To drop your tree off at Zilker Park, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Drop your tree off between 10am and 2pm on one of the following days:</p></li><ol><li><p>Saturday, December 30, 2017</p></li><li><p>Sunday, December 31, 2017</p></li><li><p>Saturday, January 6, 2018</p></li><li><p>Sunday, January 7, 2018</p></li></ol><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li><li><p>Do you live in a house? Skip ahead and read about recycling your Christmas tree at the curb.</p></li></ol>\", \"content_pt\": null, \"content_es\": \"\", \"content_fr\": null, \"extra_content\": \"[{\\\"type\\\": \\\"application_block\\\", \\\"value\\\": 3, \\\"id\\\": \\\"f3154cf7-22c1-4d88-89f9-ee3f834f6ec7\\\"}, {\\\"type\\\": \\\"content\\\", \\\"value\\\": \\\"<h2>Free Drop-Off Locations</h2><p>Trees will be accepted free of cost at the locations listed below. However, a contamination fee will be added to any trees with tags, decorations, and/or plastic remaining.</p><br/><p><a href=\\\\\\\"http://www.texasdisposal.com/contact/\\\\\\\">Texas Disposal Systems</a><br/>TDS Landfill: 3016 FM 1327, Creedmoor, Texas<br/>Eco Depot: 4001 RR 620 South, Bee Cave, Texas</p><p><a href=\\\\\\\"http://www.organicsbygosh.com/drop-off-collection/\\\\\\\">Organics By Gosh</a><br/>13602 FM 969, Austin, TX 78724\\\\u2028 | (512) 276-1211</p><p><a href=\\\\\\\"http://www.daisyworksdirt.com/\\\\\\\">Walker Aero Environmental (JV Dirt)</a><br/>3600 FM 973 North Austin, Texas 78725</p><p><a href=\\\\\\\"http://www.989rock.com/\\\\\\\">Whittlesey Landscape Supplies</a><br/>3219 S IH 35 Round Rock, Texas 78664<br/>629 Dalton Lane, Austin, Texas 78742</p><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Travis County Transfer Station</a><br/>2625 Woodall Dr. Leander, Texas 78641</p><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Travis County Service Center</a><br/>6013 Blue Bluff Rd Austin, Texas 78724</p><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Del Valle Softball Complex (Behind the Southwest Rural Center)</a><br/>3614 FM 973 Del Valle, Texas 78617</p><br/><h2>Drop-Off Locations with a Fee</h2><p>Locations listed below have varying fees. Call the location for more information. \\\\u00a0</p><p><a href=\\\\\\\"http://firewoodandmulchaustintx.com/\\\\\\\">Kinser Ranch LLC.</a><br/>Starts at $1.00/per tree to $20/per load.<br/>For more information: 512-748-0800<br/>10701 Kinser Lane, Austin, Texas 78736</p><p><a href=\\\\\\\"http://www.sidmourningtreeservice.com/\\\\\\\">Sid Mourning Tree Service</a><br/>Pricing varies.<br/>Call for fee information: 512-420-0733<br/>3810 Medical Parkway Austin, TX 78756</p><p><a href=\\\\\\\"http://www.austinwoodrecycling.com/\\\\\\\">Austin Wood Recycling</a><br/>$5.00/per tree.<br/>For more information: 512-259-7430<br/>3875 E. Whitestone Blvd., Cedar Park, TX 78613</p><p><a href=\\\\\\\"http://www.goodguystreeservice.com/\\\\\\\">Good Guys Tree Service</a><br/>Prices vary.<br/>For more information: 512-743-3909<br/>11601 Anderson Mill Rd., Austin, TX 78750</p><h1>Do you live in a house? You can recycle your Christmas tree at the curb</h1><br/><ol><li><p>If you are a City of Austin curbside customer, and you would like to have your tree picked up and turned into mulch, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Cut the tree in half if it is longer than 6 feet.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Set your tree out on the curb by 6:30 am on your regular collection day.</p></li><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li></ol>\\\", \\\"id\\\": \\\"b748924c-4c94-4a4f-a3b2-3730684980f8\\\"}]\", \"topic\": 1, \"contacts\": []}",
-      "approved_go_live_at": null
-    }
-  },
-  {
-    "model": "wagtailcore.pagerevision",
-    "pk": 19,
-    "fields": {
-      "page": 4,
-      "submitted_for_moderation": false,
-      "created_at": "2017-12-29T06:02:11.715Z",
-      "user": [
-        "admin@austintexas.io"
-      ],
-      "content_json": "{\"pk\": 4, \"path\": \"000100010001\", \"depth\": 3, \"numchild\": 0, \"title\": \"Recycle your Christmas treeeeeeeeeeee\", \"draft_title\": \"Recycle your Christmas treeeeeeeeeeee\", \"slug\": \"holiday-tree-recycling\", \"content_type\": 12, \"live\": true, \"has_unpublished_changes\": true, \"url_path\": \"/home/holiday-tree-recycling/\", \"owner\": 1, \"seo_title\": \"\", \"show_in_menus\": false, \"search_description\": \"\", \"go_live_at\": null, \"expire_at\": null, \"expired\": false, \"locked\": false, \"first_published_at\": \"2017-12-06T17:09:43.276Z\", \"last_published_at\": \"2017-12-29T04:43:18.837Z\", \"latest_revision_created_at\": \"2017-12-29T05:15:16.075Z\", \"live_revision\": 15, \"created_at\": \"2017-12-06T17:09:43.155Z\", \"updated_at\": \"2017-12-29T06:02:11.714Z\", \"content\": \"<ol><li><p>All residents can drop-off their trees to be recycled into mulch. To drop your tree off at Zilker Park, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Drop your tree off between 10am and 2pm on one of the following days:</p></li><ol><li><p>Saturday, December 30, 2017</p></li><li><p>Sunday, December 31, 2017</p></li><li><p>Saturday, January 6, 2018</p></li><li><p>Sunday, January 7, 2018</p></li></ol><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li><li><p>Do you live in a house? Skip ahead and read about recycling your Christmas tree at the curb.</p></li></ol>\", \"content_en\": \"<ol><li><p>All residents can drop-off their trees to be recycled into mulch. To drop your tree off at Zilker Park, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Drop your tree off between 10am and 2pm on one of the following days:</p></li><ol><li><p>Saturday, December 30, 2017</p></li><li><p>Sunday, December 31, 2017</p></li><li><p>Saturday, January 6, 2018</p></li><li><p>Sunday, January 7, 2018</p></li></ol><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li><li><p>Do you live in a house? Skip ahead and read about recycling your Christmas tree at the curb.</p></li></ol>\", \"content_pt\": null, \"content_es\": \"\", \"content_fr\": null, \"extra_content\": \"[{\\\"type\\\": \\\"application_block\\\", \\\"value\\\": 3, \\\"id\\\": \\\"f3154cf7-22c1-4d88-89f9-ee3f834f6ec7\\\"}, {\\\"type\\\": \\\"content\\\", \\\"value\\\": \\\"<h2>Free Drop-Off Locations</h2><p>Trees will be accepted free of cost at the locations listed below. However, a contamination fee will be added to any trees with tags, decorations, and/or plastic remaining.</p><br/><p><a href=\\\\\\\"http://www.texasdisposal.com/contact/\\\\\\\">Texas Disposal Systems</a><br/>TDS Landfill: 3016 FM 1327, Creedmoor, Texas<br/>Eco Depot: 4001 RR 620 South, Bee Cave, Texas</p><p><a href=\\\\\\\"http://www.organicsbygosh.com/drop-off-collection/\\\\\\\">Organics By Gosh</a><br/>13602 FM 969, Austin, TX 78724\\\\u2028 | (512) 276-1211</p><p><a href=\\\\\\\"http://www.daisyworksdirt.com/\\\\\\\">Walker Aero Environmental (JV Dirt)</a><br/>3600 FM 973 North Austin, Texas 78725</p><p><a href=\\\\\\\"http://www.989rock.com/\\\\\\\">Whittlesey Landscape Supplies</a><br/>3219 S IH 35 Round Rock, Texas 78664<br/>629 Dalton Lane, Austin, Texas 78742</p><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Travis County Transfer Station</a><br/>2625 Woodall Dr. Leander, Texas 78641</p><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Travis County Service Center</a><br/>6013 Blue Bluff Rd Austin, Texas 78724</p><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Del Valle Softball Complex (Behind the Southwest Rural Center)</a><br/>3614 FM 973 Del Valle, Texas 78617</p><br/><h2>Drop-Off Locations with a Fee</h2><p>Locations listed below have varying fees. Call the location for more information. \\\\u00a0</p><p><a href=\\\\\\\"http://firewoodandmulchaustintx.com/\\\\\\\">Kinser Ranch LLC.</a><br/>Starts at $1.00/per tree to $20/per load.<br/>For more information: 512-748-0800<br/>10701 Kinser Lane, Austin, Texas 78736</p><p><a href=\\\\\\\"http://www.sidmourningtreeservice.com/\\\\\\\">Sid Mourning Tree Service</a><br/>Pricing varies.<br/>Call for fee information: 512-420-0733<br/>3810 Medical Parkway Austin, TX 78756</p><p><a href=\\\\\\\"http://www.austinwoodrecycling.com/\\\\\\\">Austin Wood Recycling</a><br/>$5.00/per tree.<br/>For more information: 512-259-7430<br/>3875 E. Whitestone Blvd., Cedar Park, TX 78613</p><p><a href=\\\\\\\"http://www.goodguystreeservice.com/\\\\\\\">Good Guys Tree Service</a><br/>Prices vary.<br/>For more information: 512-743-3909<br/>11601 Anderson Mill Rd., Austin, TX 78750</p><h1>Do you live in a house? You can recycle your Christmas tree at the curb</h1><br/><ol><li><p>If you are a City of Austin curbside customer, and you would like to have your tree picked up and turned into mulch, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Cut the tree in half if it is longer than 6 feet.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Set your tree out on the curb by 6:30 am on your regular collection day.</p></li><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li></ol>\\\", \\\"id\\\": \\\"b748924c-4c94-4a4f-a3b2-3730684980f8\\\"}]\", \"topic\": 1, \"contacts\": []}",
-      "approved_go_live_at": null
-    }
-  },
-  {
-    "model": "wagtailcore.pagerevision",
-    "pk": 20,
-    "fields": {
-      "page": 4,
-      "submitted_for_moderation": false,
-      "created_at": "2018-01-02T21:21:54.628Z",
-      "user": [
-        "admin@austintexas.io"
-      ],
-      "content_json": "{\"pk\": 4, \"path\": \"000100010001\", \"depth\": 3, \"numchild\": 0, \"title\": \"Recycle your Christmas treeeeeeeeeeee\", \"draft_title\": \"Recycle your Christmas treeeeeeeeeeee\", \"slug\": \"holiday-tree-recycling\", \"content_type\": 12, \"live\": true, \"has_unpublished_changes\": false, \"url_path\": \"/home/holiday-tree-recycling/\", \"owner\": 1, \"seo_title\": \"\", \"show_in_menus\": false, \"search_description\": \"\", \"go_live_at\": null, \"expire_at\": null, \"expired\": false, \"locked\": false, \"first_published_at\": \"2017-12-06T17:09:43.276Z\", \"last_published_at\": \"2017-12-29T06:02:11.869Z\", \"latest_revision_created_at\": \"2017-12-29T06:02:11.715Z\", \"live_revision\": 19, \"created_at\": \"2017-12-06T17:09:43.155Z\", \"updated_at\": \"2018-01-02T21:21:54.627Z\", \"content\": \"<ol><li><p>All residents can drop-off their trees to be recycled into mulch. To drop your tree off at Zilker Park, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Drop your tree off between 10am and 2pm on one of the following days:</p></li><ol><li><p>Saturday, December 30, 2017</p></li><li><p>Sunday, December 31, 2017</p></li><li><p>Saturday, January 6, 2018</p></li><li><p>Sunday, January 7, 2018</p></li></ol><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li><li><p>Do you live in a house? Skip ahead and read about recycling your Christmas tree at the curb.</p></li></ol>\", \"content_en\": \"<ol><li><p>All residents can drop-off their trees to be recycled into mulch. To drop your tree off at Zilker Park, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Drop your tree off between 10am and 2pm on one of the following days:</p></li><ol><li><p>Saturday, December 30, 2017</p></li><li><p>Sunday, December 31, 2017</p></li><li><p>Saturday, January 6, 2018</p></li><li><p>Sunday, January 7, 2018</p></li></ol><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li><li><p>Do you live in a house? Skip ahead and read about recycling your Christmas tree at the curb.</p></li></ol>\", \"content_pt\": null, \"content_es\": \"\", \"content_fr\": null, \"extra_content\": \"[{\\\"type\\\": \\\"application_block\\\", \\\"value\\\": 3, \\\"id\\\": \\\"f3154cf7-22c1-4d88-89f9-ee3f834f6ec7\\\"}, {\\\"type\\\": \\\"content\\\", \\\"value\\\": \\\"<h2>Free Drop-Off Locations</h2><p>Trees will be accepted free of cost at the locations listed below. However, a contamination fee will be added to any trees with tags, decorations, and/or plastic remaining.</p><br/><p><a href=\\\\\\\"http://www.texasdisposal.com/contact/\\\\\\\">Texas Disposal Systems</a><br/>TDS Landfill: 3016 FM 1327, Creedmoor, Texas<br/>Eco Depot: 4001 RR 620 South, Bee Cave, Texas</p><p><a href=\\\\\\\"http://www.organicsbygosh.com/drop-off-collection/\\\\\\\">Organics By Gosh</a><br/>13602 FM 969, Austin, TX 78724\\\\u2028 | (512) 276-1211</p><p><a href=\\\\\\\"http://www.daisyworksdirt.com/\\\\\\\">Walker Aero Environmental (JV Dirt)</a><br/>3600 FM 973 North Austin, Texas 78725</p><p><a href=\\\\\\\"http://www.989rock.com/\\\\\\\">Whittlesey Landscape Supplies</a><br/>3219 S IH 35 Round Rock, Texas 78664<br/>629 Dalton Lane, Austin, Texas 78742</p><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Travis County Transfer Station</a><br/>2625 Woodall Dr. Leander, Texas 78641</p><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Travis County Service Center</a><br/>6013 Blue Bluff Rd Austin, Texas 78724</p><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Del Valle Softball Complex (Behind the Southwest Rural Center)</a><br/>3614 FM 973 Del Valle, Texas 78617</p><br/><h2>Drop-Off Locations with a Fee</h2><p>Locations listed below have varying fees. Call the location for more information. \\\\u00a0</p><p><a href=\\\\\\\"http://firewoodandmulchaustintx.com/\\\\\\\">Kinser Ranch LLC.</a><br/>Starts at $1.00/per tree to $20/per load.<br/>For more information: 512-748-0800<br/>10701 Kinser Lane, Austin, Texas 78736</p><p><a href=\\\\\\\"http://www.sidmourningtreeservice.com/\\\\\\\">Sid Mourning Tree Service</a><br/>Pricing varies.<br/>Call for fee information: 512-420-0733<br/>3810 Medical Parkway Austin, TX 78756</p><p><a href=\\\\\\\"http://www.austinwoodrecycling.com/\\\\\\\">Austin Wood Recycling</a><br/>$5.00/per tree.<br/>For more information: 512-259-7430<br/>3875 E. Whitestone Blvd., Cedar Park, TX 78613</p><p><a href=\\\\\\\"http://www.goodguystreeservice.com/\\\\\\\">Good Guys Tree Service</a><br/>Prices vary.<br/>For more information: 512-743-3909<br/>11601 Anderson Mill Rd., Austin, TX 78750</p><h1>Do you live in a house? You can recycle your Christmas tree at the curb</h1><br/><ol><li><p>If you are a City of Austin curbside customer, and you would like to have your tree picked up and turned into mulch, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Cut the tree in half if it is longer than 6 feet.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Set your tree out on the curb by 6:30 am on your regular collection day.</p></li><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li></ol>\\\", \\\"id\\\": \\\"b748924c-4c94-4a4f-a3b2-3730684980f8\\\"}]\", \"topic\": 1, \"contacts\": [{\"pk\": null, \"page\": 4, \"contact\": 2}]}",
-      "approved_go_live_at": null
-    }
-  },
-  {
-    "model": "wagtailcore.pagerevision",
-    "pk": 21,
-    "fields": {
-      "page": 5,
-      "submitted_for_moderation": false,
-      "created_at": "2018-01-04T23:46:30.064Z",
-      "user": [
-        "admin@austintexas.io"
-      ],
-      "content_json": "{\"pk\": 5, \"path\": \"000100010002\", \"depth\": 3, \"numchild\": 0, \"title\": \"Pick Up Free Household Items from the ReUse Store\", \"draft_title\": \"Pick Up Free Household Items from the ReUse Store\", \"slug\": \"dropoff\", \"content_type\": 12, \"live\": true, \"has_unpublished_changes\": false, \"url_path\": \"/home/dropoff/\", \"owner\": 1, \"seo_title\": \"\", \"show_in_menus\": false, \"search_description\": \"\", \"go_live_at\": null, \"expire_at\": null, \"expired\": false, \"locked\": false, \"first_published_at\": \"2017-12-06T21:02:34.309Z\", \"last_published_at\": \"2017-12-15T16:26:52.652Z\", \"latest_revision_created_at\": \"2017-12-15T16:26:52.483Z\", \"live_revision\": 13, \"created_at\": \"2017-12-06T21:02:34.149Z\", \"updated_at\": \"2018-01-04T23:46:30.061Z\", \"content\": \"<ol><li><p>Visit the ReUse Store in the Recycle &amp; Reuse Drop-Off Center at 2514 Business Center Dr, Austin, TX 78744.</p></li><li><p>Many materials that are dropped off at the Recycle &amp; Reuse Drop-Off Center are in usable condition. These items go to the ReUse Store. Pick up these items for free:</p></li><ol><li><p>House paint</p></li><li><p>Art supplies</p></li><li><p>Cleaning products</p></li><li><p>Household chemicals</p></li><li><p>Automotive fluids</p></li><li><p>Mulch</p></li></ol></ol>\", \"content_ar\": null, \"content_en\": \"<ol><li><p>Visit the ReUse Store in the Recycle &amp; Reuse Drop-Off Center at 2514 Business Center Dr, Austin, TX 78744.</p></li><li><p>Many materials that are dropped off at the Recycle &amp; Reuse Drop-Off Center are in usable condition. These items go to the ReUse Store. Pick up these items for free:</p></li><ol><li><p>House paint</p></li><li><p>Art supplies</p></li><li><p>Cleaning products</p></li><li><p>Household chemicals</p></li><li><p>Automotive fluids</p></li><li><p>Mulch</p></li></ol></ol>\", \"content_es\": \"<p>This is a spanish version<br/></p>\", \"content_ko\": null, \"content_my\": null, \"content_ur\": null, \"content_vi\": \"<p>This is a vietnamese version<br/></p>\", \"content_zh_hans\": null, \"content_zh_hant\": null, \"extra_content\": \"[{\\\"type\\\": \\\"application_block\\\", \\\"value\\\": 4, \\\"id\\\": \\\"003658b6-170d-4baf-9c61-848d26511e5f\\\"}, {\\\"type\\\": \\\"content\\\", \\\"value\\\": \\\"<h1>Learn About Austin ReBlend Paint</h1><p>Paint dropped off by customers is inspected before it is chosen to be used in Austin ReBlend. It is then consolidated, blended, filtered and packed by trained personnel to ensure a quality product.</p><p>Austin ReBlend paint is free for individuals and nonprofits, and can save residents money when refurbishing their homes. The paint is not available to businesses.</p><p>It is available in 3.5 gallon containers and three colors:</p><ul><li><p>Texas Limestone (beige)</p></li><li><p>Balcones Canyonland (dark beige)</p></li><li><p>Barton Creek Greenbelt (dark green)</p></li></ul><h1>Pick Up Free Mulch</h1><p>You can pick up mulch for free; however, you must load it yourself. Bring a pitchfork or shovel, work gloves and containers.</p>\\\", \\\"id\\\": \\\"fff2155d-fc2b-411d-8c3a-1dcef2fff99c\\\"}]\", \"topic\": 1, \"contacts\": [{\"pk\": 1, \"page\": 5, \"contact\": 1}]}",
-      "approved_go_live_at": null
-    }
-  },
-  {
-    "model": "wagtailcore.pagerevision",
-    "pk": 22,
-    "fields": {
-      "page": 5,
-      "submitted_for_moderation": false,
-      "created_at": "2018-01-04T23:46:35.052Z",
-      "user": [
-        "admin@austintexas.io"
-      ],
-      "content_json": "{\"pk\": 5, \"path\": \"000100010002\", \"depth\": 3, \"numchild\": 0, \"title\": \"Pick Up Free Household Items from the ReUse Store\", \"draft_title\": \"Pick Up Free Household Items from the ReUse Store\", \"slug\": \"dropoff\", \"content_type\": 12, \"live\": true, \"has_unpublished_changes\": true, \"url_path\": \"/home/dropoff/\", \"owner\": 1, \"seo_title\": \"\", \"show_in_menus\": false, \"search_description\": \"\", \"go_live_at\": null, \"expire_at\": null, \"expired\": false, \"locked\": false, \"first_published_at\": \"2017-12-06T21:02:34.309Z\", \"last_published_at\": \"2017-12-15T16:26:52.652Z\", \"latest_revision_created_at\": \"2018-01-04T23:46:30.064Z\", \"live_revision\": 13, \"created_at\": \"2017-12-06T21:02:34.149Z\", \"updated_at\": \"2018-01-04T23:46:35.050Z\", \"content\": \"<ol><li><p>Visit the ReUse Store in the Recycle &amp; Reuse Drop-Off Center at 2514 Business Center Dr, Austin, TX 78744.</p></li><li><p>Many materials that are dropped off at the Recycle &amp; Reuse Drop-Off Center are in usable condition. These items go to the ReUse Store. Pick up these items for free:</p></li><ol><li><p>House paint</p></li><li><p>Art supplies</p></li><li><p>Cleaning products</p></li><li><p>Household chemicals</p></li><li><p>Automotive fluids</p></li><li><p>Mulch</p></li></ol></ol>\", \"content_ar\": null, \"content_en\": \"<ol><li><p>Visit the ReUse Store in the Recycle &amp; Reuse Drop-Off Center at 2514 Business Center Dr, Austin, TX 78744.</p></li><li><p>Many materials that are dropped off at the Recycle &amp; Reuse Drop-Off Center are in usable condition. These items go to the ReUse Store. Pick up these items for free:</p></li><ol><li><p>House paint</p></li><li><p>Art supplies</p></li><li><p>Cleaning products</p></li><li><p>Household chemicals</p></li><li><p>Automotive fluids</p></li><li><p>Mulch</p></li></ol></ol>\", \"content_es\": \"<p>This is a spanish version<br/></p>\", \"content_ko\": null, \"content_my\": null, \"content_ur\": null, \"content_vi\": \"<p>This is a vietnamese version<br/></p>\", \"content_zh_hans\": null, \"content_zh_hant\": null, \"extra_content\": \"[{\\\"type\\\": \\\"application_block\\\", \\\"value\\\": 4, \\\"id\\\": \\\"003658b6-170d-4baf-9c61-848d26511e5f\\\"}, {\\\"type\\\": \\\"content\\\", \\\"value\\\": \\\"<h1>Learn About Austin ReBlend Paint</h1><p>Paint dropped off by customers is inspected before it is chosen to be used in Austin ReBlend. It is then consolidated, blended, filtered and packed by trained personnel to ensure a quality product.</p><p>Austin ReBlend paint is free for individuals and nonprofits, and can save residents money when refurbishing their homes. The paint is not available to businesses.</p><p>It is available in 3.5 gallon containers and three colors:</p><ul><li><p>Texas Limestone (beige)</p></li><li><p>Balcones Canyonland (dark beige)</p></li><li><p>Barton Creek Greenbelt (dark green)</p></li></ul><h1>Pick Up Free Mulch</h1><p>You can pick up mulch for free; however, you must load it yourself. Bring a pitchfork or shovel, work gloves and containers.</p>\\\", \\\"id\\\": \\\"fff2155d-fc2b-411d-8c3a-1dcef2fff99c\\\"}]\", \"topic\": 1, \"contacts\": [{\"pk\": 1, \"page\": null, \"contact\": 1}]}",
-      "approved_go_live_at": null
-    }
+{
+  "model": "base.homepage",
+  "pk": 3,
+  "fields": {}
+},
+{
+  "model": "base.servicepage",
+  "pk": 4,
+  "fields": {
+    "created_at": "2017-12-06T17:09:43.155Z",
+    "updated_at": "2018-01-02T21:21:54.922Z",
+    "content": "",
+    "content_ar": null,
+    "content_en": "<ol><li><p>All residents can drop-off their trees to be recycled into mulch. To drop your tree off at Zilker Park, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Drop your tree off between 10am and 2pm on one of the following days:</p></li><ol><li><p>Saturday, December 30, 2017</p></li><li><p>Sunday, December 31, 2017</p></li><li><p>Saturday, January 6, 2018</p></li><li><p>Sunday, January 7, 2018</p></li></ol><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li><li><p>Do you live in a house? Skip ahead and read about recycling your Christmas tree at the curb.</p></li></ol>",
+    "content_es": "",
+    "content_ko": null,
+    "content_my": null,
+    "content_ur": null,
+    "content_vi": null,
+    "content_zh_hans": null,
+    "content_zh_hant": null,
+    "extra_content": "[{\"type\": \"application_block\", \"value\": 3, \"id\": \"f3154cf7-22c1-4d88-89f9-ee3f834f6ec7\"}, {\"type\": \"content\", \"value\": \"<h2>Free Drop-Off Locations</h2><p>Trees will be accepted free of cost at the locations listed below. However, a contamination fee will be added to any trees with tags, decorations, and/or plastic remaining.</p><br/><p><a href=\\\"http://www.texasdisposal.com/contact/\\\">Texas Disposal Systems</a><br/>TDS Landfill: 3016 FM 1327, Creedmoor, Texas<br/>Eco Depot: 4001 RR 620 South, Bee Cave, Texas</p><p><a href=\\\"http://www.organicsbygosh.com/drop-off-collection/\\\">Organics By Gosh</a><br/>13602 FM 969, Austin, TX 78724\\u2028 | (512) 276-1211</p><p><a href=\\\"http://www.daisyworksdirt.com/\\\">Walker Aero Environmental (JV Dirt)</a><br/>3600 FM 973 North Austin, Texas 78725</p><p><a href=\\\"http://www.989rock.com/\\\">Whittlesey Landscape Supplies</a><br/>3219 S IH 35 Round Rock, Texas 78664<br/>629 Dalton Lane, Austin, Texas 78742</p><p><a href=\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\">Travis County Transfer Station</a><br/>2625 Woodall Dr. Leander, Texas 78641</p><p><a href=\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\">Travis County Service Center</a><br/>6013 Blue Bluff Rd Austin, Texas 78724</p><p><a href=\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\">Del Valle Softball Complex (Behind the Southwest Rural Center)</a><br/>3614 FM 973 Del Valle, Texas 78617</p><br/><h2>Drop-Off Locations with a Fee</h2><p>Locations listed below have varying fees. Call the location for more information. \\u00a0</p><p><a href=\\\"http://firewoodandmulchaustintx.com/\\\">Kinser Ranch LLC.</a><br/>Starts at $1.00/per tree to $20/per load.<br/>For more information: 512-748-0800<br/>10701 Kinser Lane, Austin, Texas 78736</p><p><a href=\\\"http://www.sidmourningtreeservice.com/\\\">Sid Mourning Tree Service</a><br/>Pricing varies.<br/>Call for fee information: 512-420-0733<br/>3810 Medical Parkway Austin, TX 78756</p><p><a href=\\\"http://www.austinwoodrecycling.com/\\\">Austin Wood Recycling</a><br/>$5.00/per tree.<br/>For more information: 512-259-7430<br/>3875 E. Whitestone Blvd., Cedar Park, TX 78613</p><p><a href=\\\"http://www.goodguystreeservice.com/\\\">Good Guys Tree Service</a><br/>Prices vary.<br/>For more information: 512-743-3909<br/>11601 Anderson Mill Rd., Austin, TX 78750</p><h1>Do you live in a house? You can recycle your Christmas tree at the curb</h1><br/><ol><li><p>If you are a City of Austin curbside customer, and you would like to have your tree picked up and turned into mulch, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Cut the tree in half if it is longer than 6 feet.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Set your tree out on the curb by 6:30 am on your regular collection day.</p></li><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li></ol>\", \"id\": \"b748924c-4c94-4a4f-a3b2-3730684980f8\"}]",
+    "topic": 1
   }
+},
+{
+  "model": "base.servicepage",
+  "pk": 5,
+  "fields": {
+    "created_at": "2017-12-06T21:02:34.149Z",
+    "updated_at": "2018-01-04T23:46:35.212Z",
+    "content": "",
+    "content_ar": null,
+    "content_en": "<ol><li><p>Visit the ReUse Store in the Recycle &amp; Reuse Drop-Off Center at 2514 Business Center Dr, Austin, TX 78744.</p></li><li><p>Many materials that are dropped off at the Recycle &amp; Reuse Drop-Off Center are in usable condition. These items go to the ReUse Store. Pick up these items for free:</p></li><ol><li><p>House paint</p></li><li><p>Art supplies</p></li><li><p>Cleaning products</p></li><li><p>Household chemicals</p></li><li><p>Automotive fluids</p></li><li><p>Mulch</p></li></ol></ol>",
+    "content_es": "<p>This is a spanish version<br/></p>",
+    "content_ko": null,
+    "content_my": null,
+    "content_ur": null,
+    "content_vi": "<p>This is a vietnamese version<br/></p>",
+    "content_zh_hans": null,
+    "content_zh_hant": null,
+    "extra_content": "[{\"type\": \"application_block\", \"value\": 4, \"id\": \"003658b6-170d-4baf-9c61-848d26511e5f\"}, {\"type\": \"content\", \"value\": \"<h1>Learn About Austin ReBlend Paint</h1><p>Paint dropped off by customers is inspected before it is chosen to be used in Austin ReBlend. It is then consolidated, blended, filtered and packed by trained personnel to ensure a quality product.</p><p>Austin ReBlend paint is free for individuals and nonprofits, and can save residents money when refurbishing their homes. The paint is not available to businesses.</p><p>It is available in 3.5 gallon containers and three colors:</p><ul><li><p>Texas Limestone (beige)</p></li><li><p>Balcones Canyonland (dark beige)</p></li><li><p>Barton Creek Greenbelt (dark green)</p></li></ul><h1>Pick Up Free Mulch</h1><p>You can pick up mulch for free; however, you must load it yourself. Bring a pitchfork or shovel, work gloves and containers.</p>\", \"id\": \"fff2155d-fc2b-411d-8c3a-1dcef2fff99c\"}]",
+    "topic": 1
+  }
+},
+{
+  "model": "base.servicepage",
+  "pk": 6,
+  "fields": {
+    "created_at": "2017-12-06T21:04:17.978Z",
+    "updated_at": "2017-12-13T22:40:28.196Z",
+    "content": "",
+    "content_ar": null,
+    "content_en": "<ol><li><p>Type your address, without apartment or unit number, in the box below.</p></li><li><p>Press the search button to view your curbside pickup schedule. </p></li><li><p>Use <a href=\"https://austintexas.gov/page/my-collection-schedule\">My Schedule</a> to get your personalized collection calendar.</p></li><li><p>(Optional) Click the icon to add your pickup days to your Google, iCal, or Microsoft calendar or print a copy of your schedule.</p></li></ol>",
+    "content_es": "",
+    "content_ko": null,
+    "content_my": null,
+    "content_ur": null,
+    "content_vi": null,
+    "content_zh_hans": null,
+    "content_zh_hant": null,
+    "extra_content": "[{\"type\": \"application_block\", \"value\": 1, \"id\": \"31dfdd2f-162c-4523-a4a5-ea6dced160f8\"}, {\"type\": \"content\", \"value\": \"<p>If your pickup day falls on Thanksgiving Day, Christmas Day or New Year's Day\\u2014or if it falls after the holiday in the same week\\u2014it slides to one day later. If the holiday falls on a Sunday, your pickup day will not slide.</p><br/>We will pick up your trash, compost, and yard trimmings every week. Every other week, we will pick up recycling, clothing, and housewares. All curbside pick-ups happen on the same day of the week unless it is a holiday. Use <a href=\\\"https://austintexas.gov/page/my-collection-schedule\\\">My Schedule</a> to get your personalized collection calendar.\", \"id\": \"975a8966-601c-4940-a306-4a53ff01b85b\"}]",
+    "topic": 1
+  }
+},
+{
+  "model": "base.servicepage",
+  "pk": 7,
+  "fields": {
+    "created_at": "2017-12-06T21:05:44.483Z",
+    "updated_at": "2017-12-13T22:07:17.819Z",
+    "content": "",
+    "content_ar": null,
+    "content_en": "<ol><li><p>Place appliances, furniture, carpet and other bulk items on your curb. Use the <a href=\"http://austintexas.gov/what-do-i-do\">\u201cWhat do I do with\u201d tool</a> to find out what you can bulk pick-up below. </p></li><li><p>Look up your twice-a-year bulk pick-up weeks with <a href=\"http://www.austintexas.gov/page/my-collection-schedule\">My Collection Schedule</a>. We only collect bulk items from Austin residential trash and recycling customers. </p></li><li><p>Place bulk items at the curb in front of your house by 6:30 a.m. on the first day of your scheduled collection week.</p></li><li><p>Separate items into three piles. </p></li><ol><li><p>Metal - includes appliances, doors must be removed</p></li><li><p>Passenger car tires - limit of eight tires per household, rims must be removed, no truck or tractor tires </p></li><li><p>Non-metal items - includes carpeting and nail-free lumber</p></li></ol></ol>",
+    "content_es": "",
+    "content_ko": null,
+    "content_my": null,
+    "content_ur": null,
+    "content_vi": null,
+    "content_zh_hans": null,
+    "content_zh_hant": null,
+    "extra_content": "[{\"type\": \"application_block\", \"value\": 2, \"id\": \"ac2d7108-e0ee-4887-b454-b0cdc4886b06\"}, {\"type\": \"application_block\", \"value\": 1, \"id\": \"cb0fc00e-5811-4117-b369-72d9222000ac\"}, {\"type\": \"content\", \"value\": \"<p>Do not put bulk items in bags, boxes or other containers. Bags will be treated as extra trash and are subject to extra trash fees.</p><br/><p>Items will not be picked up if they are in an alley in any area, including Hyde Park, in front of a vacant lot or in front of a business</p><br/><p>To prevent damage to your property, keep bulk items 5 feet away from your:</p><ol><ol><li><p>trash cart</p></li><li><p>Mailbox</p></li><li><p>fences or walls</p></li><li><p>water meter</p></li><li><p>telephone connection box</p></li><li><p>parked cars. </p></li></ol></ol><br/><p>Do not place any items under low hanging tree limbs or power lines.</p><br/><p>The three separate piles are collected by different trucks and may be collected at different times throughout the week.</p>\", \"id\": \"60dacf8d-e0c9-4248-9252-d3a438ba58a3\"}]",
+    "topic": 1
+  }
+},
+{
+  "model": "base.topic",
+  "pk": 1,
+  "fields": {
+    "text": "Manage recycling, compost, trash, energy, and water",
+    "description": "The City of Austin provides hundreds of services to residents to help them manage things like recycling, trash, energy, and water. This is a short list of services that will grow over time."
+  }
+},
+{
+  "model": "base.applicationblock",
+  "pk": 1,
+  "fields": {
+    "url": "http://www.austintexas.gov/page/my-collection-schedule",
+    "description": "Collection Schedule Lookup"
+  }
+},
+{
+  "model": "base.applicationblock",
+  "pk": 2,
+  "fields": {
+    "url": "http://austintexas.gov/what-do-i-do",
+    "description": "What do I do with..."
+  }
+},
+{
+  "model": "base.applicationblock",
+  "pk": 3,
+  "fields": {
+    "url": "http://www.austintexas.gov/sites/default/files/files/Resource_Recovery/ZilkerMap_ButtonArtwork.png",
+    "description": "Map for Christmas Tree Dropoff"
+  }
+},
+{
+  "model": "base.applicationblock",
+  "pk": 4,
+  "fields": {
+    "url": "https://www.google.com/maps/place/2514+Business+Center+Dr,+Austin,+TX+78744/@30.2131997,-97.739937,17z",
+    "description": "Map for Hazardous Waste Dropoff Center"
+  }
+},
+{
+  "model": "base.location",
+  "pk": 1,
+  "fields": {
+    "name": "Austin Recycle and Reuse Drop-off Center",
+    "street": "2514 Business Center Dr",
+    "city": "Austin",
+    "state": "TX",
+    "country": "United States",
+    "zip": "78744"
+  }
+},
+{
+  "model": "base.dayandduration",
+  "pk": 1,
+  "fields": {
+    "day_of_week": "Monday",
+    "start_time": "08:00:00",
+    "end_time": "16:00:00"
+  }
+},
+{
+  "model": "base.dayandduration",
+  "pk": 2,
+  "fields": {
+    "day_of_week": "Monday",
+    "start_time": "10:00:00",
+    "end_time": "18:00:00"
+  }
+},
+{
+  "model": "base.dayandduration",
+  "pk": 3,
+  "fields": {
+    "day_of_week": "Monday",
+    "start_time": "12:00:00",
+    "end_time": "15:00:00"
+  }
+},
+{
+  "model": "base.contact",
+  "pk": 1,
+  "fields": {
+    "name": "Francine Hammerschmidt",
+    "email": "fran@gmail.com",
+    "phone": "5553941212",
+    "location": 1
+  }
+},
+{
+  "model": "base.contact",
+  "pk": 2,
+  "fields": {
+    "name": "\ud83e\udd8f",
+    "email": "rhinos@austintexas.io",
+    "phone": "5551211212",
+    "location": 1
+  }
+},
+{
+  "model": "base.contactdayandduration",
+  "pk": 2,
+  "fields": {
+    "sort_order": 0,
+    "contact": 1
+  }
+},
+{
+  "model": "base.contactdayandduration",
+  "pk": 3,
+  "fields": {
+    "sort_order": 0,
+    "contact": 2
+  }
+},
+{
+  "model": "base.servicepagecontact",
+  "pk": 1,
+  "fields": {
+    "page": 5,
+    "contact": 1
+  }
+},
+{
+  "model": "base.servicepagecontact",
+  "pk": 3,
+  "fields": {
+    "page": 4,
+    "contact": 2
+  }
+},
+{
+  "model": "base.department",
+  "pk": 1,
+  "fields": {
+    "name": "Rhino Recovery Resources",
+    "mission": "We recover rhinos for the City of Austin. Got rhino problems? We're here to help."
+  }
+},
+{
+  "model": "base.departmentcontact",
+  "pk": 1,
+  "fields": {
+    "department": 1,
+    "contact": 2
+  }
+},
+{
+  "model": "wagtailcore.page",
+  "pk": 1,
+  "fields": {
+    "path": "0001",
+    "depth": 1,
+    "numchild": 1,
+    "title": "Root",
+    "draft_title": "Root",
+    "slug": "root",
+    "content_type": [
+      "wagtailcore",
+      "page"
+    ],
+    "live": true,
+    "has_unpublished_changes": false,
+    "url_path": "/",
+    "owner": null,
+    "seo_title": "",
+    "show_in_menus": false,
+    "search_description": "",
+    "go_live_at": null,
+    "expire_at": null,
+    "expired": false,
+    "locked": false,
+    "first_published_at": null,
+    "last_published_at": null,
+    "latest_revision_created_at": null,
+    "live_revision": null
+  }
+},
+{
+  "model": "wagtailcore.page",
+  "pk": 3,
+  "fields": {
+    "path": "00010001",
+    "depth": 2,
+    "numchild": 4,
+    "title": "Home",
+    "draft_title": "Home",
+    "slug": "home",
+    "content_type": [
+      "base",
+      "homepage"
+    ],
+    "live": true,
+    "has_unpublished_changes": false,
+    "url_path": "/home/",
+    "owner": null,
+    "seo_title": "",
+    "show_in_menus": false,
+    "search_description": "",
+    "go_live_at": null,
+    "expire_at": null,
+    "expired": false,
+    "locked": false,
+    "first_published_at": null,
+    "last_published_at": null,
+    "latest_revision_created_at": null,
+    "live_revision": null
+  }
+},
+{
+  "model": "wagtailcore.page",
+  "pk": 4,
+  "fields": {
+    "path": "000100010001",
+    "depth": 3,
+    "numchild": 0,
+    "title": "Recycle your Christmas tree",
+    "draft_title": "Recycle your Christmas tree",
+    "slug": "holiday-tree-recycling",
+    "content_type": [
+      "base",
+      "servicepage"
+    ],
+    "live": true,
+    "has_unpublished_changes": false,
+    "url_path": "/home/holiday-tree-recycling/",
+    "owner": [
+      "admin@austintexas.io"
+    ],
+    "seo_title": "",
+    "show_in_menus": false,
+    "search_description": "",
+    "go_live_at": null,
+    "expire_at": null,
+    "expired": false,
+    "locked": false,
+    "first_published_at": "2017-12-06T17:09:43.276Z",
+    "last_published_at": "2018-01-02T21:21:54.865Z",
+    "latest_revision_created_at": "2018-01-02T21:21:54.628Z",
+    "live_revision": 20
+  }
+},
+{
+  "model": "wagtailcore.page",
+  "pk": 5,
+  "fields": {
+    "path": "000100010002",
+    "depth": 3,
+    "numchild": 0,
+    "title": "Pick Up Free Household Items from the ReUse Store",
+    "draft_title": "Pick Up Free Household Items from the ReUse Store",
+    "slug": "dropoff",
+    "content_type": [
+      "base",
+      "servicepage"
+    ],
+    "live": true,
+    "has_unpublished_changes": false,
+    "url_path": "/home/dropoff/",
+    "owner": [
+      "admin@austintexas.io"
+    ],
+    "seo_title": "",
+    "show_in_menus": false,
+    "search_description": "",
+    "go_live_at": null,
+    "expire_at": null,
+    "expired": false,
+    "locked": false,
+    "first_published_at": "2017-12-06T21:02:34.309Z",
+    "last_published_at": "2018-01-04T23:46:35.175Z",
+    "latest_revision_created_at": "2018-01-04T23:46:35.052Z",
+    "live_revision": 22
+  }
+},
+{
+  "model": "wagtailcore.page",
+  "pk": 6,
+  "fields": {
+    "path": "000100010003",
+    "depth": 3,
+    "numchild": 0,
+    "title": "Look up your Trash, Recycling, and Compost Days",
+    "draft_title": "Look up your Trash, Recycling, and Compost Days",
+    "slug": "residential-curbside-collection-schedule",
+    "content_type": [
+      "base",
+      "servicepage"
+    ],
+    "live": true,
+    "has_unpublished_changes": false,
+    "url_path": "/home/residential-curbside-collection-schedule/",
+    "owner": [
+      "admin@austintexas.io"
+    ],
+    "seo_title": "",
+    "show_in_menus": false,
+    "search_description": "",
+    "go_live_at": null,
+    "expire_at": null,
+    "expired": false,
+    "locked": false,
+    "first_published_at": "2017-12-06T21:04:18.098Z",
+    "last_published_at": "2017-12-13T22:40:28.138Z",
+    "latest_revision_created_at": "2017-12-13T22:40:27.871Z",
+    "live_revision": 10
+  }
+},
+{
+  "model": "wagtailcore.page",
+  "pk": 7,
+  "fields": {
+    "path": "000100010004",
+    "depth": 3,
+    "numchild": 0,
+    "title": "Get Ready for Bulk Item Pick-up",
+    "draft_title": "Get Ready for Bulk Item Pick-up",
+    "slug": "residential-bulk-collection",
+    "content_type": [
+      "base",
+      "servicepage"
+    ],
+    "live": true,
+    "has_unpublished_changes": false,
+    "url_path": "/home/residential-bulk-collection/",
+    "owner": [
+      "admin@austintexas.io"
+    ],
+    "seo_title": "",
+    "show_in_menus": false,
+    "search_description": "",
+    "go_live_at": null,
+    "expire_at": null,
+    "expired": false,
+    "locked": false,
+    "first_published_at": "2017-12-06T21:05:44.625Z",
+    "last_published_at": "2017-12-13T22:07:17.788Z",
+    "latest_revision_created_at": "2017-12-13T22:07:17.667Z",
+    "live_revision": 8
+  }
+},
+{
+  "model": "wagtailcore.pagerevision",
+  "pk": 1,
+  "fields": {
+    "page": 4,
+    "submitted_for_moderation": false,
+    "created_at": "2017-12-06T17:09:43.202Z",
+    "user": [
+      "admin@austintexas.io"
+    ],
+    "content_json": "{\"pk\": 4, \"path\": \"000100010001\", \"depth\": 3, \"numchild\": 0, \"title\": \"Recycle your Christmas tree\", \"draft_title\": \"Recycle your Christmas tree\", \"slug\": \"holiday-tree-recycling\", \"content_type\": 12, \"live\": true, \"has_unpublished_changes\": false, \"url_path\": \"/home/holiday-tree-recycling/\", \"owner\": 1, \"seo_title\": \"\", \"show_in_menus\": false, \"search_description\": \"\", \"go_live_at\": null, \"expire_at\": null, \"expired\": false, \"locked\": false, \"first_published_at\": null, \"last_published_at\": null, \"latest_revision_created_at\": null, \"live_revision\": null, \"created_at\": \"2017-12-06T17:09:43.155Z\", \"updated_at\": \"2017-12-06T17:09:43.200Z\", \"content\": \"<ol><li><p>All residents can drop-off their trees to be recycled into mulch. To drop your tree off at Zilker Park, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Drop your tree off between 10am and 2pm on one of the following days:</p></li><ol><li><p>Saturday, December 30, 2017</p></li><li><p>Sunday, December 31, 2017</p></li><li><p>Saturday, January 6, 2018</p></li><li><p>Sunday, January 7, 2018</p></li></ol><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li></ol><br/><ol><li><p>If you are a City of Austin curbside customer, and you would like to have your tree picked up and turned into mulch, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Cut the tree in half if it is longer than 6 feet.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Set your tree out on the curb by 6:30 am on your regular collection day.</p></li><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li></ol>\", \"extra_content\": \"[{\\\"type\\\": \\\"application_block\\\", \\\"value\\\": 3, \\\"id\\\": \\\"f3154cf7-22c1-4d88-89f9-ee3f834f6ec7\\\"}, {\\\"type\\\": \\\"content\\\", \\\"value\\\": \\\"<h2>Free Drop-Off Locations</h2><p>Trees will be accepted free of cost at the locations listed below. However, a contamination fee will be added to any trees with tags, decorations, and/or plastic remaining.</p><br/><p><a href=\\\\\\\"http://www.texasdisposal.com/contact/\\\\\\\">Texas Disposal Systems</a></p><ul><li><p>TDS Landfill: 3016 FM 1327, Creedmoor, Texas</p></li><li><p>Eco Depot: 4001 RR 620 South, Bee Cave, Texas</p></li></ul><p><a href=\\\\\\\"http://www.organicsbygosh.com/drop-off-collection/\\\\\\\">Organics By Gosh</a></p><ul><li><p>13602 FM 969, Austin, TX 78724\\\\u2028 | (512) 276-1211</p></li></ul><p><a href=\\\\\\\"http://www.daisyworksdirt.com/\\\\\\\">Walker Aero Environmental (JV Dirt) </a></p><ul><li><p>3600 FM 973 North Austin, Texas 78725</p></li></ul><p><a href=\\\\\\\"http://www.989rock.com/\\\\\\\">Whittlesey Landscape Supplies</a></p><ul><li><p>3219 S IH 35 Round Rock, Texas 78664</p></li><li><p>629 Dalton Lane, Austin, Texas 78742</p></li></ul><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Travis County Transfer Station</a></p><ul><li><p>2625 Woodall Dr. Leander, Texas 78641</p></li></ul><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Travis County Service Center</a></p><ul><li><p>6013 Blue Bluff Rd Austin, Texas 78724</p></li></ul><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Del Valle Softball Complex (Behind the Southwest Rural Center)</a></p><ul><li><p>3614 FM 973 Del Valle, Texas 78617</p></li></ul><br/><h2>Drop-Off Locations with a Fee</h2><p>Locations listed below have varying fees. Call the location for more information. \\\\u00a0</p><p><a href=\\\\\\\"http://firewoodandmulchaustintx.com/\\\\\\\">Kinser Ranch LLC.</a></p><p>Starts at $1.00/per tree to $20/per load.</p><p>For more information: 512-748-0800</p><p>10701 Kinser Lane, Austin, Texas 78736</p><p><a href=\\\\\\\"http://www.sidmourningtreeservice.com/\\\\\\\">Sid Mourning Tree Service</a></p><p>Pricing varies. </p><p>Call for fee information: 512-420-0733</p><p>3810 Medical Parkway Austin, TX 78756</p><p><a href=\\\\\\\"http://www.austinwoodrecycling.com/\\\\\\\">Austin Wood Recycling</a></p><p>$5.00/per tree.</p><p>For more information: 512-259-7430</p><p>3875 E. Whitestone Blvd., Cedar Park, TX 78613</p><p><a href=\\\\\\\"http://www.goodguystreeservice.com/\\\\\\\">Good Guys Tree Service</a></p><p>Prices vary.</p><p>For more information: 512-743-3909</p><p>11601 Anderson Mill Rd., Austin, TX 78750</p>\\\", \\\"id\\\": \\\"b748924c-4c94-4a4f-a3b2-3730684980f8\\\"}]\", \"topic\": 1}",
+    "approved_go_live_at": null
+  }
+},
+{
+  "model": "wagtailcore.pagerevision",
+  "pk": 2,
+  "fields": {
+    "page": 5,
+    "submitted_for_moderation": false,
+    "created_at": "2017-12-06T21:02:34.221Z",
+    "user": [
+      "admin@austintexas.io"
+    ],
+    "content_json": "{\"pk\": 5, \"path\": \"000100010002\", \"depth\": 3, \"numchild\": 0, \"title\": \"Visit the Recycle and Reuse Drop-off Center\", \"draft_title\": \"Visit the Recycle and Reuse Drop-off Center\", \"slug\": \"dropoff\", \"content_type\": 12, \"live\": true, \"has_unpublished_changes\": false, \"url_path\": \"/home/dropoff/\", \"owner\": 1, \"seo_title\": \"\", \"show_in_menus\": false, \"search_description\": \"\", \"go_live_at\": null, \"expire_at\": null, \"expired\": false, \"locked\": false, \"first_published_at\": null, \"last_published_at\": null, \"latest_revision_created_at\": null, \"live_revision\": null, \"created_at\": \"2017-12-06T21:02:34.149Z\", \"updated_at\": \"2017-12-06T21:02:34.220Z\", \"content\": \"<ol><li><p>Check below to find out what hazardous waste items are accepted. Some items are free to drop off and some items, like tires, require a fee.</p></li><li><p>Drop off your household hazardous waste or visit the ReUse Store at 2514 Business Center Dr, Austin, TX 78744.</p></li><li><p>Be sure to bring products in original containers; do not mix, bring items in 5-gallon (or smaller) containers and put small containers upright in sturdy boxes.</p></li><li><p>If something is leaking, put it in a container and absorb the spill with cat litter.</p></li></ol>\", \"extra_content\": \"[{\\\"type\\\": \\\"application_block\\\", \\\"value\\\": 2, \\\"id\\\": \\\"2d3602e3-251a-49ef-9493-132c945fde38\\\"}, {\\\"type\\\": \\\"application_block\\\", \\\"value\\\": 4, \\\"id\\\": \\\"003658b6-170d-4baf-9c61-848d26511e5f\\\"}, {\\\"type\\\": \\\"content\\\", \\\"value\\\": \\\"<h2>Household Hazardous Waste</h2><p>Throwing household hazardous waste in the trash or pouring it down the drain is dangerous and harmful to the environment. Austin and Travis County residents can drop off hazardous waste for free, up to 30 gallons annually. Large truck or trailer loads will not be accepted after 4:45PM.</p><br/><p>Businesses are not eligible to drop off hazardous waste. For information about how businesses can dispose of hazardous waste, call 512-974-4336.</p><h2>ReUse Store</h2><p>Many materials that are dropped off at the center are in usable condition. These items go to the ReUse Store, where everyone can pick them up for free. Store items often include: </p><ul><li><p>Art supplies</p></li><li><p>Cleaning products</p></li><li><p>Household chemicals</p></li><li><p>Automotive fluids</p></li><li><p><a href=\\\\\\\"http://www.austintexas.gov/department/austin-reblend\\\\\\\">Austin ReBlend paint</a> (link to austintexas.gov page)</p></li><li><p>Mulch</p></li></ul><br/><p>Austin ReBlend paint is free for individuals and nonprofits. It is not available to businesses.</p><p>Mulch is free for everyone, but you must load it yourself. Bring a pitchfork or shovel, work gloves and containers. </p>\\\", \\\"id\\\": \\\"fff2155d-fc2b-411d-8c3a-1dcef2fff99c\\\"}]\", \"topic\": 1}",
+    "approved_go_live_at": null
+  }
+},
+{
+  "model": "wagtailcore.pagerevision",
+  "pk": 3,
+  "fields": {
+    "page": 6,
+    "submitted_for_moderation": false,
+    "created_at": "2017-12-06T21:04:18.025Z",
+    "user": [
+      "admin@austintexas.io"
+    ],
+    "content_json": "{\"pk\": 6, \"path\": \"000100010003\", \"depth\": 3, \"numchild\": 0, \"title\": \"Look up your Trash, Recycling, and Compost Days\", \"draft_title\": \"Look up your Trash, Recycling, and Compost Days\", \"slug\": \"residential-curbside-collection-schedule\", \"content_type\": 12, \"live\": true, \"has_unpublished_changes\": false, \"url_path\": \"/home/residential-curbside-collection-schedule/\", \"owner\": 1, \"seo_title\": \"\", \"show_in_menus\": false, \"search_description\": \"\", \"go_live_at\": null, \"expire_at\": null, \"expired\": false, \"locked\": false, \"first_published_at\": null, \"last_published_at\": null, \"latest_revision_created_at\": null, \"live_revision\": null, \"created_at\": \"2017-12-06T21:04:17.978Z\", \"updated_at\": \"2017-12-06T21:04:18.024Z\", \"content\": \"<ol><li>Type your address, without apartment or unit number, in the box below.</li><li>Press the search button to view your pickup schedule.</li><li>(Optional) Click the icon to add your pickup days to your Google, iCal, or Microsoft calendar or print a copy of your schedule.</li></ol>\", \"extra_content\": \"[{\\\"type\\\": \\\"application_block\\\", \\\"value\\\": 1, \\\"id\\\": \\\"31dfdd2f-162c-4523-a4a5-ea6dced160f8\\\"}, {\\\"type\\\": \\\"content\\\", \\\"value\\\": \\\"<p>If your pickup day falls on Thanksgiving Day, Christmas Day or New Year's Day\\\\u2014or if it falls after the holiday in the same week\\\\u2014it slides to one day later. If the holiday falls on a Sunday, your pickup day will not slide.</p><br/>We will pick up your trash, compost, and yard trimmings every week. Every other week, we will pick up recycling, clothing, and housewares. All curbside pick-ups happen on the same day of the week unless it is a holiday. Use <a href=\\\\\\\"https://austintexas.gov/page/my-collection-schedule\\\\\\\">My Schedule</a> to get your personalized collection calendar.\\\", \\\"id\\\": \\\"975a8966-601c-4940-a306-4a53ff01b85b\\\"}]\", \"topic\": 1}",
+    "approved_go_live_at": null
+  }
+},
+{
+  "model": "wagtailcore.pagerevision",
+  "pk": 4,
+  "fields": {
+    "page": 7,
+    "submitted_for_moderation": false,
+    "created_at": "2017-12-06T21:05:44.529Z",
+    "user": [
+      "admin@austintexas.io"
+    ],
+    "content_json": "{\"pk\": 7, \"path\": \"000100010004\", \"depth\": 3, \"numchild\": 0, \"title\": \"Get Ready for Bulk Item Pick-up\", \"draft_title\": \"Get Ready for Bulk Item Pick-up\", \"slug\": \"residential-bulk-collection\", \"content_type\": 12, \"live\": true, \"has_unpublished_changes\": false, \"url_path\": \"/home/residential-bulk-collection/\", \"owner\": 1, \"seo_title\": \"\", \"show_in_menus\": false, \"search_description\": \"\", \"go_live_at\": null, \"expire_at\": null, \"expired\": false, \"locked\": false, \"first_published_at\": null, \"last_published_at\": null, \"latest_revision_created_at\": null, \"live_revision\": null, \"created_at\": \"2017-12-06T21:05:44.483Z\", \"updated_at\": \"2017-12-06T21:05:44.527Z\", \"content\": \"<ol><li><p>Check what items are accepted for bulk pick-up below. </p></li><li><p>Look up your twice-a-year bulk pick-up weeks below. We only collect bulk items from residential trash and recycling customers. </p></li><li><p>Place bulk items at the curb in front of your house by 6:30 a.m. on the first day of your scheduled collection week</p></li><li><p>Separate items into three piles. </p></li><ol><li><p>Metal - includes appliances, doors must be removed</p></li><li><p>Passenger car tires - limit of eight tires per household, rims must be removed, no truck or tractor tires </p></li><li><p>Non-metal items - includes carpeting and nail-free lumber</p></li></ol></ol>\", \"extra_content\": \"[{\\\"type\\\": \\\"application_block\\\", \\\"value\\\": 2, \\\"id\\\": \\\"ac2d7108-e0ee-4887-b454-b0cdc4886b06\\\"}, {\\\"type\\\": \\\"application_block\\\", \\\"value\\\": 1, \\\"id\\\": \\\"cb0fc00e-5811-4117-b369-72d9222000ac\\\"}, {\\\"type\\\": \\\"content\\\", \\\"value\\\": \\\"<p>Do not put bulk items in bags, boxes or other containers. Bags will be treated as extra trash and are subject to extra trash fees.</p><br/><p>Items will not be picked up if they are in an alley in any area, including Hyde Park, in front of a vacant lot or in front of a business</p><br/><p>To prevent damage to your property, keep bulk items 5 feet away from your:</p><ol><ol><li><p>trash cart</p></li><li><p>Mailbox</p></li><li><p>fences or walls</p></li><li><p>water meter</p></li><li><p>telephone connection box</p></li><li><p>parked cars. </p></li></ol></ol><br/><p>Do not place any items under low hanging tree limbs or power lines.</p><br/><p>The three separate piles are collected by different trucks and may be collected at different times throughout the week.</p>\\\", \\\"id\\\": \\\"60dacf8d-e0c9-4248-9252-d3a438ba58a3\\\"}]\", \"topic\": 1}",
+    "approved_go_live_at": null
+  }
+},
+{
+  "model": "wagtailcore.pagerevision",
+  "pk": 5,
+  "fields": {
+    "page": 5,
+    "submitted_for_moderation": false,
+    "created_at": "2017-12-13T22:00:09.263Z",
+    "user": [
+      "admin@austintexas.io"
+    ],
+    "content_json": "{\"pk\": 5, \"path\": \"000100010002\", \"depth\": 3, \"numchild\": 0, \"title\": \"Pick Up Free Household Items from the ReUse Store\", \"draft_title\": \"Visit the Recycle and Reuse Drop-off Center\", \"slug\": \"dropoff\", \"content_type\": 12, \"live\": true, \"has_unpublished_changes\": false, \"url_path\": \"/home/dropoff/\", \"owner\": 1, \"seo_title\": \"\", \"show_in_menus\": false, \"search_description\": \"\", \"go_live_at\": null, \"expire_at\": null, \"expired\": false, \"locked\": false, \"first_published_at\": \"2017-12-06T21:02:34.309Z\", \"last_published_at\": \"2017-12-06T21:02:34.309Z\", \"latest_revision_created_at\": \"2017-12-06T21:02:34.221Z\", \"live_revision\": 2, \"created_at\": \"2017-12-06T21:02:34.149Z\", \"updated_at\": \"2017-12-13T22:00:09.262Z\", \"content\": \"<ol><li><p>Visit the ReUse Store in the Recycle &amp; Reuse Drop-Off Center at 2514 Business Center Dr, Austin, TX 78744.</p></li><li><p>Many materials that are dropped off at the Recycle &amp; Reuse Drop-Off Center are in usable condition. These items go to the ReUse Store. Pick up these items for free:</p></li><ol><li><p>House paint</p></li><li><p>Art supplies</p></li><li><p>Cleaning products</p></li><li><p>Household chemicals</p></li><li><p>Automotive fluids</p></li><li><p>Mulch</p></li></ol></ol>\", \"content_en\": \"<ol><li><p>Visit the ReUse Store in the Recycle &amp; Reuse Drop-Off Center at 2514 Business Center Dr, Austin, TX 78744.</p></li><li><p>Many materials that are dropped off at the Recycle &amp; Reuse Drop-Off Center are in usable condition. These items go to the ReUse Store. Pick up these items for free:</p></li><ol><li><p>House paint</p></li><li><p>Art supplies</p></li><li><p>Cleaning products</p></li><li><p>Household chemicals</p></li><li><p>Automotive fluids</p></li><li><p>Mulch</p></li></ol></ol>\", \"content_pt\": null, \"content_es\": \"\", \"content_fr\": null, \"extra_content\": \"[{\\\"type\\\": \\\"application_block\\\", \\\"value\\\": 4, \\\"id\\\": \\\"003658b6-170d-4baf-9c61-848d26511e5f\\\"}, {\\\"type\\\": \\\"content\\\", \\\"value\\\": \\\"<h1>Learn About Austin ReBlend Paint</h1><p>Paint dropped off by customers is inspected before it is chosen to be used in Austin ReBlend. It is then consolidated, blended, filtered and packed by trained personnel to ensure a quality product.</p><br/><p>Austin ReBlend paint is free for individuals and nonprofits, and can save residents money when refurbishing their homes. The paint is not available to businesses.</p><br/><p>It is available in 3.5 gallon containers and three colors:</p><ul><li><p>Texas Limestone (beige)</p></li><li><p>Balcones Canyonland (dark beige)</p></li><li><p>Barton Creek Greenbelt (dark green)</p></li></ul><h1>Pick Up Free Mulch</h1><p>You can pick up mulch for free; however, you must load it yourself. Bring a pitchfork or shovel, work gloves and containers.</p><br/><p>Notes from Laura: transferred content to wagtail 12/13/17</p>\\\", \\\"id\\\": \\\"fff2155d-fc2b-411d-8c3a-1dcef2fff99c\\\"}]\", \"topic\": 1, \"locations\": [], \"contacts\": []}",
+    "approved_go_live_at": null
+  }
+},
+{
+  "model": "wagtailcore.pagerevision",
+  "pk": 6,
+  "fields": {
+    "page": 4,
+    "submitted_for_moderation": false,
+    "created_at": "2017-12-13T22:02:14.706Z",
+    "user": [
+      "admin@austintexas.io"
+    ],
+    "content_json": "{\"pk\": 4, \"path\": \"000100010001\", \"depth\": 3, \"numchild\": 0, \"title\": \"Recycle your Christmas tree\", \"draft_title\": \"Recycle your Christmas tree\", \"slug\": \"holiday-tree-recycling\", \"content_type\": 12, \"live\": true, \"has_unpublished_changes\": false, \"url_path\": \"/home/holiday-tree-recycling/\", \"owner\": 1, \"seo_title\": \"\", \"show_in_menus\": false, \"search_description\": \"\", \"go_live_at\": null, \"expire_at\": null, \"expired\": false, \"locked\": false, \"first_published_at\": \"2017-12-06T17:09:43.276Z\", \"last_published_at\": \"2017-12-06T17:09:43.276Z\", \"latest_revision_created_at\": \"2017-12-06T17:09:43.202Z\", \"live_revision\": 1, \"created_at\": \"2017-12-06T17:09:43.155Z\", \"updated_at\": \"2017-12-13T22:02:14.704Z\", \"content\": \"<ol><li><p>All residents can drop-off their trees to be recycled into mulch. To drop your tree off at Zilker Park, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Drop your tree off between 10am and 2pm on one of the following days:</p></li><ol><li><p>Saturday, December 30, 2017</p></li><li><p>Sunday, December 31, 2017</p></li><li><p>Saturday, January 6, 2018</p></li><li><p>Sunday, January 7, 2018</p></li></ol><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li><li><p>Do you live in a house? Skip ahead and read about recycling your Christmas tree at the curb.</p></li></ol>\", \"content_en\": \"<ol><li><p>All residents can drop-off their trees to be recycled into mulch. To drop your tree off at Zilker Park, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Drop your tree off between 10am and 2pm on one of the following days:</p></li><ol><li><p>Saturday, December 30, 2017</p></li><li><p>Sunday, December 31, 2017</p></li><li><p>Saturday, January 6, 2018</p></li><li><p>Sunday, January 7, 2018</p></li></ol><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li><li><p>Do you live in a house? Skip ahead and read about recycling your Christmas tree at the curb.</p></li></ol>\", \"content_pt\": null, \"content_es\": \"\", \"content_fr\": null, \"extra_content\": \"[{\\\"type\\\": \\\"application_block\\\", \\\"value\\\": 3, \\\"id\\\": \\\"f3154cf7-22c1-4d88-89f9-ee3f834f6ec7\\\"}, {\\\"type\\\": \\\"content\\\", \\\"value\\\": \\\"<h2>Free Drop-Off Locations</h2><p>Trees will be accepted free of cost at the locations listed below. However, a contamination fee will be added to any trees with tags, decorations, and/or plastic remaining.</p><br/><p><a href=\\\\\\\"http://www.texasdisposal.com/contact/\\\\\\\">Texas Disposal Systems</a></p><ul><li><p>TDS Landfill: 3016 FM 1327, Creedmoor, Texas</p></li><li><p>Eco Depot: 4001 RR 620 South, Bee Cave, Texas</p></li></ul><p><a href=\\\\\\\"http://www.organicsbygosh.com/drop-off-collection/\\\\\\\">Organics By Gosh</a></p><ul><li><p>13602 FM 969, Austin, TX 78724\\\\u2028 | (512) 276-1211</p></li></ul><p><a href=\\\\\\\"http://www.daisyworksdirt.com/\\\\\\\">Walker Aero Environmental (JV Dirt) </a></p><ul><li><p>3600 FM 973 North Austin, Texas 78725</p></li></ul><p><a href=\\\\\\\"http://www.989rock.com/\\\\\\\">Whittlesey Landscape Supplies</a></p><ul><li><p>3219 S IH 35 Round Rock, Texas 78664</p></li><li><p>629 Dalton Lane, Austin, Texas 78742</p></li></ul><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Travis County Transfer Station</a></p><ul><li><p>2625 Woodall Dr. Leander, Texas 78641</p></li></ul><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Travis County Service Center</a></p><ul><li><p>6013 Blue Bluff Rd Austin, Texas 78724</p></li></ul><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Del Valle Softball Complex (Behind the Southwest Rural Center)</a></p><ul><li><p>3614 FM 973 Del Valle, Texas 78617</p></li></ul><br/><h2>Drop-Off Locations with a Fee</h2><p>Locations listed below have varying fees. Call the location for more information. \\\\u00a0</p><p><a href=\\\\\\\"http://firewoodandmulchaustintx.com/\\\\\\\">Kinser Ranch LLC.</a></p><p>Starts at $1.00/per tree to $20/per load.</p><p>For more information: 512-748-0800</p><p>10701 Kinser Lane, Austin, Texas 78736</p><p><a href=\\\\\\\"http://www.sidmourningtreeservice.com/\\\\\\\">Sid Mourning Tree Service</a></p><p>Pricing varies. </p><p>Call for fee information: 512-420-0733</p><p>3810 Medical Parkway Austin, TX 78756</p><p><a href=\\\\\\\"http://www.austinwoodrecycling.com/\\\\\\\">Austin Wood Recycling</a></p><p>$5.00/per tree.</p><p>For more information: 512-259-7430</p><p>3875 E. Whitestone Blvd., Cedar Park, TX 78613</p><p><a href=\\\\\\\"http://www.goodguystreeservice.com/\\\\\\\">Good Guys Tree Service</a></p><p>Prices vary.</p><p>For more information: 512-743-3909</p><p>11601 Anderson Mill Rd., Austin, TX 78750</p><h1>Do you live in a house? You can recycle your Christmas tree at the curb</h1><br/><ol><li><p>If you are a City of Austin curbside customer, and you would like to have your tree picked up and turned into mulch, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Cut the tree in half if it is longer than 6 feet.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Set your tree out on the curb by 6:30 am on your regular collection day.</p></li><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li></ol>\\\", \\\"id\\\": \\\"b748924c-4c94-4a4f-a3b2-3730684980f8\\\"}]\", \"topic\": 1, \"locations\": [], \"contacts\": []}",
+    "approved_go_live_at": null
+  }
+},
+{
+  "model": "wagtailcore.pagerevision",
+  "pk": 7,
+  "fields": {
+    "page": 4,
+    "submitted_for_moderation": false,
+    "created_at": "2017-12-13T22:04:09.245Z",
+    "user": [
+      "admin@austintexas.io"
+    ],
+    "content_json": "{\"pk\": 4, \"path\": \"000100010001\", \"depth\": 3, \"numchild\": 0, \"title\": \"Recycle your Christmas tree\", \"draft_title\": \"Recycle your Christmas tree\", \"slug\": \"holiday-tree-recycling\", \"content_type\": 12, \"live\": true, \"has_unpublished_changes\": false, \"url_path\": \"/home/holiday-tree-recycling/\", \"owner\": 1, \"seo_title\": \"\", \"show_in_menus\": false, \"search_description\": \"\", \"go_live_at\": null, \"expire_at\": null, \"expired\": false, \"locked\": false, \"first_published_at\": \"2017-12-06T17:09:43.276Z\", \"last_published_at\": \"2017-12-13T22:02:14.801Z\", \"latest_revision_created_at\": \"2017-12-13T22:02:14.706Z\", \"live_revision\": 6, \"created_at\": \"2017-12-06T17:09:43.155Z\", \"updated_at\": \"2017-12-13T22:04:09.243Z\", \"content\": \"<ol><li><p>All residents can drop-off their trees to be recycled into mulch. To drop your tree off at Zilker Park, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Drop your tree off between 10am and 2pm on one of the following days:</p></li><ol><li><p>Saturday, December 30, 2017</p></li><li><p>Sunday, December 31, 2017</p></li><li><p>Saturday, January 6, 2018</p></li><li><p>Sunday, January 7, 2018</p></li></ol><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li><li><p>Do you live in a house? Skip ahead and read about recycling your Christmas tree at the curb.</p></li></ol>\", \"content_en\": \"<ol><li><p>All residents can drop-off their trees to be recycled into mulch. To drop your tree off at Zilker Park, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Drop your tree off between 10am and 2pm on one of the following days:</p></li><ol><li><p>Saturday, December 30, 2017</p></li><li><p>Sunday, December 31, 2017</p></li><li><p>Saturday, January 6, 2018</p></li><li><p>Sunday, January 7, 2018</p></li></ol><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li><li><p>Do you live in a house? Skip ahead and read about recycling your Christmas tree at the curb.</p></li></ol>\", \"content_pt\": null, \"content_es\": \"\", \"content_fr\": null, \"extra_content\": \"[{\\\"type\\\": \\\"application_block\\\", \\\"value\\\": 3, \\\"id\\\": \\\"f3154cf7-22c1-4d88-89f9-ee3f834f6ec7\\\"}, {\\\"type\\\": \\\"content\\\", \\\"value\\\": \\\"<h2>Free Drop-Off Locations</h2><p>Trees will be accepted free of cost at the locations listed below. However, a contamination fee will be added to any trees with tags, decorations, and/or plastic remaining.</p><br/><p><a href=\\\\\\\"http://www.texasdisposal.com/contact/\\\\\\\">Texas Disposal Systems</a></p><ul><li><p>TDS Landfill: 3016 FM 1327, Creedmoor, Texas</p></li><li><p>Eco Depot: 4001 RR 620 South, Bee Cave, Texas</p></li></ul><p><a href=\\\\\\\"http://www.organicsbygosh.com/drop-off-collection/\\\\\\\">Organics By Gosh</a></p><ul><li><p>13602 FM 969, Austin, TX 78724\\\\u2028 | (512) 276-1211</p></li></ul><p><a href=\\\\\\\"http://www.daisyworksdirt.com/\\\\\\\">Walker Aero Environmental (JV Dirt) </a></p><ul><li><p>3600 FM 973 North Austin, Texas 78725</p></li></ul><p><a href=\\\\\\\"http://www.989rock.com/\\\\\\\">Whittlesey Landscape Supplies</a></p><ul><li><p>3219 S IH 35 Round Rock, Texas 78664</p></li><li><p>629 Dalton Lane, Austin, Texas 78742</p></li></ul><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Travis County Transfer Station</a></p><ul><li><p>2625 Woodall Dr. Leander, Texas 78641</p></li></ul><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Travis County Service Center</a></p><ul><li><p>6013 Blue Bluff Rd Austin, Texas 78724</p></li></ul><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Del Valle Softball Complex (Behind the Southwest Rural Center)</a></p><ul><li><p>3614 FM 973 Del Valle, Texas 78617</p></li></ul><br/><h2>Drop-Off Locations with a Fee</h2><p>Locations listed below have varying fees. Call the location for more information. \\\\u00a0</p><p><a href=\\\\\\\"http://firewoodandmulchaustintx.com/\\\\\\\">Kinser Ranch LLC.</a></p><p>Starts at $1.00/per tree to $20/per load.</p><p>For more information: 512-748-0800</p><p>10701 Kinser Lane, Austin, Texas 78736</p><p><a href=\\\\\\\"http://www.sidmourningtreeservice.com/\\\\\\\">Sid Mourning Tree Service</a></p><p>Pricing varies. </p><p>Call for fee information: 512-420-0733</p><p>3810 Medical Parkway Austin, TX 78756</p><p><a href=\\\\\\\"http://www.austinwoodrecycling.com/\\\\\\\">Austin Wood Recycling</a></p><p>$5.00/per tree.</p><p>For more information: 512-259-7430</p><p>3875 E. Whitestone Blvd., Cedar Park, TX 78613</p><p><a href=\\\\\\\"http://www.goodguystreeservice.com/\\\\\\\">Good Guys Tree Service</a></p><p>Prices vary.</p><p>For more information: 512-743-3909</p><p>11601 Anderson Mill Rd., Austin, TX 78750</p><h1>Do you live in a house? You can recycle your Christmas tree at the curb</h1><br/><ol><li><p>If you are a City of Austin curbside customer, and you would like to have your tree picked up and turned into mulch, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Cut the tree in half if it is longer than 6 feet.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Set your tree out on the curb by 6:30 am on your regular collection day.</p></li><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li></ol>\\\", \\\"id\\\": \\\"b748924c-4c94-4a4f-a3b2-3730684980f8\\\"}]\", \"topic\": 1, \"locations\": [], \"contacts\": []}",
+    "approved_go_live_at": null
+  }
+},
+{
+  "model": "wagtailcore.pagerevision",
+  "pk": 8,
+  "fields": {
+    "page": 7,
+    "submitted_for_moderation": false,
+    "created_at": "2017-12-13T22:07:17.667Z",
+    "user": [
+      "admin@austintexas.io"
+    ],
+    "content_json": "{\"pk\": 7, \"path\": \"000100010004\", \"depth\": 3, \"numchild\": 0, \"title\": \"Get Ready for Bulk Item Pick-up\", \"draft_title\": \"Get Ready for Bulk Item Pick-up\", \"slug\": \"residential-bulk-collection\", \"content_type\": 12, \"live\": true, \"has_unpublished_changes\": false, \"url_path\": \"/home/residential-bulk-collection/\", \"owner\": 1, \"seo_title\": \"\", \"show_in_menus\": false, \"search_description\": \"\", \"go_live_at\": null, \"expire_at\": null, \"expired\": false, \"locked\": false, \"first_published_at\": \"2017-12-06T21:05:44.625Z\", \"last_published_at\": \"2017-12-06T21:05:44.625Z\", \"latest_revision_created_at\": \"2017-12-06T21:05:44.529Z\", \"live_revision\": 4, \"created_at\": \"2017-12-06T21:05:44.483Z\", \"updated_at\": \"2017-12-13T22:07:17.666Z\", \"content\": \"<ol><li><p>Place appliances, furniture, carpet and other bulk items on your curb. Use the <a href=\\\"http://austintexas.gov/what-do-i-do\\\">\\u201cWhat do I do with\\u201d tool</a> to find out what you can bulk pick-up below. </p></li><li><p>Look up your twice-a-year bulk pick-up weeks with <a href=\\\"http://www.austintexas.gov/page/my-collection-schedule\\\">My Collection Schedule</a>. We only collect bulk items from Austin residential trash and recycling customers. </p></li><li><p>Place bulk items at the curb in front of your house by 6:30 a.m. on the first day of your scheduled collection week.</p></li><li><p>Separate items into three piles. </p></li><ol><li><p>Metal - includes appliances, doors must be removed</p></li><li><p>Passenger car tires - limit of eight tires per household, rims must be removed, no truck or tractor tires </p></li><li><p>Non-metal items - includes carpeting and nail-free lumber</p></li></ol></ol>\", \"content_en\": \"<ol><li><p>Place appliances, furniture, carpet and other bulk items on your curb. Use the <a href=\\\"http://austintexas.gov/what-do-i-do\\\">\\u201cWhat do I do with\\u201d tool</a> to find out what you can bulk pick-up below. </p></li><li><p>Look up your twice-a-year bulk pick-up weeks with <a href=\\\"http://www.austintexas.gov/page/my-collection-schedule\\\">My Collection Schedule</a>. We only collect bulk items from Austin residential trash and recycling customers. </p></li><li><p>Place bulk items at the curb in front of your house by 6:30 a.m. on the first day of your scheduled collection week.</p></li><li><p>Separate items into three piles. </p></li><ol><li><p>Metal - includes appliances, doors must be removed</p></li><li><p>Passenger car tires - limit of eight tires per household, rims must be removed, no truck or tractor tires </p></li><li><p>Non-metal items - includes carpeting and nail-free lumber</p></li></ol></ol>\", \"content_pt\": null, \"content_es\": \"\", \"content_fr\": null, \"extra_content\": \"[{\\\"type\\\": \\\"application_block\\\", \\\"value\\\": 2, \\\"id\\\": \\\"ac2d7108-e0ee-4887-b454-b0cdc4886b06\\\"}, {\\\"type\\\": \\\"application_block\\\", \\\"value\\\": 1, \\\"id\\\": \\\"cb0fc00e-5811-4117-b369-72d9222000ac\\\"}, {\\\"type\\\": \\\"content\\\", \\\"value\\\": \\\"<p>Do not put bulk items in bags, boxes or other containers. Bags will be treated as extra trash and are subject to extra trash fees.</p><br/><p>Items will not be picked up if they are in an alley in any area, including Hyde Park, in front of a vacant lot or in front of a business</p><br/><p>To prevent damage to your property, keep bulk items 5 feet away from your:</p><ol><ol><li><p>trash cart</p></li><li><p>Mailbox</p></li><li><p>fences or walls</p></li><li><p>water meter</p></li><li><p>telephone connection box</p></li><li><p>parked cars. </p></li></ol></ol><br/><p>Do not place any items under low hanging tree limbs or power lines.</p><br/><p>The three separate piles are collected by different trucks and may be collected at different times throughout the week.</p>\\\", \\\"id\\\": \\\"60dacf8d-e0c9-4248-9252-d3a438ba58a3\\\"}]\", \"topic\": 1, \"locations\": [], \"contacts\": []}",
+    "approved_go_live_at": null
+  }
+},
+{
+  "model": "wagtailcore.pagerevision",
+  "pk": 9,
+  "fields": {
+    "page": 5,
+    "submitted_for_moderation": false,
+    "created_at": "2017-12-13T22:36:06.288Z",
+    "user": [
+      "admin@austintexas.io"
+    ],
+    "content_json": "{\"pk\": 5, \"path\": \"000100010002\", \"depth\": 3, \"numchild\": 0, \"title\": \"Pick Up Free Household Items from the ReUse Store\", \"draft_title\": \"Pick Up Free Household Items from the ReUse Store\", \"slug\": \"dropoff\", \"content_type\": 12, \"live\": true, \"has_unpublished_changes\": false, \"url_path\": \"/home/dropoff/\", \"owner\": 1, \"seo_title\": \"\", \"show_in_menus\": false, \"search_description\": \"\", \"go_live_at\": null, \"expire_at\": null, \"expired\": false, \"locked\": false, \"first_published_at\": \"2017-12-06T21:02:34.309Z\", \"last_published_at\": \"2017-12-13T22:00:09.375Z\", \"latest_revision_created_at\": \"2017-12-13T22:00:09.263Z\", \"live_revision\": 5, \"created_at\": \"2017-12-06T21:02:34.149Z\", \"updated_at\": \"2017-12-13T22:36:06.287Z\", \"content\": \"<ol><li><p>Visit the ReUse Store in the Recycle &amp; Reuse Drop-Off Center at 2514 Business Center Dr, Austin, TX 78744.</p></li><li><p>Many materials that are dropped off at the Recycle &amp; Reuse Drop-Off Center are in usable condition. These items go to the ReUse Store. Pick up these items for free:</p></li><ol><li><p>House paint</p></li><li><p>Art supplies</p></li><li><p>Cleaning products</p></li><li><p>Household chemicals</p></li><li><p>Automotive fluids</p></li><li><p>Mulch</p></li></ol></ol>\", \"content_en\": \"<ol><li><p>Visit the ReUse Store in the Recycle &amp; Reuse Drop-Off Center at 2514 Business Center Dr, Austin, TX 78744.</p></li><li><p>Many materials that are dropped off at the Recycle &amp; Reuse Drop-Off Center are in usable condition. These items go to the ReUse Store. Pick up these items for free:</p></li><ol><li><p>House paint</p></li><li><p>Art supplies</p></li><li><p>Cleaning products</p></li><li><p>Household chemicals</p></li><li><p>Automotive fluids</p></li><li><p>Mulch</p></li></ol></ol>\", \"content_pt\": null, \"content_es\": \"\", \"content_fr\": null, \"extra_content\": \"[{\\\"type\\\": \\\"application_block\\\", \\\"value\\\": 4, \\\"id\\\": \\\"003658b6-170d-4baf-9c61-848d26511e5f\\\"}, {\\\"type\\\": \\\"content\\\", \\\"value\\\": \\\"<h1>Learn About Austin ReBlend Paint</h1><p>Paint dropped off by customers is inspected before it is chosen to be used in Austin ReBlend. It is then consolidated, blended, filtered and packed by trained personnel to ensure a quality product.</p><br/><p>Austin ReBlend paint is free for individuals and nonprofits, and can save residents money when refurbishing their homes. The paint is not available to businesses.</p><br/><p>It is available in 3.5 gallon containers and three colors:</p><ul><li><p>Texas Limestone (beige)</p></li><li><p>Balcones Canyonland (dark beige)</p></li><li><p>Barton Creek Greenbelt (dark green)</p></li></ul><h1>Pick Up Free Mulch</h1><p>You can pick up mulch for free; however, you must load it yourself. Bring a pitchfork or shovel, work gloves and containers.</p>\\\", \\\"id\\\": \\\"fff2155d-fc2b-411d-8c3a-1dcef2fff99c\\\"}]\", \"topic\": 1, \"locations\": [], \"contacts\": []}",
+    "approved_go_live_at": null
+  }
+},
+{
+  "model": "wagtailcore.pagerevision",
+  "pk": 10,
+  "fields": {
+    "page": 6,
+    "submitted_for_moderation": false,
+    "created_at": "2017-12-13T22:40:27.871Z",
+    "user": [
+      "admin@austintexas.io"
+    ],
+    "content_json": "{\"pk\": 6, \"path\": \"000100010003\", \"depth\": 3, \"numchild\": 0, \"title\": \"Look up your Trash, Recycling, and Compost Days\", \"draft_title\": \"Look up your Trash, Recycling, and Compost Days\", \"slug\": \"residential-curbside-collection-schedule\", \"content_type\": 12, \"live\": true, \"has_unpublished_changes\": false, \"url_path\": \"/home/residential-curbside-collection-schedule/\", \"owner\": 1, \"seo_title\": \"\", \"show_in_menus\": false, \"search_description\": \"\", \"go_live_at\": null, \"expire_at\": null, \"expired\": false, \"locked\": false, \"first_published_at\": \"2017-12-06T21:04:18.098Z\", \"last_published_at\": \"2017-12-06T21:04:18.098Z\", \"latest_revision_created_at\": \"2017-12-06T21:04:18.025Z\", \"live_revision\": 3, \"created_at\": \"2017-12-06T21:04:17.978Z\", \"updated_at\": \"2017-12-13T22:40:27.866Z\", \"content\": \"<ol><li><p>Type your address, without apartment or unit number, in the box below.</p></li><li><p>Press the search button to view your curbside pickup schedule. </p></li><li><p>Use <a href=\\\"https://austintexas.gov/page/my-collection-schedule\\\">My Schedule</a> to get your personalized collection calendar.</p></li><li><p>(Optional) Click the icon to add your pickup days to your Google, iCal, or Microsoft calendar or print a copy of your schedule.</p></li></ol>\", \"content_en\": \"<ol><li><p>Type your address, without apartment or unit number, in the box below.</p></li><li><p>Press the search button to view your curbside pickup schedule. </p></li><li><p>Use <a href=\\\"https://austintexas.gov/page/my-collection-schedule\\\">My Schedule</a> to get your personalized collection calendar.</p></li><li><p>(Optional) Click the icon to add your pickup days to your Google, iCal, or Microsoft calendar or print a copy of your schedule.</p></li></ol>\", \"content_pt\": null, \"content_es\": \"\", \"content_fr\": null, \"extra_content\": \"[{\\\"type\\\": \\\"application_block\\\", \\\"value\\\": 1, \\\"id\\\": \\\"31dfdd2f-162c-4523-a4a5-ea6dced160f8\\\"}, {\\\"type\\\": \\\"content\\\", \\\"value\\\": \\\"<p>If your pickup day falls on Thanksgiving Day, Christmas Day or New Year's Day\\\\u2014or if it falls after the holiday in the same week\\\\u2014it slides to one day later. If the holiday falls on a Sunday, your pickup day will not slide.</p><br/>We will pick up your trash, compost, and yard trimmings every week. Every other week, we will pick up recycling, clothing, and housewares. All curbside pick-ups happen on the same day of the week unless it is a holiday. Use <a href=\\\\\\\"https://austintexas.gov/page/my-collection-schedule\\\\\\\">My Schedule</a> to get your personalized collection calendar.\\\", \\\"id\\\": \\\"975a8966-601c-4940-a306-4a53ff01b85b\\\"}]\", \"topic\": 1, \"locations\": [], \"contacts\": []}",
+    "approved_go_live_at": null
+  }
+},
+{
+  "model": "wagtailcore.pagerevision",
+  "pk": 11,
+  "fields": {
+    "page": 4,
+    "submitted_for_moderation": false,
+    "created_at": "2017-12-13T22:43:34.605Z",
+    "user": [
+      "admin@austintexas.io"
+    ],
+    "content_json": "{\"pk\": 4, \"path\": \"000100010001\", \"depth\": 3, \"numchild\": 0, \"title\": \"Recycle your Christmas tree\", \"draft_title\": \"Recycle your Christmas tree\", \"slug\": \"holiday-tree-recycling\", \"content_type\": 12, \"live\": true, \"has_unpublished_changes\": false, \"url_path\": \"/home/holiday-tree-recycling/\", \"owner\": 1, \"seo_title\": \"\", \"show_in_menus\": false, \"search_description\": \"\", \"go_live_at\": null, \"expire_at\": null, \"expired\": false, \"locked\": false, \"first_published_at\": \"2017-12-06T17:09:43.276Z\", \"last_published_at\": \"2017-12-13T22:04:09.364Z\", \"latest_revision_created_at\": \"2017-12-13T22:04:09.245Z\", \"live_revision\": 7, \"created_at\": \"2017-12-06T17:09:43.155Z\", \"updated_at\": \"2017-12-13T22:43:34.603Z\", \"content\": \"<ol><li><p>All residents can drop-off their trees to be recycled into mulch. To drop your tree off at Zilker Park, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Drop your tree off between 10am and 2pm on one of the following days:</p></li><ol><li><p>Saturday, December 30, 2017</p></li><li><p>Sunday, December 31, 2017</p></li><li><p>Saturday, January 6, 2018</p></li><li><p>Sunday, January 7, 2018</p></li></ol><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li><li><p>Do you live in a house? Skip ahead and read about recycling your Christmas tree at the curb.</p></li></ol>\", \"content_en\": \"<ol><li><p>All residents can drop-off their trees to be recycled into mulch. To drop your tree off at Zilker Park, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Drop your tree off between 10am and 2pm on one of the following days:</p></li><ol><li><p>Saturday, December 30, 2017</p></li><li><p>Sunday, December 31, 2017</p></li><li><p>Saturday, January 6, 2018</p></li><li><p>Sunday, January 7, 2018</p></li></ol><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li><li><p>Do you live in a house? Skip ahead and read about recycling your Christmas tree at the curb.</p></li></ol>\", \"content_pt\": null, \"content_es\": \"\", \"content_fr\": null, \"extra_content\": \"[{\\\"type\\\": \\\"application_block\\\", \\\"value\\\": 3, \\\"id\\\": \\\"f3154cf7-22c1-4d88-89f9-ee3f834f6ec7\\\"}, {\\\"type\\\": \\\"content\\\", \\\"value\\\": \\\"<h2>Free Drop-Off Locations</h2><p>Trees will be accepted free of cost at the locations listed below. However, a contamination fee will be added to any trees with tags, decorations, and/or plastic remaining.</p><br/><p><a href=\\\\\\\"http://www.texasdisposal.com/contact/\\\\\\\">Texas Disposal Systems</a><br/>TDS Landfill: 3016 FM 1327, Creedmoor, Texas<br/>Eco Depot: 4001 RR 620 South, Bee Cave, Texas</p><p><a href=\\\\\\\"http://www.organicsbygosh.com/drop-off-collection/\\\\\\\">Organics By Gosh</a><br/>13602 FM 969, Austin, TX 78724\\\\u2028 | (512) 276-1211</p><p><a href=\\\\\\\"http://www.daisyworksdirt.com/\\\\\\\">Walker Aero Environmental (JV Dirt)</a><br/>3600 FM 973 North Austin, Texas 78725</p><p><a href=\\\\\\\"http://www.989rock.com/\\\\\\\">Whittlesey Landscape Supplies</a><br/>3219 S IH 35 Round Rock, Texas 78664<br/>629 Dalton Lane, Austin, Texas 78742</p><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Travis County Transfer Station</a><br/>2625 Woodall Dr. Leander, Texas 78641</p><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Travis County Service Center</a><br/>6013 Blue Bluff Rd Austin, Texas 78724</p><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Del Valle Softball Complex (Behind the Southwest Rural Center)</a><br/>3614 FM 973 Del Valle, Texas 78617</p><br/><h2>Drop-Off Locations with a Fee</h2><p>Locations listed below have varying fees. Call the location for more information. \\\\u00a0</p><p><a href=\\\\\\\"http://firewoodandmulchaustintx.com/\\\\\\\">Kinser Ranch LLC.</a><br/>Starts at $1.00/per tree to $20/per load.<br/>For more information: 512-748-0800<br/>10701 Kinser Lane, Austin, Texas 78736</p><p><a href=\\\\\\\"http://www.sidmourningtreeservice.com/\\\\\\\">Sid Mourning Tree Service</a><br/>Pricing varies.<br/>Call for fee information: 512-420-0733<br/>3810 Medical Parkway Austin, TX 78756</p><p><a href=\\\\\\\"http://www.austinwoodrecycling.com/\\\\\\\">Austin Wood Recycling</a><br/>$5.00/per tree.<br/>For more information: 512-259-7430<br/>3875 E. Whitestone Blvd., Cedar Park, TX 78613</p><p><a href=\\\\\\\"http://www.goodguystreeservice.com/\\\\\\\">Good Guys Tree Service</a><br/>Prices vary.<br/>For more information: 512-743-3909<br/>11601 Anderson Mill Rd., Austin, TX 78750</p><h1>Do you live in a house? You can recycle your Christmas tree at the curb</h1><br/><ol><li><p>If you are a City of Austin curbside customer, and you would like to have your tree picked up and turned into mulch, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Cut the tree in half if it is longer than 6 feet.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Set your tree out on the curb by 6:30 am on your regular collection day.</p></li><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li></ol>\\\", \\\"id\\\": \\\"b748924c-4c94-4a4f-a3b2-3730684980f8\\\"}]\", \"topic\": 1, \"locations\": [], \"contacts\": []}",
+    "approved_go_live_at": null
+  }
+},
+{
+  "model": "wagtailcore.pagerevision",
+  "pk": 12,
+  "fields": {
+    "page": 5,
+    "submitted_for_moderation": false,
+    "created_at": "2017-12-13T22:44:02.325Z",
+    "user": [
+      "admin@austintexas.io"
+    ],
+    "content_json": "{\"pk\": 5, \"path\": \"000100010002\", \"depth\": 3, \"numchild\": 0, \"title\": \"Pick Up Free Household Items from the ReUse Store\", \"draft_title\": \"Pick Up Free Household Items from the ReUse Store\", \"slug\": \"dropoff\", \"content_type\": 12, \"live\": true, \"has_unpublished_changes\": false, \"url_path\": \"/home/dropoff/\", \"owner\": 1, \"seo_title\": \"\", \"show_in_menus\": false, \"search_description\": \"\", \"go_live_at\": null, \"expire_at\": null, \"expired\": false, \"locked\": false, \"first_published_at\": \"2017-12-06T21:02:34.309Z\", \"last_published_at\": \"2017-12-13T22:36:06.399Z\", \"latest_revision_created_at\": \"2017-12-13T22:36:06.288Z\", \"live_revision\": 9, \"created_at\": \"2017-12-06T21:02:34.149Z\", \"updated_at\": \"2017-12-13T22:44:02.323Z\", \"content\": \"<ol><li><p>Visit the ReUse Store in the Recycle &amp; Reuse Drop-Off Center at 2514 Business Center Dr, Austin, TX 78744.</p></li><li><p>Many materials that are dropped off at the Recycle &amp; Reuse Drop-Off Center are in usable condition. These items go to the ReUse Store. Pick up these items for free:</p></li><ol><li><p>House paint</p></li><li><p>Art supplies</p></li><li><p>Cleaning products</p></li><li><p>Household chemicals</p></li><li><p>Automotive fluids</p></li><li><p>Mulch</p></li></ol></ol>\", \"content_en\": \"<ol><li><p>Visit the ReUse Store in the Recycle &amp; Reuse Drop-Off Center at 2514 Business Center Dr, Austin, TX 78744.</p></li><li><p>Many materials that are dropped off at the Recycle &amp; Reuse Drop-Off Center are in usable condition. These items go to the ReUse Store. Pick up these items for free:</p></li><ol><li><p>House paint</p></li><li><p>Art supplies</p></li><li><p>Cleaning products</p></li><li><p>Household chemicals</p></li><li><p>Automotive fluids</p></li><li><p>Mulch</p></li></ol></ol>\", \"content_pt\": null, \"content_es\": \"\", \"content_fr\": null, \"extra_content\": \"[{\\\"type\\\": \\\"application_block\\\", \\\"value\\\": 4, \\\"id\\\": \\\"003658b6-170d-4baf-9c61-848d26511e5f\\\"}, {\\\"type\\\": \\\"content\\\", \\\"value\\\": \\\"<h1>Learn About Austin ReBlend Paint</h1><p>Paint dropped off by customers is inspected before it is chosen to be used in Austin ReBlend. It is then consolidated, blended, filtered and packed by trained personnel to ensure a quality product.</p><p>Austin ReBlend paint is free for individuals and nonprofits, and can save residents money when refurbishing their homes. The paint is not available to businesses.</p><p>It is available in 3.5 gallon containers and three colors:</p><ul><li><p>Texas Limestone (beige)</p></li><li><p>Balcones Canyonland (dark beige)</p></li><li><p>Barton Creek Greenbelt (dark green)</p></li></ul><h1>Pick Up Free Mulch</h1><p>You can pick up mulch for free; however, you must load it yourself. Bring a pitchfork or shovel, work gloves and containers.</p>\\\", \\\"id\\\": \\\"fff2155d-fc2b-411d-8c3a-1dcef2fff99c\\\"}]\", \"topic\": 1, \"locations\": [], \"contacts\": []}",
+    "approved_go_live_at": null
+  }
+},
+{
+  "model": "wagtailcore.pagerevision",
+  "pk": 13,
+  "fields": {
+    "page": 5,
+    "submitted_for_moderation": false,
+    "created_at": "2017-12-15T16:26:52.483Z",
+    "user": [
+      "admin@austintexas.io"
+    ],
+    "content_json": "{\"pk\": 5, \"path\": \"000100010002\", \"depth\": 3, \"numchild\": 0, \"title\": \"Pick Up Free Household Items from the ReUse Store\", \"draft_title\": \"Pick Up Free Household Items from the ReUse Store\", \"slug\": \"dropoff\", \"content_type\": 12, \"live\": true, \"has_unpublished_changes\": false, \"url_path\": \"/home/dropoff/\", \"owner\": 1, \"seo_title\": \"\", \"show_in_menus\": false, \"search_description\": \"\", \"go_live_at\": null, \"expire_at\": null, \"expired\": false, \"locked\": false, \"first_published_at\": \"2017-12-06T21:02:34.309Z\", \"last_published_at\": \"2017-12-13T22:44:02.435Z\", \"latest_revision_created_at\": \"2017-12-13T22:44:02.325Z\", \"live_revision\": 12, \"created_at\": \"2017-12-06T21:02:34.149Z\", \"updated_at\": \"2017-12-15T16:26:52.481Z\", \"content\": \"<ol><li><p>Visit the ReUse Store in the Recycle &amp; Reuse Drop-Off Center at 2514 Business Center Dr, Austin, TX 78744.</p></li><li><p>Many materials that are dropped off at the Recycle &amp; Reuse Drop-Off Center are in usable condition. These items go to the ReUse Store. Pick up these items for free:</p></li><ol><li><p>House paint</p></li><li><p>Art supplies</p></li><li><p>Cleaning products</p></li><li><p>Household chemicals</p></li><li><p>Automotive fluids</p></li><li><p>Mulch</p></li></ol></ol>\", \"content_en\": \"<ol><li><p>Visit the ReUse Store in the Recycle &amp; Reuse Drop-Off Center at 2514 Business Center Dr, Austin, TX 78744.</p></li><li><p>Many materials that are dropped off at the Recycle &amp; Reuse Drop-Off Center are in usable condition. These items go to the ReUse Store. Pick up these items for free:</p></li><ol><li><p>House paint</p></li><li><p>Art supplies</p></li><li><p>Cleaning products</p></li><li><p>Household chemicals</p></li><li><p>Automotive fluids</p></li><li><p>Mulch</p></li></ol></ol>\", \"content_pt\": null, \"content_es\": \"\", \"content_fr\": null, \"extra_content\": \"[{\\\"type\\\": \\\"application_block\\\", \\\"value\\\": 4, \\\"id\\\": \\\"003658b6-170d-4baf-9c61-848d26511e5f\\\"}, {\\\"type\\\": \\\"content\\\", \\\"value\\\": \\\"<h1>Learn About Austin ReBlend Paint</h1><p>Paint dropped off by customers is inspected before it is chosen to be used in Austin ReBlend. It is then consolidated, blended, filtered and packed by trained personnel to ensure a quality product.</p><p>Austin ReBlend paint is free for individuals and nonprofits, and can save residents money when refurbishing their homes. The paint is not available to businesses.</p><p>It is available in 3.5 gallon containers and three colors:</p><ul><li><p>Texas Limestone (beige)</p></li><li><p>Balcones Canyonland (dark beige)</p></li><li><p>Barton Creek Greenbelt (dark green)</p></li></ul><h1>Pick Up Free Mulch</h1><p>You can pick up mulch for free; however, you must load it yourself. Bring a pitchfork or shovel, work gloves and containers.</p>\\\", \\\"id\\\": \\\"fff2155d-fc2b-411d-8c3a-1dcef2fff99c\\\"}]\", \"topic\": 1, \"locations\": [{\"pk\": null, \"page\": 5, \"location\": 1}], \"contacts\": [{\"pk\": null, \"page\": 5, \"contact\": 1}]}",
+    "approved_go_live_at": null
+  }
+},
+{
+  "model": "wagtailcore.pagerevision",
+  "pk": 14,
+  "fields": {
+    "page": 4,
+    "submitted_for_moderation": false,
+    "created_at": "2017-12-29T04:42:20.565Z",
+    "user": [
+      "admin@austintexas.io"
+    ],
+    "content_json": "{\"pk\": 4, \"path\": \"000100010001\", \"depth\": 3, \"numchild\": 0, \"title\": \"Recycle your Christmas tree\", \"draft_title\": \"Recycle your Christmas tree\", \"slug\": \"holiday-tree-recycling\", \"content_type\": 12, \"live\": true, \"has_unpublished_changes\": false, \"url_path\": \"/home/holiday-tree-recycling/\", \"owner\": 1, \"seo_title\": \"\", \"show_in_menus\": false, \"search_description\": \"\", \"go_live_at\": null, \"expire_at\": null, \"expired\": false, \"locked\": false, \"first_published_at\": \"2017-12-06T17:09:43.276Z\", \"last_published_at\": \"2017-12-13T22:43:34.715Z\", \"latest_revision_created_at\": \"2017-12-13T22:43:34.605Z\", \"live_revision\": 11, \"created_at\": \"2017-12-06T17:09:43.155Z\", \"updated_at\": \"2017-12-29T04:42:20.559Z\", \"content\": \"<ol><li><p>All residents can drop-off their trees to be recycled into mulch. To drop your tree off at Zilker Park, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Drop your tree off between 10am and 2pm on one of the following days:</p></li><ol><li><p>Saturday, December 30, 2017</p></li><li><p>Sunday, December 31, 2017</p></li><li><p>Saturday, January 6, 2018</p></li><li><p>Sunday, January 7, 2018</p></li></ol><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li><li><p>Do you live in a house? Skip ahead and read about recycling your Christmas tree at the curb.</p></li></ol>\", \"content_en\": \"<ol><li><p>All residents can drop-off their trees to be recycled into mulch. To drop your tree off at Zilker Park, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Drop your tree off between 10am and 2pm on one of the following days:</p></li><ol><li><p>Saturday, December 30, 2017</p></li><li><p>Sunday, December 31, 2017</p></li><li><p>Saturday, January 6, 2018</p></li><li><p>Sunday, January 7, 2018</p></li></ol><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li><li><p>Do you live in a house? Skip ahead and read about recycling your Christmas tree at the curb.</p></li></ol>\", \"content_pt\": null, \"content_es\": \"\", \"content_fr\": null, \"extra_content\": \"[{\\\"type\\\": \\\"application_block\\\", \\\"value\\\": 3, \\\"id\\\": \\\"f3154cf7-22c1-4d88-89f9-ee3f834f6ec7\\\"}, {\\\"type\\\": \\\"content\\\", \\\"value\\\": \\\"<h2>Free Drop-Off Locations</h2><p>Trees will be accepted free of cost at the locations listed below. However, a contamination fee will be added to any trees with tags, decorations, and/or plastic remaining.</p><br/><p><a href=\\\\\\\"http://www.texasdisposal.com/contact/\\\\\\\">Texas Disposal Systems</a><br/>TDS Landfill: 3016 FM 1327, Creedmoor, Texas<br/>Eco Depot: 4001 RR 620 South, Bee Cave, Texas</p><p><a href=\\\\\\\"http://www.organicsbygosh.com/drop-off-collection/\\\\\\\">Organics By Gosh</a><br/>13602 FM 969, Austin, TX 78724\\\\u2028 | (512) 276-1211</p><p><a href=\\\\\\\"http://www.daisyworksdirt.com/\\\\\\\">Walker Aero Environmental (JV Dirt)</a><br/>3600 FM 973 North Austin, Texas 78725</p><p><a href=\\\\\\\"http://www.989rock.com/\\\\\\\">Whittlesey Landscape Supplies</a><br/>3219 S IH 35 Round Rock, Texas 78664<br/>629 Dalton Lane, Austin, Texas 78742</p><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Travis County Transfer Station</a><br/>2625 Woodall Dr. Leander, Texas 78641</p><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Travis County Service Center</a><br/>6013 Blue Bluff Rd Austin, Texas 78724</p><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Del Valle Softball Complex (Behind the Southwest Rural Center)</a><br/>3614 FM 973 Del Valle, Texas 78617</p><br/><h2>Drop-Off Locations with a Fee</h2><p>Locations listed below have varying fees. Call the location for more information. \\\\u00a0</p><p><a href=\\\\\\\"http://firewoodandmulchaustintx.com/\\\\\\\">Kinser Ranch LLC.</a><br/>Starts at $1.00/per tree to $20/per load.<br/>For more information: 512-748-0800<br/>10701 Kinser Lane, Austin, Texas 78736</p><p><a href=\\\\\\\"http://www.sidmourningtreeservice.com/\\\\\\\">Sid Mourning Tree Service</a><br/>Pricing varies.<br/>Call for fee information: 512-420-0733<br/>3810 Medical Parkway Austin, TX 78756</p><p><a href=\\\\\\\"http://www.austinwoodrecycling.com/\\\\\\\">Austin Wood Recycling</a><br/>$5.00/per tree.<br/>For more information: 512-259-7430<br/>3875 E. Whitestone Blvd., Cedar Park, TX 78613</p><p><a href=\\\\\\\"http://www.goodguystreeservice.com/\\\\\\\">Good Guys Tree Service</a><br/>Prices vary.<br/>For more information: 512-743-3909<br/>11601 Anderson Mill Rd., Austin, TX 78750</p><h1>Do you live in a house? You can recycle your Christmas tree at the curb</h1><br/><ol><li><p>If you are a City of Austin curbside customer, and you would like to have your tree picked up and turned into mulch, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Cut the tree in half if it is longer than 6 feet.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Set your tree out on the curb by 6:30 am on your regular collection day.</p></li><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li></ol>\\\", \\\"id\\\": \\\"b748924c-4c94-4a4f-a3b2-3730684980f8\\\"}]\", \"topic\": 1, \"contacts\": [{\"pk\": null, \"page\": 4, \"contact\": 1}]}",
+    "approved_go_live_at": null
+  }
+},
+{
+  "model": "wagtailcore.pagerevision",
+  "pk": 15,
+  "fields": {
+    "page": 4,
+    "submitted_for_moderation": false,
+    "created_at": "2017-12-29T04:43:18.522Z",
+    "user": [
+      "admin@austintexas.io"
+    ],
+    "content_json": "{\"pk\": 4, \"path\": \"000100010001\", \"depth\": 3, \"numchild\": 0, \"title\": \"Recycle your Christmas tree\", \"draft_title\": \"Recycle your Christmas tree\", \"slug\": \"holiday-tree-recycling\", \"content_type\": 12, \"live\": true, \"has_unpublished_changes\": true, \"url_path\": \"/home/holiday-tree-recycling/\", \"owner\": 1, \"seo_title\": \"\", \"show_in_menus\": false, \"search_description\": \"\", \"go_live_at\": null, \"expire_at\": null, \"expired\": false, \"locked\": false, \"first_published_at\": \"2017-12-06T17:09:43.276Z\", \"last_published_at\": \"2017-12-13T22:43:34.715Z\", \"latest_revision_created_at\": \"2017-12-29T04:42:20.565Z\", \"live_revision\": 11, \"created_at\": \"2017-12-06T17:09:43.155Z\", \"updated_at\": \"2017-12-29T04:43:18.519Z\", \"content\": \"<ol><li><p>All residents can drop-off their trees to be recycled into mulch. To drop your tree off at Zilker Park, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Drop your tree off between 10am and 2pm on one of the following days:</p></li><ol><li><p>Saturday, December 30, 2017</p></li><li><p>Sunday, December 31, 2017</p></li><li><p>Saturday, January 6, 2018</p></li><li><p>Sunday, January 7, 2018</p></li></ol><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li><li><p>Do you live in a house? Skip ahead and read about recycling your Christmas tree at the curb.</p></li></ol>\", \"content_en\": \"<ol><li><p>All residents can drop-off their trees to be recycled into mulch. To drop your tree off at Zilker Park, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Drop your tree off between 10am and 2pm on one of the following days:</p></li><ol><li><p>Saturday, December 30, 2017</p></li><li><p>Sunday, December 31, 2017</p></li><li><p>Saturday, January 6, 2018</p></li><li><p>Sunday, January 7, 2018</p></li></ol><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li><li><p>Do you live in a house? Skip ahead and read about recycling your Christmas tree at the curb.</p></li></ol>\", \"content_pt\": null, \"content_es\": \"\", \"content_fr\": null, \"extra_content\": \"[{\\\"type\\\": \\\"application_block\\\", \\\"value\\\": 3, \\\"id\\\": \\\"f3154cf7-22c1-4d88-89f9-ee3f834f6ec7\\\"}, {\\\"type\\\": \\\"content\\\", \\\"value\\\": \\\"<h2>Free Drop-Off Locations</h2><p>Trees will be accepted free of cost at the locations listed below. However, a contamination fee will be added to any trees with tags, decorations, and/or plastic remaining.</p><br/><p><a href=\\\\\\\"http://www.texasdisposal.com/contact/\\\\\\\">Texas Disposal Systems</a><br/>TDS Landfill: 3016 FM 1327, Creedmoor, Texas<br/>Eco Depot: 4001 RR 620 South, Bee Cave, Texas</p><p><a href=\\\\\\\"http://www.organicsbygosh.com/drop-off-collection/\\\\\\\">Organics By Gosh</a><br/>13602 FM 969, Austin, TX 78724\\\\u2028 | (512) 276-1211</p><p><a href=\\\\\\\"http://www.daisyworksdirt.com/\\\\\\\">Walker Aero Environmental (JV Dirt)</a><br/>3600 FM 973 North Austin, Texas 78725</p><p><a href=\\\\\\\"http://www.989rock.com/\\\\\\\">Whittlesey Landscape Supplies</a><br/>3219 S IH 35 Round Rock, Texas 78664<br/>629 Dalton Lane, Austin, Texas 78742</p><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Travis County Transfer Station</a><br/>2625 Woodall Dr. Leander, Texas 78641</p><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Travis County Service Center</a><br/>6013 Blue Bluff Rd Austin, Texas 78724</p><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Del Valle Softball Complex (Behind the Southwest Rural Center)</a><br/>3614 FM 973 Del Valle, Texas 78617</p><br/><h2>Drop-Off Locations with a Fee</h2><p>Locations listed below have varying fees. Call the location for more information. \\\\u00a0</p><p><a href=\\\\\\\"http://firewoodandmulchaustintx.com/\\\\\\\">Kinser Ranch LLC.</a><br/>Starts at $1.00/per tree to $20/per load.<br/>For more information: 512-748-0800<br/>10701 Kinser Lane, Austin, Texas 78736</p><p><a href=\\\\\\\"http://www.sidmourningtreeservice.com/\\\\\\\">Sid Mourning Tree Service</a><br/>Pricing varies.<br/>Call for fee information: 512-420-0733<br/>3810 Medical Parkway Austin, TX 78756</p><p><a href=\\\\\\\"http://www.austinwoodrecycling.com/\\\\\\\">Austin Wood Recycling</a><br/>$5.00/per tree.<br/>For more information: 512-259-7430<br/>3875 E. Whitestone Blvd., Cedar Park, TX 78613</p><p><a href=\\\\\\\"http://www.goodguystreeservice.com/\\\\\\\">Good Guys Tree Service</a><br/>Prices vary.<br/>For more information: 512-743-3909<br/>11601 Anderson Mill Rd., Austin, TX 78750</p><h1>Do you live in a house? You can recycle your Christmas tree at the curb</h1><br/><ol><li><p>If you are a City of Austin curbside customer, and you would like to have your tree picked up and turned into mulch, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Cut the tree in half if it is longer than 6 feet.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Set your tree out on the curb by 6:30 am on your regular collection day.</p></li><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li></ol>\\\", \\\"id\\\": \\\"b748924c-4c94-4a4f-a3b2-3730684980f8\\\"}]\", \"topic\": 1, \"contacts\": [{\"pk\": null, \"page\": 4, \"contact\": 1}]}",
+    "approved_go_live_at": null
+  }
+},
+{
+  "model": "wagtailcore.pagerevision",
+  "pk": 16,
+  "fields": {
+    "page": 4,
+    "submitted_for_moderation": false,
+    "created_at": "2017-12-29T04:48:15.808Z",
+    "user": [
+      "admin@austintexas.io"
+    ],
+    "content_json": "{\"pk\": 4, \"path\": \"000100010001\", \"depth\": 3, \"numchild\": 0, \"title\": \"Recycle your Christmas tree\", \"draft_title\": \"Recycle your Christmas tree\", \"slug\": \"holiday-tree-recycling\", \"content_type\": 12, \"live\": true, \"has_unpublished_changes\": false, \"url_path\": \"/home/holiday-tree-recycling/\", \"owner\": 1, \"seo_title\": \"\", \"show_in_menus\": false, \"search_description\": \"\", \"go_live_at\": null, \"expire_at\": null, \"expired\": false, \"locked\": false, \"first_published_at\": \"2017-12-06T17:09:43.276Z\", \"last_published_at\": \"2017-12-29T04:43:18.837Z\", \"latest_revision_created_at\": \"2017-12-29T04:43:18.522Z\", \"live_revision\": 15, \"created_at\": \"2017-12-06T17:09:43.155Z\", \"updated_at\": \"2017-12-29T04:48:15.806Z\", \"content\": \"<ol><li><p>All residents can drop-off their trees to be recycled into mulch. To drop your tree off at Zilker Park, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Drop your tree off between 10am and 2pm on one of the following days:</p></li><ol><li><p>Saturday, December 30, 2017</p></li><li><p>Sunday, December 31, 2017</p></li><li><p>Saturday, January 6, 2018</p></li><li><p>Sunday, January 7, 2018</p></li></ol><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li><li><p>Do you live in a house? Skip ahead and read about recycling your Christmas tree at the curb.</p></li></ol>\", \"content_en\": \"<ol><li><p>All residents can drop-off their trees to be recycled into mulch. To drop your tree off at Zilker Park, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Drop your tree off between 10am and 2pm on one of the following days:</p></li><ol><li><p>Saturday, December 30, 2017</p></li><li><p>Sunday, December 31, 2017</p></li><li><p>Saturday, January 6, 2018</p></li><li><p>Sunday, January 7, 2018</p></li></ol><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li><li><p>Do you live in a house? Skip ahead and read about recycling your Christmas tree at the curb.</p></li></ol>\", \"content_pt\": null, \"content_es\": \"\", \"content_fr\": null, \"extra_content\": \"[{\\\"type\\\": \\\"application_block\\\", \\\"value\\\": 3, \\\"id\\\": \\\"f3154cf7-22c1-4d88-89f9-ee3f834f6ec7\\\"}, {\\\"type\\\": \\\"content\\\", \\\"value\\\": \\\"<h2>Free Drop-Off Locations</h2><p>Trees will be accepted free of cost at the locations listed below. However, a contamination fee will be added to any trees with tags, decorations, and/or plastic remaining.</p><br/><p><a href=\\\\\\\"http://www.texasdisposal.com/contact/\\\\\\\">Texas Disposal Systems</a><br/>TDS Landfill: 3016 FM 1327, Creedmoor, Texas<br/>Eco Depot: 4001 RR 620 South, Bee Cave, Texas</p><p><a href=\\\\\\\"http://www.organicsbygosh.com/drop-off-collection/\\\\\\\">Organics By Gosh</a><br/>13602 FM 969, Austin, TX 78724\\\\u2028 | (512) 276-1211</p><p><a href=\\\\\\\"http://www.daisyworksdirt.com/\\\\\\\">Walker Aero Environmental (JV Dirt)</a><br/>3600 FM 973 North Austin, Texas 78725</p><p><a href=\\\\\\\"http://www.989rock.com/\\\\\\\">Whittlesey Landscape Supplies</a><br/>3219 S IH 35 Round Rock, Texas 78664<br/>629 Dalton Lane, Austin, Texas 78742</p><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Travis County Transfer Station</a><br/>2625 Woodall Dr. Leander, Texas 78641</p><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Travis County Service Center</a><br/>6013 Blue Bluff Rd Austin, Texas 78724</p><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Del Valle Softball Complex (Behind the Southwest Rural Center)</a><br/>3614 FM 973 Del Valle, Texas 78617</p><br/><h2>Drop-Off Locations with a Fee</h2><p>Locations listed below have varying fees. Call the location for more information. \\\\u00a0</p><p><a href=\\\\\\\"http://firewoodandmulchaustintx.com/\\\\\\\">Kinser Ranch LLC.</a><br/>Starts at $1.00/per tree to $20/per load.<br/>For more information: 512-748-0800<br/>10701 Kinser Lane, Austin, Texas 78736</p><p><a href=\\\\\\\"http://www.sidmourningtreeservice.com/\\\\\\\">Sid Mourning Tree Service</a><br/>Pricing varies.<br/>Call for fee information: 512-420-0733<br/>3810 Medical Parkway Austin, TX 78756</p><p><a href=\\\\\\\"http://www.austinwoodrecycling.com/\\\\\\\">Austin Wood Recycling</a><br/>$5.00/per tree.<br/>For more information: 512-259-7430<br/>3875 E. Whitestone Blvd., Cedar Park, TX 78613</p><p><a href=\\\\\\\"http://www.goodguystreeservice.com/\\\\\\\">Good Guys Tree Service</a><br/>Prices vary.<br/>For more information: 512-743-3909<br/>11601 Anderson Mill Rd., Austin, TX 78750</p><h1>Do you live in a house? You can recycle your Christmas tree at the curb</h1><br/><ol><li><p>If you are a City of Austin curbside customer, and you would like to have your tree picked up and turned into mulch, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Cut the tree in half if it is longer than 6 feet.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Set your tree out on the curb by 6:30 am on your regular collection day.</p></li><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li></ol>\\\", \\\"id\\\": \\\"b748924c-4c94-4a4f-a3b2-3730684980f8\\\"}]\", \"topic\": 1, \"contacts\": []}",
+    "approved_go_live_at": null
+  }
+},
+{
+  "model": "wagtailcore.pagerevision",
+  "pk": 17,
+  "fields": {
+    "page": 4,
+    "submitted_for_moderation": false,
+    "created_at": "2017-12-29T04:56:27.169Z",
+    "user": [
+      "admin@austintexas.io"
+    ],
+    "content_json": "{\"pk\": 4, \"path\": \"000100010001\", \"depth\": 3, \"numchild\": 0, \"title\": \"Recycle your Christmas tree\", \"draft_title\": \"Recycle your Christmas tree\", \"slug\": \"holiday-tree-recycling\", \"content_type\": 12, \"live\": true, \"has_unpublished_changes\": true, \"url_path\": \"/home/holiday-tree-recycling/\", \"owner\": 1, \"seo_title\": \"\", \"show_in_menus\": false, \"search_description\": \"\", \"go_live_at\": null, \"expire_at\": null, \"expired\": false, \"locked\": false, \"first_published_at\": \"2017-12-06T17:09:43.276Z\", \"last_published_at\": \"2017-12-29T04:43:18.837Z\", \"latest_revision_created_at\": \"2017-12-29T04:48:15.808Z\", \"live_revision\": 15, \"created_at\": \"2017-12-06T17:09:43.155Z\", \"updated_at\": \"2017-12-29T04:56:27.168Z\", \"content\": \"<ol><li><p>All residents can drop-off their trees to be recycled into mulch. To drop your tree off at Zilker Park, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Drop your tree off between 10am and 2pm on one of the following days:</p></li><ol><li><p>Saturday, December 30, 2017</p></li><li><p>Sunday, December 31, 2017</p></li><li><p>Saturday, January 6, 2018</p></li><li><p>Sunday, January 7, 2018</p></li></ol><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li><li><p>Do you live in a house? Skip ahead and read about recycling your Christmas tree at the curb.</p></li></ol>\", \"content_en\": \"<ol><li><p>All residents can drop-off their trees to be recycled into mulch. To drop your tree off at Zilker Park, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Drop your tree off between 10am and 2pm on one of the following days:</p></li><ol><li><p>Saturday, December 30, 2017</p></li><li><p>Sunday, December 31, 2017</p></li><li><p>Saturday, January 6, 2018</p></li><li><p>Sunday, January 7, 2018</p></li></ol><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li><li><p>Do you live in a house? Skip ahead and read about recycling your Christmas tree at the curb.</p></li></ol>\", \"content_pt\": null, \"content_es\": \"\", \"content_fr\": null, \"extra_content\": \"[{\\\"type\\\": \\\"application_block\\\", \\\"value\\\": 3, \\\"id\\\": \\\"f3154cf7-22c1-4d88-89f9-ee3f834f6ec7\\\"}, {\\\"type\\\": \\\"content\\\", \\\"value\\\": \\\"<h2>Free Drop-Off Locations</h2><p>Trees will be accepted free of cost at the locations listed below. However, a contamination fee will be added to any trees with tags, decorations, and/or plastic remaining.</p><br/><p><a href=\\\\\\\"http://www.texasdisposal.com/contact/\\\\\\\">Texas Disposal Systems</a><br/>TDS Landfill: 3016 FM 1327, Creedmoor, Texas<br/>Eco Depot: 4001 RR 620 South, Bee Cave, Texas</p><p><a href=\\\\\\\"http://www.organicsbygosh.com/drop-off-collection/\\\\\\\">Organics By Gosh</a><br/>13602 FM 969, Austin, TX 78724\\\\u2028 | (512) 276-1211</p><p><a href=\\\\\\\"http://www.daisyworksdirt.com/\\\\\\\">Walker Aero Environmental (JV Dirt)</a><br/>3600 FM 973 North Austin, Texas 78725</p><p><a href=\\\\\\\"http://www.989rock.com/\\\\\\\">Whittlesey Landscape Supplies</a><br/>3219 S IH 35 Round Rock, Texas 78664<br/>629 Dalton Lane, Austin, Texas 78742</p><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Travis County Transfer Station</a><br/>2625 Woodall Dr. Leander, Texas 78641</p><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Travis County Service Center</a><br/>6013 Blue Bluff Rd Austin, Texas 78724</p><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Del Valle Softball Complex (Behind the Southwest Rural Center)</a><br/>3614 FM 973 Del Valle, Texas 78617</p><br/><h2>Drop-Off Locations with a Fee</h2><p>Locations listed below have varying fees. Call the location for more information. \\\\u00a0</p><p><a href=\\\\\\\"http://firewoodandmulchaustintx.com/\\\\\\\">Kinser Ranch LLC.</a><br/>Starts at $1.00/per tree to $20/per load.<br/>For more information: 512-748-0800<br/>10701 Kinser Lane, Austin, Texas 78736</p><p><a href=\\\\\\\"http://www.sidmourningtreeservice.com/\\\\\\\">Sid Mourning Tree Service</a><br/>Pricing varies.<br/>Call for fee information: 512-420-0733<br/>3810 Medical Parkway Austin, TX 78756</p><p><a href=\\\\\\\"http://www.austinwoodrecycling.com/\\\\\\\">Austin Wood Recycling</a><br/>$5.00/per tree.<br/>For more information: 512-259-7430<br/>3875 E. Whitestone Blvd., Cedar Park, TX 78613</p><p><a href=\\\\\\\"http://www.goodguystreeservice.com/\\\\\\\">Good Guys Tree Service</a><br/>Prices vary.<br/>For more information: 512-743-3909<br/>11601 Anderson Mill Rd., Austin, TX 78750</p><h1>Do you live in a house? You can recycle your Christmas tree at the curb</h1><br/><ol><li><p>If you are a City of Austin curbside customer, and you would like to have your tree picked up and turned into mulch, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Cut the tree in half if it is longer than 6 feet.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Set your tree out on the curb by 6:30 am on your regular collection day.</p></li><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li></ol>\\\", \\\"id\\\": \\\"b748924c-4c94-4a4f-a3b2-3730684980f8\\\"}]\", \"topic\": 1, \"contacts\": []}",
+    "approved_go_live_at": null
+  }
+},
+{
+  "model": "wagtailcore.pagerevision",
+  "pk": 18,
+  "fields": {
+    "page": 4,
+    "submitted_for_moderation": false,
+    "created_at": "2017-12-29T05:15:16.075Z",
+    "user": [
+      "admin@austintexas.io"
+    ],
+    "content_json": "{\"pk\": 4, \"path\": \"000100010001\", \"depth\": 3, \"numchild\": 0, \"title\": \"Recycle your Christmas treeeeeeeeeeee\", \"draft_title\": \"Recycle your Christmas tree\", \"slug\": \"holiday-tree-recycling\", \"content_type\": 12, \"live\": true, \"has_unpublished_changes\": true, \"url_path\": \"/home/holiday-tree-recycling/\", \"owner\": 1, \"seo_title\": \"\", \"show_in_menus\": false, \"search_description\": \"\", \"go_live_at\": null, \"expire_at\": null, \"expired\": false, \"locked\": false, \"first_published_at\": \"2017-12-06T17:09:43.276Z\", \"last_published_at\": \"2017-12-29T04:43:18.837Z\", \"latest_revision_created_at\": \"2017-12-29T04:56:27.169Z\", \"live_revision\": 15, \"created_at\": \"2017-12-06T17:09:43.155Z\", \"updated_at\": \"2017-12-29T05:15:16.073Z\", \"content\": \"<ol><li><p>All residents can drop-off their trees to be recycled into mulch. To drop your tree off at Zilker Park, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Drop your tree off between 10am and 2pm on one of the following days:</p></li><ol><li><p>Saturday, December 30, 2017</p></li><li><p>Sunday, December 31, 2017</p></li><li><p>Saturday, January 6, 2018</p></li><li><p>Sunday, January 7, 2018</p></li></ol><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li><li><p>Do you live in a house? Skip ahead and read about recycling your Christmas tree at the curb.</p></li></ol>\", \"content_en\": \"<ol><li><p>All residents can drop-off their trees to be recycled into mulch. To drop your tree off at Zilker Park, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Drop your tree off between 10am and 2pm on one of the following days:</p></li><ol><li><p>Saturday, December 30, 2017</p></li><li><p>Sunday, December 31, 2017</p></li><li><p>Saturday, January 6, 2018</p></li><li><p>Sunday, January 7, 2018</p></li></ol><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li><li><p>Do you live in a house? Skip ahead and read about recycling your Christmas tree at the curb.</p></li></ol>\", \"content_pt\": null, \"content_es\": \"\", \"content_fr\": null, \"extra_content\": \"[{\\\"type\\\": \\\"application_block\\\", \\\"value\\\": 3, \\\"id\\\": \\\"f3154cf7-22c1-4d88-89f9-ee3f834f6ec7\\\"}, {\\\"type\\\": \\\"content\\\", \\\"value\\\": \\\"<h2>Free Drop-Off Locations</h2><p>Trees will be accepted free of cost at the locations listed below. However, a contamination fee will be added to any trees with tags, decorations, and/or plastic remaining.</p><br/><p><a href=\\\\\\\"http://www.texasdisposal.com/contact/\\\\\\\">Texas Disposal Systems</a><br/>TDS Landfill: 3016 FM 1327, Creedmoor, Texas<br/>Eco Depot: 4001 RR 620 South, Bee Cave, Texas</p><p><a href=\\\\\\\"http://www.organicsbygosh.com/drop-off-collection/\\\\\\\">Organics By Gosh</a><br/>13602 FM 969, Austin, TX 78724\\\\u2028 | (512) 276-1211</p><p><a href=\\\\\\\"http://www.daisyworksdirt.com/\\\\\\\">Walker Aero Environmental (JV Dirt)</a><br/>3600 FM 973 North Austin, Texas 78725</p><p><a href=\\\\\\\"http://www.989rock.com/\\\\\\\">Whittlesey Landscape Supplies</a><br/>3219 S IH 35 Round Rock, Texas 78664<br/>629 Dalton Lane, Austin, Texas 78742</p><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Travis County Transfer Station</a><br/>2625 Woodall Dr. Leander, Texas 78641</p><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Travis County Service Center</a><br/>6013 Blue Bluff Rd Austin, Texas 78724</p><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Del Valle Softball Complex (Behind the Southwest Rural Center)</a><br/>3614 FM 973 Del Valle, Texas 78617</p><br/><h2>Drop-Off Locations with a Fee</h2><p>Locations listed below have varying fees. Call the location for more information. \\\\u00a0</p><p><a href=\\\\\\\"http://firewoodandmulchaustintx.com/\\\\\\\">Kinser Ranch LLC.</a><br/>Starts at $1.00/per tree to $20/per load.<br/>For more information: 512-748-0800<br/>10701 Kinser Lane, Austin, Texas 78736</p><p><a href=\\\\\\\"http://www.sidmourningtreeservice.com/\\\\\\\">Sid Mourning Tree Service</a><br/>Pricing varies.<br/>Call for fee information: 512-420-0733<br/>3810 Medical Parkway Austin, TX 78756</p><p><a href=\\\\\\\"http://www.austinwoodrecycling.com/\\\\\\\">Austin Wood Recycling</a><br/>$5.00/per tree.<br/>For more information: 512-259-7430<br/>3875 E. Whitestone Blvd., Cedar Park, TX 78613</p><p><a href=\\\\\\\"http://www.goodguystreeservice.com/\\\\\\\">Good Guys Tree Service</a><br/>Prices vary.<br/>For more information: 512-743-3909<br/>11601 Anderson Mill Rd., Austin, TX 78750</p><h1>Do you live in a house? You can recycle your Christmas tree at the curb</h1><br/><ol><li><p>If you are a City of Austin curbside customer, and you would like to have your tree picked up and turned into mulch, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Cut the tree in half if it is longer than 6 feet.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Set your tree out on the curb by 6:30 am on your regular collection day.</p></li><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li></ol>\\\", \\\"id\\\": \\\"b748924c-4c94-4a4f-a3b2-3730684980f8\\\"}]\", \"topic\": 1, \"contacts\": []}",
+    "approved_go_live_at": null
+  }
+},
+{
+  "model": "wagtailcore.pagerevision",
+  "pk": 19,
+  "fields": {
+    "page": 4,
+    "submitted_for_moderation": false,
+    "created_at": "2017-12-29T06:02:11.715Z",
+    "user": [
+      "admin@austintexas.io"
+    ],
+    "content_json": "{\"pk\": 4, \"path\": \"000100010001\", \"depth\": 3, \"numchild\": 0, \"title\": \"Recycle your Christmas treeeeeeeeeeee\", \"draft_title\": \"Recycle your Christmas treeeeeeeeeeee\", \"slug\": \"holiday-tree-recycling\", \"content_type\": 12, \"live\": true, \"has_unpublished_changes\": true, \"url_path\": \"/home/holiday-tree-recycling/\", \"owner\": 1, \"seo_title\": \"\", \"show_in_menus\": false, \"search_description\": \"\", \"go_live_at\": null, \"expire_at\": null, \"expired\": false, \"locked\": false, \"first_published_at\": \"2017-12-06T17:09:43.276Z\", \"last_published_at\": \"2017-12-29T04:43:18.837Z\", \"latest_revision_created_at\": \"2017-12-29T05:15:16.075Z\", \"live_revision\": 15, \"created_at\": \"2017-12-06T17:09:43.155Z\", \"updated_at\": \"2017-12-29T06:02:11.714Z\", \"content\": \"<ol><li><p>All residents can drop-off their trees to be recycled into mulch. To drop your tree off at Zilker Park, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Drop your tree off between 10am and 2pm on one of the following days:</p></li><ol><li><p>Saturday, December 30, 2017</p></li><li><p>Sunday, December 31, 2017</p></li><li><p>Saturday, January 6, 2018</p></li><li><p>Sunday, January 7, 2018</p></li></ol><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li><li><p>Do you live in a house? Skip ahead and read about recycling your Christmas tree at the curb.</p></li></ol>\", \"content_en\": \"<ol><li><p>All residents can drop-off their trees to be recycled into mulch. To drop your tree off at Zilker Park, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Drop your tree off between 10am and 2pm on one of the following days:</p></li><ol><li><p>Saturday, December 30, 2017</p></li><li><p>Sunday, December 31, 2017</p></li><li><p>Saturday, January 6, 2018</p></li><li><p>Sunday, January 7, 2018</p></li></ol><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li><li><p>Do you live in a house? Skip ahead and read about recycling your Christmas tree at the curb.</p></li></ol>\", \"content_pt\": null, \"content_es\": \"\", \"content_fr\": null, \"extra_content\": \"[{\\\"type\\\": \\\"application_block\\\", \\\"value\\\": 3, \\\"id\\\": \\\"f3154cf7-22c1-4d88-89f9-ee3f834f6ec7\\\"}, {\\\"type\\\": \\\"content\\\", \\\"value\\\": \\\"<h2>Free Drop-Off Locations</h2><p>Trees will be accepted free of cost at the locations listed below. However, a contamination fee will be added to any trees with tags, decorations, and/or plastic remaining.</p><br/><p><a href=\\\\\\\"http://www.texasdisposal.com/contact/\\\\\\\">Texas Disposal Systems</a><br/>TDS Landfill: 3016 FM 1327, Creedmoor, Texas<br/>Eco Depot: 4001 RR 620 South, Bee Cave, Texas</p><p><a href=\\\\\\\"http://www.organicsbygosh.com/drop-off-collection/\\\\\\\">Organics By Gosh</a><br/>13602 FM 969, Austin, TX 78724\\\\u2028 | (512) 276-1211</p><p><a href=\\\\\\\"http://www.daisyworksdirt.com/\\\\\\\">Walker Aero Environmental (JV Dirt)</a><br/>3600 FM 973 North Austin, Texas 78725</p><p><a href=\\\\\\\"http://www.989rock.com/\\\\\\\">Whittlesey Landscape Supplies</a><br/>3219 S IH 35 Round Rock, Texas 78664<br/>629 Dalton Lane, Austin, Texas 78742</p><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Travis County Transfer Station</a><br/>2625 Woodall Dr. Leander, Texas 78641</p><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Travis County Service Center</a><br/>6013 Blue Bluff Rd Austin, Texas 78724</p><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Del Valle Softball Complex (Behind the Southwest Rural Center)</a><br/>3614 FM 973 Del Valle, Texas 78617</p><br/><h2>Drop-Off Locations with a Fee</h2><p>Locations listed below have varying fees. Call the location for more information. \\\\u00a0</p><p><a href=\\\\\\\"http://firewoodandmulchaustintx.com/\\\\\\\">Kinser Ranch LLC.</a><br/>Starts at $1.00/per tree to $20/per load.<br/>For more information: 512-748-0800<br/>10701 Kinser Lane, Austin, Texas 78736</p><p><a href=\\\\\\\"http://www.sidmourningtreeservice.com/\\\\\\\">Sid Mourning Tree Service</a><br/>Pricing varies.<br/>Call for fee information: 512-420-0733<br/>3810 Medical Parkway Austin, TX 78756</p><p><a href=\\\\\\\"http://www.austinwoodrecycling.com/\\\\\\\">Austin Wood Recycling</a><br/>$5.00/per tree.<br/>For more information: 512-259-7430<br/>3875 E. Whitestone Blvd., Cedar Park, TX 78613</p><p><a href=\\\\\\\"http://www.goodguystreeservice.com/\\\\\\\">Good Guys Tree Service</a><br/>Prices vary.<br/>For more information: 512-743-3909<br/>11601 Anderson Mill Rd., Austin, TX 78750</p><h1>Do you live in a house? You can recycle your Christmas tree at the curb</h1><br/><ol><li><p>If you are a City of Austin curbside customer, and you would like to have your tree picked up and turned into mulch, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Cut the tree in half if it is longer than 6 feet.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Set your tree out on the curb by 6:30 am on your regular collection day.</p></li><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li></ol>\\\", \\\"id\\\": \\\"b748924c-4c94-4a4f-a3b2-3730684980f8\\\"}]\", \"topic\": 1, \"contacts\": []}",
+    "approved_go_live_at": null
+  }
+},
+{
+  "model": "wagtailcore.pagerevision",
+  "pk": 20,
+  "fields": {
+    "page": 4,
+    "submitted_for_moderation": false,
+    "created_at": "2018-01-02T21:21:54.628Z",
+    "user": [
+      "admin@austintexas.io"
+    ],
+    "content_json": "{\"pk\": 4, \"path\": \"000100010001\", \"depth\": 3, \"numchild\": 0, \"title\": \"Recycle your Christmas treeeeeeeeeeee\", \"draft_title\": \"Recycle your Christmas treeeeeeeeeeee\", \"slug\": \"holiday-tree-recycling\", \"content_type\": 12, \"live\": true, \"has_unpublished_changes\": false, \"url_path\": \"/home/holiday-tree-recycling/\", \"owner\": 1, \"seo_title\": \"\", \"show_in_menus\": false, \"search_description\": \"\", \"go_live_at\": null, \"expire_at\": null, \"expired\": false, \"locked\": false, \"first_published_at\": \"2017-12-06T17:09:43.276Z\", \"last_published_at\": \"2017-12-29T06:02:11.869Z\", \"latest_revision_created_at\": \"2017-12-29T06:02:11.715Z\", \"live_revision\": 19, \"created_at\": \"2017-12-06T17:09:43.155Z\", \"updated_at\": \"2018-01-02T21:21:54.627Z\", \"content\": \"<ol><li><p>All residents can drop-off their trees to be recycled into mulch. To drop your tree off at Zilker Park, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Drop your tree off between 10am and 2pm on one of the following days:</p></li><ol><li><p>Saturday, December 30, 2017</p></li><li><p>Sunday, December 31, 2017</p></li><li><p>Saturday, January 6, 2018</p></li><li><p>Sunday, January 7, 2018</p></li></ol><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li><li><p>Do you live in a house? Skip ahead and read about recycling your Christmas tree at the curb.</p></li></ol>\", \"content_en\": \"<ol><li><p>All residents can drop-off their trees to be recycled into mulch. To drop your tree off at Zilker Park, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Drop your tree off between 10am and 2pm on one of the following days:</p></li><ol><li><p>Saturday, December 30, 2017</p></li><li><p>Sunday, December 31, 2017</p></li><li><p>Saturday, January 6, 2018</p></li><li><p>Sunday, January 7, 2018</p></li></ol><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li><li><p>Do you live in a house? Skip ahead and read about recycling your Christmas tree at the curb.</p></li></ol>\", \"content_pt\": null, \"content_es\": \"\", \"content_fr\": null, \"extra_content\": \"[{\\\"type\\\": \\\"application_block\\\", \\\"value\\\": 3, \\\"id\\\": \\\"f3154cf7-22c1-4d88-89f9-ee3f834f6ec7\\\"}, {\\\"type\\\": \\\"content\\\", \\\"value\\\": \\\"<h2>Free Drop-Off Locations</h2><p>Trees will be accepted free of cost at the locations listed below. However, a contamination fee will be added to any trees with tags, decorations, and/or plastic remaining.</p><br/><p><a href=\\\\\\\"http://www.texasdisposal.com/contact/\\\\\\\">Texas Disposal Systems</a><br/>TDS Landfill: 3016 FM 1327, Creedmoor, Texas<br/>Eco Depot: 4001 RR 620 South, Bee Cave, Texas</p><p><a href=\\\\\\\"http://www.organicsbygosh.com/drop-off-collection/\\\\\\\">Organics By Gosh</a><br/>13602 FM 969, Austin, TX 78724\\\\u2028 | (512) 276-1211</p><p><a href=\\\\\\\"http://www.daisyworksdirt.com/\\\\\\\">Walker Aero Environmental (JV Dirt)</a><br/>3600 FM 973 North Austin, Texas 78725</p><p><a href=\\\\\\\"http://www.989rock.com/\\\\\\\">Whittlesey Landscape Supplies</a><br/>3219 S IH 35 Round Rock, Texas 78664<br/>629 Dalton Lane, Austin, Texas 78742</p><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Travis County Transfer Station</a><br/>2625 Woodall Dr. Leander, Texas 78641</p><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Travis County Service Center</a><br/>6013 Blue Bluff Rd Austin, Texas 78724</p><p><a href=\\\\\\\"https://www.traviscountytx.gov/news/1212-15-recycle-tree\\\\\\\">Del Valle Softball Complex (Behind the Southwest Rural Center)</a><br/>3614 FM 973 Del Valle, Texas 78617</p><br/><h2>Drop-Off Locations with a Fee</h2><p>Locations listed below have varying fees. Call the location for more information. \\\\u00a0</p><p><a href=\\\\\\\"http://firewoodandmulchaustintx.com/\\\\\\\">Kinser Ranch LLC.</a><br/>Starts at $1.00/per tree to $20/per load.<br/>For more information: 512-748-0800<br/>10701 Kinser Lane, Austin, Texas 78736</p><p><a href=\\\\\\\"http://www.sidmourningtreeservice.com/\\\\\\\">Sid Mourning Tree Service</a><br/>Pricing varies.<br/>Call for fee information: 512-420-0733<br/>3810 Medical Parkway Austin, TX 78756</p><p><a href=\\\\\\\"http://www.austinwoodrecycling.com/\\\\\\\">Austin Wood Recycling</a><br/>$5.00/per tree.<br/>For more information: 512-259-7430<br/>3875 E. Whitestone Blvd., Cedar Park, TX 78613</p><p><a href=\\\\\\\"http://www.goodguystreeservice.com/\\\\\\\">Good Guys Tree Service</a><br/>Prices vary.<br/>For more information: 512-743-3909<br/>11601 Anderson Mill Rd., Austin, TX 78750</p><h1>Do you live in a house? You can recycle your Christmas tree at the curb</h1><br/><ol><li><p>If you are a City of Austin curbside customer, and you would like to have your tree picked up and turned into mulch, remove any ornaments, lighting, decorations, and stands from your tree. Trees with flocking, or fake-snow, will not be accepted.</p></li><li><p>Cut the tree in half if it is longer than 6 feet.</p></li><li><p>Do not place in a plastic bag.</p></li><li><p>Set your tree out on the curb by 6:30 am on your regular collection day.</p></li><li><p>Pick-up mulch at Zilker park on January 18, 2018. It will be available for free on a first-come, first serve basis. Be sure to bring your own tools and storage containers for loading and transporting the mulch.</p></li></ol>\\\", \\\"id\\\": \\\"b748924c-4c94-4a4f-a3b2-3730684980f8\\\"}]\", \"topic\": 1, \"contacts\": [{\"pk\": null, \"page\": 4, \"contact\": 2}]}",
+    "approved_go_live_at": null
+  }
+},
+{
+  "model": "wagtailcore.pagerevision",
+  "pk": 21,
+  "fields": {
+    "page": 5,
+    "submitted_for_moderation": false,
+    "created_at": "2018-01-04T23:46:30.064Z",
+    "user": [
+      "admin@austintexas.io"
+    ],
+    "content_json": "{\"pk\": 5, \"path\": \"000100010002\", \"depth\": 3, \"numchild\": 0, \"title\": \"Pick Up Free Household Items from the ReUse Store\", \"draft_title\": \"Pick Up Free Household Items from the ReUse Store\", \"slug\": \"dropoff\", \"content_type\": 12, \"live\": true, \"has_unpublished_changes\": false, \"url_path\": \"/home/dropoff/\", \"owner\": 1, \"seo_title\": \"\", \"show_in_menus\": false, \"search_description\": \"\", \"go_live_at\": null, \"expire_at\": null, \"expired\": false, \"locked\": false, \"first_published_at\": \"2017-12-06T21:02:34.309Z\", \"last_published_at\": \"2017-12-15T16:26:52.652Z\", \"latest_revision_created_at\": \"2017-12-15T16:26:52.483Z\", \"live_revision\": 13, \"created_at\": \"2017-12-06T21:02:34.149Z\", \"updated_at\": \"2018-01-04T23:46:30.061Z\", \"content\": \"<ol><li><p>Visit the ReUse Store in the Recycle &amp; Reuse Drop-Off Center at 2514 Business Center Dr, Austin, TX 78744.</p></li><li><p>Many materials that are dropped off at the Recycle &amp; Reuse Drop-Off Center are in usable condition. These items go to the ReUse Store. Pick up these items for free:</p></li><ol><li><p>House paint</p></li><li><p>Art supplies</p></li><li><p>Cleaning products</p></li><li><p>Household chemicals</p></li><li><p>Automotive fluids</p></li><li><p>Mulch</p></li></ol></ol>\", \"content_ar\": null, \"content_en\": \"<ol><li><p>Visit the ReUse Store in the Recycle &amp; Reuse Drop-Off Center at 2514 Business Center Dr, Austin, TX 78744.</p></li><li><p>Many materials that are dropped off at the Recycle &amp; Reuse Drop-Off Center are in usable condition. These items go to the ReUse Store. Pick up these items for free:</p></li><ol><li><p>House paint</p></li><li><p>Art supplies</p></li><li><p>Cleaning products</p></li><li><p>Household chemicals</p></li><li><p>Automotive fluids</p></li><li><p>Mulch</p></li></ol></ol>\", \"content_es\": \"<p>This is a spanish version<br/></p>\", \"content_ko\": null, \"content_my\": null, \"content_ur\": null, \"content_vi\": \"<p>This is a vietnamese version<br/></p>\", \"content_zh_hans\": null, \"content_zh_hant\": null, \"extra_content\": \"[{\\\"type\\\": \\\"application_block\\\", \\\"value\\\": 4, \\\"id\\\": \\\"003658b6-170d-4baf-9c61-848d26511e5f\\\"}, {\\\"type\\\": \\\"content\\\", \\\"value\\\": \\\"<h1>Learn About Austin ReBlend Paint</h1><p>Paint dropped off by customers is inspected before it is chosen to be used in Austin ReBlend. It is then consolidated, blended, filtered and packed by trained personnel to ensure a quality product.</p><p>Austin ReBlend paint is free for individuals and nonprofits, and can save residents money when refurbishing their homes. The paint is not available to businesses.</p><p>It is available in 3.5 gallon containers and three colors:</p><ul><li><p>Texas Limestone (beige)</p></li><li><p>Balcones Canyonland (dark beige)</p></li><li><p>Barton Creek Greenbelt (dark green)</p></li></ul><h1>Pick Up Free Mulch</h1><p>You can pick up mulch for free; however, you must load it yourself. Bring a pitchfork or shovel, work gloves and containers.</p>\\\", \\\"id\\\": \\\"fff2155d-fc2b-411d-8c3a-1dcef2fff99c\\\"}]\", \"topic\": 1, \"contacts\": [{\"pk\": 1, \"page\": 5, \"contact\": 1}]}",
+    "approved_go_live_at": null
+  }
+},
+{
+  "model": "wagtailcore.pagerevision",
+  "pk": 22,
+  "fields": {
+    "page": 5,
+    "submitted_for_moderation": false,
+    "created_at": "2018-01-04T23:46:35.052Z",
+    "user": [
+      "admin@austintexas.io"
+    ],
+    "content_json": "{\"pk\": 5, \"path\": \"000100010002\", \"depth\": 3, \"numchild\": 0, \"title\": \"Pick Up Free Household Items from the ReUse Store\", \"draft_title\": \"Pick Up Free Household Items from the ReUse Store\", \"slug\": \"dropoff\", \"content_type\": 12, \"live\": true, \"has_unpublished_changes\": true, \"url_path\": \"/home/dropoff/\", \"owner\": 1, \"seo_title\": \"\", \"show_in_menus\": false, \"search_description\": \"\", \"go_live_at\": null, \"expire_at\": null, \"expired\": false, \"locked\": false, \"first_published_at\": \"2017-12-06T21:02:34.309Z\", \"last_published_at\": \"2017-12-15T16:26:52.652Z\", \"latest_revision_created_at\": \"2018-01-04T23:46:30.064Z\", \"live_revision\": 13, \"created_at\": \"2017-12-06T21:02:34.149Z\", \"updated_at\": \"2018-01-04T23:46:35.050Z\", \"content\": \"<ol><li><p>Visit the ReUse Store in the Recycle &amp; Reuse Drop-Off Center at 2514 Business Center Dr, Austin, TX 78744.</p></li><li><p>Many materials that are dropped off at the Recycle &amp; Reuse Drop-Off Center are in usable condition. These items go to the ReUse Store. Pick up these items for free:</p></li><ol><li><p>House paint</p></li><li><p>Art supplies</p></li><li><p>Cleaning products</p></li><li><p>Household chemicals</p></li><li><p>Automotive fluids</p></li><li><p>Mulch</p></li></ol></ol>\", \"content_ar\": null, \"content_en\": \"<ol><li><p>Visit the ReUse Store in the Recycle &amp; Reuse Drop-Off Center at 2514 Business Center Dr, Austin, TX 78744.</p></li><li><p>Many materials that are dropped off at the Recycle &amp; Reuse Drop-Off Center are in usable condition. These items go to the ReUse Store. Pick up these items for free:</p></li><ol><li><p>House paint</p></li><li><p>Art supplies</p></li><li><p>Cleaning products</p></li><li><p>Household chemicals</p></li><li><p>Automotive fluids</p></li><li><p>Mulch</p></li></ol></ol>\", \"content_es\": \"<p>This is a spanish version<br/></p>\", \"content_ko\": null, \"content_my\": null, \"content_ur\": null, \"content_vi\": \"<p>This is a vietnamese version<br/></p>\", \"content_zh_hans\": null, \"content_zh_hant\": null, \"extra_content\": \"[{\\\"type\\\": \\\"application_block\\\", \\\"value\\\": 4, \\\"id\\\": \\\"003658b6-170d-4baf-9c61-848d26511e5f\\\"}, {\\\"type\\\": \\\"content\\\", \\\"value\\\": \\\"<h1>Learn About Austin ReBlend Paint</h1><p>Paint dropped off by customers is inspected before it is chosen to be used in Austin ReBlend. It is then consolidated, blended, filtered and packed by trained personnel to ensure a quality product.</p><p>Austin ReBlend paint is free for individuals and nonprofits, and can save residents money when refurbishing their homes. The paint is not available to businesses.</p><p>It is available in 3.5 gallon containers and three colors:</p><ul><li><p>Texas Limestone (beige)</p></li><li><p>Balcones Canyonland (dark beige)</p></li><li><p>Barton Creek Greenbelt (dark green)</p></li></ul><h1>Pick Up Free Mulch</h1><p>You can pick up mulch for free; however, you must load it yourself. Bring a pitchfork or shovel, work gloves and containers.</p>\\\", \\\"id\\\": \\\"fff2155d-fc2b-411d-8c3a-1dcef2fff99c\\\"}]\", \"topic\": 1, \"contacts\": [{\"pk\": 1, \"page\": null, \"contact\": 1}]}",
+    "approved_go_live_at": null
+  }
+}
 ]


### PR DESCRIPTION
I was using the formatter in VSCode, but we should stick to the formatting used by the data dump tool so it's consistent across developers. I also added a little more context in the README about dumping which sets of data.