### PR TITLE
prevent page breaking when adding content that belongs to a department

### DIFF
--- a/joplin/base/views/joplin_views.py
+++ b/joplin/base/views/joplin_views.py
@@ -45,9 +45,6 @@ def new_page_from_modal(request):
         print(body['type'])
 
         data = {}
-        if body['type'] != 'department' and body['type'] != 'topic':
-            if body['department'] != None:
-                data['department'] = DepartmentPage.objects.get(id=body['department'])
         data['title'] = body['title']
         data['owner'] = request.user
 


### PR DESCRIPTION
Ref: cityofaustin/techstack#2679