### PR TITLE
1964 account settings

### DIFF
--- a/joplin/css/admin.scss
+++ b/joplin/css/admin.scss
@@ -47,3 +47,13 @@
 .pagination {
   margin-top: $secondary-header-height * 3/2;
 }
+
+.account-link {
+  display: inherit;
+}
+
+.avatar {
+  img {
+    margin: auto 0px !important;
+  }
+}

--- a/joplin/templates/wagtailadmin/base.html
+++ b/joplin/templates/wagtailadmin/base.html
@@ -17,8 +17,10 @@
             />
         </div>
         <div class="actions coa-user-actions">
+            <a href="/admin/account/" class="account-link">
             <div class="avatar"><img src="{% avatar_url user %}" alt="avatar" /></div>
             <div class="user coa-user">{{ user }}</div>
+            </a>
             <a href="{% url 'wagtailadmin_logout' %}" class="icon icon-logout">Log out</a>
         </div>
     </div>


### PR DESCRIPTION
in order to fix the timezone issue from https://github.com/cityofaustin/techstack/issues/1964, we need to be able to change the timezone for a user. Instead of passing around a secret URL for this I've made the account avatar and email in the top right corner link to the account settings page