### PR TITLE
re-write routes for styleguide pages

### DIFF
--- a/joplin/base/templatetags/joplin_tags.py
+++ b/joplin/base/templatetags/joplin_tags.py
@@ -22,7 +22,7 @@ STYLEGUIDE_PAGES = {
   'service page': '/pick-the-perfect-content-type/service-page',
   'process page': '/pick-the-perfect-content-type/process-page',
   'information page': '/pick-the-perfect-content-type/information-page',
-  'department page': '',
+  'department page': 'pick-the-perfect-content-type/department-page',
   'topic page': '',
   'topic collection page': '',
 }

--- a/joplin/base/templatetags/joplin_tags.py
+++ b/joplin/base/templatetags/joplin_tags.py
@@ -19,12 +19,12 @@ def get_revision_preview_url(*args, **kwargs):
     return os.environ["JANIS_URL"] + "/en/preview/" + url_page_type + "/" + global_id
 
 STYLEGUIDE_PAGES = {
-  'service page': '/writing-service-pages/',
-  'process page': '/writing-process-pages/',
-  'information page': '/writing-process-pages/',
-  'department page': '/writing-process-pages/',
-  'topic page': '/writing-process-pages/',
-  'topic collection page': '/writing-process-pages/',
+  'service page': '/pick-the-perfect-content-type/service-page',
+  'process page': '/pick-the-perfect-content-type/process-page',
+  'information page': '/pick-the-perfect-content-type/information-page',
+  'department page': '',
+  'topic page': '',
+  'topic collection page': '',
 }
 
 @register.simple_tag


### PR DESCRIPTION
related to https://github.com/cityofaustin/techstack/issues/2254 , this at least gets the right page loaded for each content type