### PR TITLE
Copy media folder to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ COPY "$PWD/fixtures" /app/fixtures
 
 COPY "$PWD/docker-entrypoint.sh" /app/docker-entrypoint.sh
 COPY "$PWD/joplin" /app/joplin
+COPY "$PWD/media" /app/media
 
 ENV PORT ${PORT:-80}
 EXPOSE $PORT


### PR DESCRIPTION
Now that we're packing up images, we need to ship the `media` folder with the container so the preset images get served when deployed.

Fixes cityofaustin/joplin#70