### PR TITLE
2181 user account controls

### DIFF
--- a/joplin/base/wagtail_hooks.py
+++ b/joplin/base/wagtail_hooks.py
@@ -41,6 +41,9 @@ def configure_main_menu(request, menu_items):
     locations_item = MenuItem('', "/admin/snippets/base/location/", classnames="icon icon-locations", order=900)
     new_items.append(locations_item)
 
+    manage_users_item = MenuItem('', "/admin/users/", classnames="icon icon-group", order=1000)
+    new_items.append(manage_users_item)
+
     for item in menu_items:
         if item.name in ('home', 'images'):
             item.label = ''

--- a/joplin/base/wagtail_hooks.py
+++ b/joplin/base/wagtail_hooks.py
@@ -41,6 +41,7 @@ def configure_main_menu(request, menu_items):
     locations_item = MenuItem('', "/admin/snippets/base/location/", classnames="icon icon-locations", order=900)
     new_items.append(locations_item)
 
+    # @TODO: make sure this only shows for admins
     manage_users_item = MenuItem('', "/admin/users/", classnames="icon icon-group", order=1000)
     new_items.append(manage_users_item)
 


### PR DESCRIPTION
Fixes https://github.com/cityofaustin/techstack/issues/2181

We have a redundant icon for now, mainly because:
For some reason we have to re-make individual icons for menu items instead of pulling them from wagtail admin? WTH?

Also, it would appear the way we are constructing the menu could use refactoring. 
As it says in the docs: 
> Adding menu items should generally be done through the register_admin_menu_item hook instead - items added through construct_main_menu will be missing any associated JavaScript includes, and their is_shown check will not be applied.
http://docs.wagtail.io/en/v2.5.1/reference/hooks.html

This may also mean refactoring some of the url stuff we have too. There is a lot of crustiness lying around...