### PR TITLE
Embed styleguide in edit page

### DIFF
--- a/joplin/static/css/preview.css
+++ b/joplin/static/css/preview.css
@@ -1,14 +1,14 @@
 .preview-container {
   position: fixed;
-  right: 50px;
-  bottom: 50px;
+  right: 10px;
+  bottom: 0;
   z-index: 1000;
 }
 
 /* This container helps the thumbnail behave as if it were an unscaled IMG element */
 .thumbnail-container {
-  width: calc(240px);
-  height: calc(500px);
+  width: calc(360px);
+  height: calc(400px);
   display: inline-block;
   overflow: hidden;
   position: relative;
@@ -28,20 +28,23 @@
   -webkit-transform: scale(2);
   content: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGVuYWJsZS1iYWNrZ3JvdW5kPSJuZXcgMCAwIDMyIDMyIiBoZWlnaHQ9IjMycHgiIGlkPSJMYXllcl8xIiB2ZXJzaW9uPSIxLjEiIHZpZXdCb3g9IjAgMCAzMiAzMiIgd2lkdGg9IjMycHgiIHhtbDpzcGFjZT0icHJlc2VydmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiPjxnIGlkPSJwaG90b18xXyI+PHBhdGggZD0iTTI3LDBINUMyLjc5MSwwLDEsMS43OTEsMSw0djI0YzAsMi4yMDksMS43OTEsNCw0LDRoMjJjMi4yMDksMCw0LTEuNzkxLDQtNFY0QzMxLDEuNzkxLDI5LjIwOSwwLDI3LDB6ICAgIE0yOSwyOGMwLDEuMTAyLTAuODk4LDItMiwySDVjLTEuMTAzLDAtMi0wLjg5OC0yLTJWNGMwLTEuMTAzLDAuODk3LTIsMi0yaDIyYzEuMTAyLDAsMiwwLjg5NywyLDJWMjh6IiBmaWxsPSIjMzMzMzMzIi8+PHBhdGggZD0iTTI2LDRINkM1LjQ0Nyw0LDUsNC40NDcsNSw1djE4YzAsMC41NTMsMC40NDcsMSwxLDFoMjBjMC41NTMsMCwxLTAuNDQ3LDEtMVY1QzI3LDQuNDQ3LDI2LjU1Myw0LDI2LDR6ICAgIE0yNiw1djEzLjg2OWwtMy4yNS0zLjUzQzIyLjU1OSwxNS4xMjMsMjIuMjg3LDE1LDIyLDE1cy0wLjU2MSwwLjEyMy0wLjc1LDAuMzM5bC0yLjYwNCwyLjk1bC03Ljg5Ni04Ljk1ICAgQzEwLjU2LDkuMTIzLDEwLjI4Nyw5LDEwLDlTOS40NCw5LjEyMyw5LjI1LDkuMzM5TDYsMTMuMDg3VjVIMjZ6IE02LDE0LjZsNC00LjZsOC4wNjYsOS4xNDNsMC41OCwwLjY1OEwyMS40MDgsMjNINlYxNC42eiAgICBNMjIuNzQsMjNsLTMuNDI4LTMuOTU1TDIyLDE2bDQsNC4zNzlWMjNIMjIuNzR6IiBmaWxsPSIjMzMzMzMzIi8+PHBhdGggZD0iTTIwLDEzYzEuNjU2LDAsMy0xLjM0MywzLTNzLTEuMzQ0LTMtMy0zYy0xLjY1OCwwLTMsMS4zNDMtMywzUzE4LjM0MiwxMywyMCwxM3ogTTIwLDhjMS4xMDIsMCwyLDAuODk3LDIsMiAgIHMtMC44OTgsMi0yLDJjLTEuMTA0LDAtMi0wLjg5Ny0yLTJTMTguODk2LDgsMjAsOHoiIGZpbGw9IiMzMzMzMzMiLz48L2c+PC9zdmc+");
 }
+.thumbnail-container .tab-nav {
+  margin: 0.1em 0;
+}
 /* This is a masking container for the zoomed iframe element */
 .thumbnail {
-  -ms-zoom: 0.50;
-  -moz-transform: scale(0.50);
+  -ms-zoom: 1.0;
+  -moz-transform: scale(1.0);
   -moz-transform-origin: 0 0;
-  -o-transform: scale(0.50);
+  -o-transform: scale(1.0);
   -o-transform-origin: 0 0;
-  -webkit-transform: scale(0.50);
+  -webkit-transform: scale(1.0);
   -webkit-transform-origin: 0 0;
 }
 /* This is our screen sizing */
 .thumbnail,
 .thumbnail iframe {
-  width: 480px;
+  width: 360px;
   height: 1000px;
 }
 /* This facilitates the fade-in transition instead of flicker. It also helps us maintain the illusion that this is an image, since some webpages will have a preloading animation or wait for some images to download */

--- a/joplin/templates/wagtailadmin/pages/edit.html
+++ b/joplin/templates/wagtailadmin/pages/edit.html
@@ -30,4 +30,16 @@
     </div>
 
     {{ block.super }}
+
+    <div class="preview-container">
+        <div class="thumbnail-container">
+            <ul class="tab-nav">
+                <li><a>Preview</a></li>
+                <li class="active"><a>Style Guide</a></li>
+            </ul>
+            <div class="thumbnail">
+                <iframe frameborder="0" onload="this.style.opacity = 1" src="https://cityofaustin.github.io/digital-services-style-guide/introduction/"></iframe>
+            </div>
+        </div>
+    </div>
 {% endblock %}


### PR DESCRIPTION
I widened the constants that were previously being used so the tabs could fit and more content could fit on the screen. Unfortunately this blocks some of the controls for editing so we might have to play with how this fits together. This seems like an OK start.

Fixes cityofaustin/techstack#467

Here's how things currently look:
![styleguide](https://user-images.githubusercontent.com/272675/42719343-ab3c8f20-86d9-11e8-8523-226c9c959a13.gif)