### PR TITLE
Delete images before loading them

### DIFF
--- a/joplin/base/management/commands/loadcontent.py
+++ b/joplin/base/management/commands/loadcontent.py
@@ -7,10 +7,17 @@ from django.core.management.base import BaseCommand
 from wagtail.core.models import Page
 from yaml import load
 
-from base.models import TranslatedImage, ThreeOneOne, Theme, Topic, Department, ServicePage, ProcessPage, ProcessPageStep, ProcessPageContact, Location, Contact, ServicePageContact, DepartmentContact, Map, ContactDayAndDuration
+from base.models import TranslatedImage, TranslatedImageRendition, ThreeOneOne, Theme, Topic, Department, ServicePage, ProcessPage, ProcessPageStep, ProcessPageContact, Location, Contact, ServicePageContact, DepartmentContact, Map, ContactDayAndDuration
+
+import logging
+logging.basicConfig(level=logging.INFO)
 
 
 def load_images(data):
+    # Clear image renditions so they get regenerated
+    TranslatedImageRendition.objects.all().delete()
+    TranslatedImage.objects.all().delete()
+
     for image_data in data['images']:
         yield load_image(image_data)
 
@@ -23,8 +30,7 @@ def load_image(data):
     filepath = Path(filename)
     with open(filename, 'rb') as f:
         data['file'] = ImageFile(f, name=filepath.name)
-        image_regex = f'original_images/{filepath.stem}'
-        image, created = TranslatedImage.objects.update_or_create(file__startswith=image_regex, defaults=data)
+        image, created = TranslatedImage.objects.update_or_create(file__startswith=filepath.stem, defaults=data)
 
     print(f'{"✅  Created" if created else "⭐  Updated"} {filepath.name} => {image.file.name}')
 

--- a/joplin/base/models.py
+++ b/joplin/base/models.py
@@ -13,8 +13,6 @@ from wagtail.images.edit_handlers import ImageChooserPanel
 from wagtail.images.models import Image, AbstractImage, AbstractRendition
 from wagtail.snippets.models import register_snippet
 
-
-
 from . import blocks as custom_blocks
 from . import forms as custom_forms
 
@@ -37,18 +35,6 @@ class TranslatedImageRendition(AbstractRendition):
         unique_together = (
             ('image', 'filter_spec', 'focal_point_key'),
         )
-
-
-# Delete the source image file when an image is deleted
-@receiver(post_delete, sender=TranslatedImage)
-def image_delete(sender, instance, **kwargs):
-    instance.file.delete(False)
-
-
-# Delete the rendition image file when a rendition is deleted
-@receiver(post_delete, sender=TranslatedImage)
-def rendition_delete(sender, instance, **kwargs):
-    instance.file.delete(False)
 
 
 @register_snippet

--- a/joplin/base/signals.py
+++ b/joplin/base/signals.py
@@ -2,13 +2,23 @@ from django.dispatch import receiver
 from django.db.models.signals import post_save
 from base.models import TranslatedImage
 
+import logging
+logger = logging.getLogger(__name__)
+
+IMAGE_WIDTHS = (
+    640,  # iPhone 5/SE
+    720,  # 720p non retina displays
+    750,  # iPhone 6/7/8/X
+    828,  # iPhone 6/7/8 Plus
+    1080,  # 1080p non retina displays
+    1440,  # 1440p non retina displays/720 retina displays
+    2160,  # 1080p retina displays
+)
+
+
 @receiver(post_save, sender=TranslatedImage)
 def generate_responsive_images(sender, **kwargs):
     image = kwargs['instance']
-    image.get_rendition('width-640') #iPhone 5/SE
-    image.get_rendition('width-720') #720p non retina displays
-    image.get_rendition('width-750') #iPhone 6/7/8/X
-    image.get_rendition('width-828') #iPhone 6/7/8 Plus
-    image.get_rendition('width-1080') #1080p non retina displays
-    image.get_rendition('width-1440') #1440p non retina displays/720 retina displays
-    image.get_rendition('width-2160') #1080p retina displays
+    for width in IMAGE_WIDTHS:
+        logger.debug(f'Generating image rendition for {width}px')
+        image.get_rendition(f'width-{width}')

--- a/scripts/serve-local.sh
+++ b/scripts/serve-local.sh
@@ -29,5 +29,5 @@ docker run \
     --volume "$PWD:/app" \
     --env "DEBUG=1" \
     --env "LOAD_DATA=$LOAD_DATA" \
-    --env "GUNICORN_CMD_ARGS=--reload  --reload-engine=poll --log-level=debug" \
+    --env "GUNICORN_CMD_ARGS=--reload  --reload-engine=poll" \
     "$TAG" "$@"


### PR DESCRIPTION
Django looks in the DB to see what images are available. We're running into a weird situation where the DB says there are images (the data is persisted because it's in postgres), but the images aren't on the filesystem (because we're using docker).

If we blow away the rows in the DB, django will remove the files on the filesystem if they exist. Then we can happily load the images and everything will be in harmony.

Other detritus:
- No need to register the delete image hooks since that bug has been fixed in wagtail
- Don't set loglevel to debug locally so we don't get so much cruft on the screen

Fixes cityofaustin/techstack#473