### PR TITLE
Publish page without recollect

### DIFF
--- a/fixtures/services/hazardous-waste-dropoff-prototype.yaml
+++ b/fixtures/services/hazardous-waste-dropoff-prototype.yaml
@@ -1,13 +1,13 @@
-slug: hazardous-waste-dropoff
+slug: hazardous-waste-dropoff-prototype
 
 topic: recycling-trash-compost
 image: household-hazardous-waste
 contact: 311
 
-title_en: Drop off household hazardous waste and other recyclables
-title_es: Entregue sus desechos peligrosos del hogar y otros artículos reciclables
-title_vi: Bỏ đi các loại rác nhà nguy hiểm và các loại rác tái chế khác
-title_ar: التخلص من النفايات الخطرة المنزلية وغيرها من المواد القابلة للتدوير
+title_en: [Prototype] Drop off household hazardous waste and other recyclables
+title_es: [Prototype] Entregue sus desechos peligrosos del hogar y otros artículos reciclables
+title_vi: [Prototype] Bỏ đi các loại rác nhà nguy hiểm và các loại rác tái chế khác
+title_ar: التخلص من النفايات الخطرة المنزلية وغيرها من المواد القابلة للتدوير[Prototype]
 
 steps_en:
     - Check the “What do I do with” tool below to find out what items are accepted. Some items are free to drop off and some items, like tires, require a fee.


### PR DESCRIPTION
When we load a page with recollect, the page gets scrolled to the position of the recollect app. It's happening when embedded in an iframe, but not when the page is loaded normally. This change is for Tori's prototype.