### PR TITLE
seo fields in main content block and custom titles

### DIFF
--- a/joplin/base/models.py
+++ b/joplin/base/models.py
@@ -55,6 +55,13 @@ class ServicePage(Page):
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 
+    seo_panels = (
+        FieldPanel('slug'),
+        FieldPanel('seo_title'),
+        FieldPanel('show_in_menus'),
+        FieldPanel('search_description'),
+    )
+
     steps = RichTextField(features=WYSIWYG_FEATURES, verbose_name='Write out the steps a resident needs to take to use the service', blank=True)
     dynamic_content = StreamField(
         [
@@ -70,7 +77,9 @@ class ServicePage(Page):
         'base.Topic',
         on_delete=models.PROTECT,
         related_name='services',
+        verbose_name='Select a topic',
     )
+
     image = models.ForeignKey(TranslatedImage, null=True, blank=True, on_delete=models.SET_NULL, related_name='+', verbose_name='Choose an image for the service banner')
 
     parent_page_types = ['base.HomePage']
@@ -85,11 +94,12 @@ class ServicePage(Page):
         StreamFieldPanel('dynamic_content'),
         FieldPanel('additional_content'),
         InlinePanel('contacts', label='Contacts'),
+        MultiFieldPanel(seo_panels, heading='Search Engine Optimization', classname='seo_panels collapsible'),
     ]
 
     edit_handler = TabbedInterface([
         ObjectList(content_panels, heading='Content'),
-        ObjectList(Page.promote_panels, heading='Search Info'),
+        # ObjectList(Page.promote_panels, heading='Search Info'),
     ])
 
 

--- a/joplin/base/models.py
+++ b/joplin/base/models.py
@@ -102,6 +102,7 @@ class ServicePage(Page):
         # ObjectList(Page.promote_panels, heading='Search Info'),
     ])
 
+ServicePage._meta.get_field('title').verbose_name='Write an actionable title'
 
 class ProcessPage(Page):
     created_at = models.DateTimeField(auto_now_add=True)

--- a/joplin/js/editor.js
+++ b/joplin/js/editor.js
@@ -26,10 +26,10 @@ $(function() {
   for (const label of labels) {
     let id = label.getAttribute("for");
 
-    // HACK: I can't find a way to override this in python
-    if (id === "id_title") {
-      label.textContent = "Actionable Title";
-    }
+    // // HACK: I can't find a way to override this in python
+    // if (id === "id_title") {
+    //   label.textContent = "Actionable Title";
+    // }
 
     // HACK: If we're dealing with subheadings in steps we need to remove the index
     if (id && id.includes("id_process_steps")) {


### PR DESCRIPTION
This branch demonstrates how to update wagtail to 
1) have a verbose name for a default model field (title) and custom model field (topic)
![screen shot 2018-08-21 at 4 02 20 pm](https://user-images.githubusercontent.com/3039125/44433552-aa25a180-a55b-11e8-9d5f-4118907a2ba1.png)

2) have the SEO fields in the same panel as the primary content.
![seo_panel](https://user-images.githubusercontent.com/3039125/44429547-a50d2600-a54c-11e8-8afb-bb79963bffd4.gif)

It might make sense to extend the base Page class and build our models of the extended class so we don't have to do this for every page type. Something like ... but I don't know python well to say this is the right syntax

```
class COAPage(Page):
   created_at = models.DateTimeField(auto_now_add=True)
   updated_at = models.DateTimeField(auto_now=True)
   
   parent_page_types = ['base.HomePage']

   seo_panels = (
        FieldPanel('slug'),
        FieldPanel('seo_title'),
        FieldPanel('show_in_menus'),
        FieldPanel('search_description'),
    )
    content_panels = [ 
        MultiFieldPanel(seo_panels, heading='Search Engine Optimization', classname='seo_panels')
    ]
    ...

COAPage._meta.get_field('title').verbose_name='Write an actionable title'

class MyPage(COAPage):
    content_panels = super.content_panels + [ 
      ...
    ]

```