### PR TITLE
Wire up Publish & Save Draft buttons

### DIFF
--- a/joplin/base/wagtail_hooks.py
+++ b/joplin/base/wagtail_hooks.py
@@ -29,7 +29,9 @@ def editor_css():
 
 @hooks.register('insert_global_admin_js')
 def global_admin_js():
-    urls = []
+    urls = [
+        static('js/admin.js'),
+    ]
 
     if settings.USE_ANALYTICS:
         urls.append(static('js/analytics.js'))
@@ -41,7 +43,7 @@ def global_admin_js():
 def editor_js():
     urls = [
         'https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.4/lodash.min.js',
-        static('js/admin.js'),
+        static('js/editor.js'),
     ]
 
     return format_html_join('\n', '<script src="{}"></script>', ((url,) for url in urls))

--- a/joplin/static/js/editor.js
+++ b/joplin/static/js/editor.js
@@ -1,0 +1,27 @@
+$(function() {
+
+  $('.js-proxy-click').click(function() {
+    let $this = $(this);
+    $this.text($this.data('clicked-text'));
+
+    let $button;
+
+    let proxyByName = $this.data('proxyByName');
+    if (proxyByName) {
+      $button = $(`[name="${proxyByName}"]`);
+    }
+
+    let proxyByClass = $this.data('proxyByClass');
+    if (proxyByClass) {
+      $button = $(`.${proxyByClass}`);
+    }
+
+    if (!$button) {
+      console.error(`Data attributes: ${$this.data()}`)
+      throw new Error('Unable to find a button. Did you specify data-proxy-by-name or data-proxy-by-class?');
+    }
+
+    $button.click();
+  });
+
+});

--- a/joplin/templates/base.html
+++ b/joplin/templates/base.html
@@ -34,9 +34,6 @@
 
         {% block content %}{% endblock %}
 
-        {# Global javascript #}
-        <script type="text/javascript" src="{% static 'js/joplin.js' %}"></script>
-
         {% block extra_js %}
             {# Override this in templates to add extra javascript #}
         {% endblock %}

--- a/joplin/templates/wagtailadmin/pages/edit.html
+++ b/joplin/templates/wagtailadmin/pages/edit.html
@@ -1,5 +1,8 @@
 {% extends "wagtailadmin/pages/edit.html" %}
 
+{% load i18n %}
+{% load wagtailadmin_tags %}
+
 {% block content %}
     <div class="header secondary">
         <div>
@@ -18,13 +21,18 @@
                 <div>See <a href="{% url 'wagtailadmin_pages:revisions_index' page.id %}" class="underlined">all revisions</a></div>
             </div>
             <div>
-                <button class="button icon icon-view secondary">Share</button>
+                {% auto_update_preview as auto_update %}
+                <button class="button action-preview icon icon-view secondary"
+                    data-action="{% url 'wagtailadmin_pages:preview_on_edit' page.id %}{% if mode %}?mode={{ mode|urlencode }}{% endif %}"
+                    data-auto-update="{{ auto_update|yesno:'true,false' }}">
+                    Preview
+                </button>
             </div>
             <div>
-                <button class="button icon icon-tick secondary">Save Draft</button>
+                <button class="button icon icon-tick secondary js-proxy-click" data-proxy-by-class="action-save">Save Draft</button>
             </div>
             <div>
-                <button class="button icon icon-doc-empty">Publish</button>
+                <button class="button button-longrunning icon icon-doc-empty js-proxy-click" data-clicked-text="{% trans 'Publishing…' %}" data-proxy-by-name="action-publish">Publish</button>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Because the current button placement doesn't allow me to put them inside the form to submit, I hooked up the new Publish & Save Draft buttons to just click the old buttons from hidden bottom bar. I also hooked up the Preview button to do what the old preview button does, but we'll want to change that to hook into the new preview flow once we've got that nailed down.

Here's everything in action:
![buttons](https://user-images.githubusercontent.com/272675/42719882-04e9ffcc-86e3-11e8-912e-b00a476ad0f5.gif)