### PR TITLE
1376 login case insensitive

### DIFF
--- a/joplin/users/models.py
+++ b/joplin/users/models.py
@@ -10,6 +10,13 @@ class UserManager(BaseUserManager):
 
     use_in_migrations = True
 
+    def get_by_natural_key(self, username):
+        return self.get(username__iexact = username)
+
+    # def get_by_natural_key(self, username):
+    #     case_insensitive_username_field = '{}__iexact'.format(self.model.USERNAME_FIELD)
+    #     return self.get(**{case_insensitive_username_field: username})
+
     def _create_user(self, email, password, **extra_fields):
         """Create and save a User with the given email and password."""
         if not email:

--- a/joplin/users/models.py
+++ b/joplin/users/models.py
@@ -10,7 +10,13 @@ class UserManager(BaseUserManager):
 
     use_in_migrations = True
 
+    
     def get_by_natural_key(self, email):
+        """ 
+        uses Django serializer to perform a case insensitive query
+        https://docs.djangoproject.com/en/2.2/topics/serialization/
+        https://docs.djangoproject.com/en/2.2/ref/models/querysets/#iexact
+        """
         return self.get(email__iexact = email)
 
     def _create_user(self, email, password, **extra_fields):

--- a/joplin/users/models.py
+++ b/joplin/users/models.py
@@ -10,12 +10,8 @@ class UserManager(BaseUserManager):
 
     use_in_migrations = True
 
-    def get_by_natural_key(self, username):
-        return self.get(username__iexact = username)
-
-    # def get_by_natural_key(self, username):
-    #     case_insensitive_username_field = '{}__iexact'.format(self.model.USERNAME_FIELD)
-    #     return self.get(**{case_insensitive_username_field: username})
+    def get_by_natural_key(self, email):
+        return self.get(email__iexact = email)
 
     def _create_user(self, email, password, **extra_fields):
         """Create and save a User with the given email and password."""


### PR DESCRIPTION
Fixes https://github.com/cityofaustin/techstack/issues/1376

@briaguya we may want to test this more eventually 

I'm using this: 
https://docs.djangoproject.com/en/2.2/ref/models/querysets/#iexact

This should work for now. But I'm not sure how we'd handle sign-up/registration of emails. We have a unique validator there, but I'm not sure if that validator is also case sensitive? Another route to go might be casting all emails to lower() when making accounts for people, etc. 
