### PR TITLE
Load phone number as JSON

### DIFF
--- a/fixtures/contacts.yaml
+++ b/fixtures/contacts.yaml
@@ -3,9 +3,9 @@ contacts:
         name: 311
         email: help@austintexas.gov
         phone:
-            default: 311
-            out-of-area: 512-974-2000
-            tdd: 512-972-9848
+            default: 512-974-2000
+            n11: 311
+            tty: 512-972-9848
         location: Austin Recycle and Reuse Drop-off Center
         hours:
             monday:

--- a/joplin/base/management/commands/loadcontent.py
+++ b/joplin/base/management/commands/loadcontent.py
@@ -1,3 +1,4 @@
+import json
 import textwrap
 from pathlib import Path
 
@@ -91,8 +92,8 @@ def load_contacts(data):
 def load_contact(data):
     data['location'] = Location.objects.get(name=data['location'])
     hours = data.pop('hours')
-    # TODO: Remove this when we can serialize phone as an array
-    data['phone'] = '; '.join([f'{key}: {value}' for key, value in data['phone'].items()])
+    # TODO: Remove this when we can serialize phone as an array/object
+    data['phone'] = json.dumps(data['phone'])
 
     contact, created = Contact.objects.update_or_create(name=data['name'], defaults=data)
     print(f'{"✅  Created" if created else "⭐  Updated"} {contact.name}')


### PR DESCRIPTION
The phone number field is still text, but we want to serve it in the API as JSON. As a workaround, we'll just load the phone number as a JSON string. Someday we'll properly separate individual fields, but today ain't that day.

Part of cityofaustin/techstack#207