### PR TITLE
Allow cookies to be set on preview

### DIFF
--- a/joplin/static/js/admin.js
+++ b/joplin/static/js/admin.js
@@ -53,10 +53,10 @@ function configurePreviewWindow() {
 
   let pageID = window.location.href.split('/').find((item) => item && !isNaN(item));
   let previewHTMLString = `
-  <div id="live-preview" class="preview-container">
+  <div id="live-preview" class="preview-container hidden">
     <div class="thumbnail-container" title="Preview">
       <div class="thumbnail">
-        <iframe src="" frameborder="0" onload="this.style.opacity = 1" sandbox="allow-scripts"></iframe>
+        <iframe src="" frameborder="0" onload="this.style.opacity = 1"></iframe>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Access `document.cookie` inside was blocked because I set the `sandbox` attribute and didn't include all the right attributes. Since we're not too concerned about restricting janis, it's easiest to just remove the attribute entirely so there's no extra restrictions.

See more info on the [MDN iframe](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-sandbox) page.

Implements cityofaustin/janis#100