### PR TITLE
consolidate JanisBasePage and JanisPage into a single Abstract model

### DIFF
--- a/joplin/api/schema.py
+++ b/joplin/api/schema.py
@@ -11,7 +11,7 @@ from wagtail.core.models import Page, PageRevision
 from django_filters import FilterSet, OrderingFilter
 from wagtail.core.blocks import PageChooserBlock, TextBlock, ListBlock
 
-from base.models import TranslatedImage, ThreeOneOne, ServicePage, ServicePageContact, ServicePageTopic, ServicePageRelatedDepartments, InformationPageRelatedDepartments, ProcessPage, ProcessPageStep, ProcessPageContact, ProcessPageTopic, InformationPage, InformationPageContact, InformationPageTopic, DepartmentPage, DepartmentPageContact, DepartmentPageDirector, Theme, TopicCollectionPage, TopicPage, Contact, Location, ContactDayAndDuration, Department, DepartmentContact, TopicPageTopicCollection, OfficialDocumentPage, OfficialDocumentPageRelatedDepartments, OfficialDocumentPageTopic, OfficialDocumentPageOfficialDocument, GuidePage, GuidePageTopic, GuidePageRelatedDepartments, GuidePageContact, JanisPage
+from base.models import TranslatedImage, ThreeOneOne, ServicePage, ServicePageContact, ServicePageTopic, ServicePageRelatedDepartments, InformationPageRelatedDepartments, ProcessPage, ProcessPageStep, ProcessPageContact, ProcessPageTopic, InformationPage, InformationPageContact, InformationPageTopic, DepartmentPage, DepartmentPageContact, DepartmentPageDirector, Theme, TopicCollectionPage, TopicPage, Contact, Location, ContactDayAndDuration, Department, DepartmentContact, TopicPageTopicCollection, OfficialDocumentPage, OfficialDocumentPageRelatedDepartments, OfficialDocumentPageTopic, OfficialDocumentPageOfficialDocument, GuidePage, GuidePageTopic, GuidePageRelatedDepartments, GuidePageContact, JanisBasePage
 
 class StreamFieldType(Scalar):
     @staticmethod

--- a/joplin/base/models/__init__.py
+++ b/joplin/base/models/__init__.py
@@ -27,7 +27,7 @@ from .day_and_duration import DayAndDuration
 from .location import Location
 from .map import Map
 
-from .janis_page import JanisPage, JanisBasePage
+from .janis_page import JanisBasePage
 from .home_page import HomePage
 from .theme import Theme
 from .topic_collection_page import TopicCollectionPage
@@ -65,7 +65,7 @@ class ThreeOneOne(ClusterableModel):
         return self.title
 
 
-class ProcessPage(JanisPage):
+class ProcessPage(JanisBasePage):
     janis_url_page_type = "processes"
 
     department = models.ForeignKey(

--- a/joplin/base/models/department_page.py
+++ b/joplin/base/models/department_page.py
@@ -12,13 +12,13 @@ from wagtail.snippets.edit_handlers import SnippetChooserPanel
 
 from base.forms import DepartmentPageForm
 
-from .janis_page import JanisPage
+from .janis_page import JanisBasePage
 from .translated_image import TranslatedImage
 from .contact import Contact
 
 from .constants import DEFAULT_MAX_LENGTH, WYSIWYG_GENERAL
 
-class DepartmentPage(JanisPage):
+class DepartmentPage(JanisBasePage):
     janis_url_page_type = "department"
 
     def __str__(self):

--- a/joplin/base/models/guide_page.py
+++ b/joplin/base/models/guide_page.py
@@ -12,7 +12,7 @@ from wagtail.images.edit_handlers import ImageChooserPanel
 
 from base.forms import GuidePageForm
 
-from .janis_page import JanisPage
+from .janis_page import JanisBasePage
 from .information_page import InformationPage
 from .service_page import ServicePage
 from .contact import Contact
@@ -20,7 +20,7 @@ from .translated_image import TranslatedImage
 
 from .constants import WYSIWYG_GENERAL
 
-class GuidePage(JanisPage):
+class GuidePage(JanisBasePage):
     janis_url_page_type = "guide"
 
     description = models.TextField(blank=True, verbose_name='Write a description of the guide')

--- a/joplin/base/models/information_page.py
+++ b/joplin/base/models/information_page.py
@@ -10,12 +10,12 @@ from wagtail.snippets.edit_handlers import SnippetChooserPanel
 
 from base.forms import InformationPageForm
 
-from .janis_page import JanisPage
+from .janis_page import JanisBasePage
 from .contact import Contact
 
 from .constants import WYSIWYG_GENERAL
 
-class InformationPage(JanisPage):
+class InformationPage(JanisBasePage):
     janis_url_page_type = "information"
 
     description = models.TextField(blank=True, verbose_name='Write a description of this page')

--- a/joplin/base/models/janis_page.py
+++ b/joplin/base/models/janis_page.py
@@ -1,5 +1,6 @@
-import graphene
 import os
+import graphene
+
 
 from django.db import models
 
@@ -13,6 +14,15 @@ from wagtail.core.fields import RichTextField
 
 
 class JanisBasePage(Page):
+    """
+    This is base page class made for our pages to inherit from.
+    It is abstract, which for Django means that it isn't stored as it's own table
+    in the DB.
+    We use it to add functionality that we know will be desired by all other pages,
+    such as setting the preview fields and urls for janis stuff to make our headless
+    setup work smoothly
+    """
+
     parent_page_types = ['base.HomePage']
     subpage_types = []
     search_fields = Page.search_fields + [
@@ -47,7 +57,7 @@ class JanisBasePage(Page):
             if self.topiccollections and self.topiccollections.all():
                 theme_slug = self.topiccollections.all()[0].topiccollection.theme.slug;
                 tc_slug = self.topiccollections.all()[0].topiccollection.slug;
-                return os.environ["JANIS_URL"] + "/en/" + theme_slug + "/" + tc_slug + "/" + page_slug            
+                return os.environ["JANIS_URL"] + "/en/" + theme_slug + "/" + tc_slug + "/" + page_slug
 
 
         if self.janis_url_page_type == "services" or self.janis_url_page_type == "information":
@@ -90,11 +100,6 @@ class JanisBasePage(Page):
             "global_id": global_id
         }
 
-    class Meta:
-        abstract = True
-
-
-class JanisPage(JanisBasePage):
     @cached_classmethod
     def get_edit_handler(cls):
         if hasattr(cls, 'edit_handler'):

--- a/joplin/base/models/official_documents_page.py
+++ b/joplin/base/models/official_documents_page.py
@@ -8,7 +8,7 @@ from base.forms import OfficialDocumentPageForm
 from wagtail.admin.edit_handlers import FieldPanel, InlinePanel, MultiFieldPanel, PageChooserPanel
 from wagtail.core.models import Orderable
 
-from .janis_page import JanisPage
+from .janis_page import JanisBasePage
 
 from .constants import DEFAULT_MAX_LENGTH
 
@@ -18,7 +18,7 @@ This page can be assigned to multiple topics or departments.
 The Documents will be displayed in date descending order (newest first by the "date" field).
 Eventually the OfficialDocumentPageOfficialDocument should be replaced by a model using Wagtail Documents
 """
-class OfficialDocumentPage(JanisPage):
+class OfficialDocumentPage(JanisBasePage):
     janis_url_page_type = "official_document"
     base_form_class = OfficialDocumentPageForm
 

--- a/joplin/base/models/service_page.py
+++ b/joplin/base/models/service_page.py
@@ -11,13 +11,13 @@ from wagtail.snippets.edit_handlers import SnippetChooserPanel
 from base.blocks import SnippetChooserBlockWithAPIGoodness, WhatDoIDoWithBlock, CollectionScheduleBlock, RecollectBlock
 from base.forms import ServicePageForm
 
-from .janis_page import JanisPage
+from .janis_page import JanisBasePage
 from .contact import Contact
 
 from .constants import WYSIWYG_GENERAL, SHORT_DESCRIPTION_LENGTH
 WYSIWYG_SERVICE_STEP = ['ul', 'ol', 'link', 'code', 'rich-text-button-link']
 
-class ServicePage(JanisPage):
+class ServicePage(JanisBasePage):
     janis_url_page_type = "services"
 
     steps = StreamField(

--- a/joplin/base/models/topic_collection_page.py
+++ b/joplin/base/models/topic_collection_page.py
@@ -5,10 +5,10 @@ from wagtail.images.edit_handlers import ImageChooserPanel
 
 from base.forms import TopicCollectionPageForm
 
-from .janis_page import JanisPage
+from .janis_page import JanisBasePage
 from .translated_image import TranslatedImage
 
-class TopicCollectionPage(JanisPage):
+class TopicCollectionPage(JanisBasePage):
     janis_url_page_type = "topiccollection"
 
     description = models.TextField(blank=True)

--- a/joplin/base/models/topic_page.py
+++ b/joplin/base/models/topic_page.py
@@ -10,10 +10,10 @@ from wagtail.images.edit_handlers import ImageChooserPanel
 
 from base.forms import TopicPageForm
 
-from .janis_page import JanisPage
+from .janis_page import JanisBasePage
 from .translated_image import TranslatedImage
 
-class TopicPage(JanisPage):
+class TopicPage(JanisBasePage):
     janis_url_page_type = "topic"
 
     description = models.TextField(blank=True)


### PR DESCRIPTION
tested locally the backend and against a build of janis and nothing broke
since the model was abstract in the first place it dosent require a migration

https://austininnovation.slack.com/archives/G82KEHEQZ/p1565204354002600
Eric Sherman:chicago: 1:59 PM
@brian one question i did want to ask about code organization...i understand how we have the JanisBasePage inherit from the Page model, but any particualr reason why we have another point of inheritance from JanisBasePage to JanisPage? Couldn't we just add that method to JanisBasePage?
side-note, is that method even used/doing anything useful? it seemed related to the promote and search tabs which we dont even expose for a page
i'd love to either clean that up or document what the decision is there
Brian Smith 2:00 PM
I forget what exactly we needed the JanisBasePage vs JanisPage for
I know we had some fields on JanisPage that we didn't want everywhere so we needed JanisBasePage
it used to just be JanisPage for everything
I think it happened around DepartmentPage times
but I'm not sure how much they apply to our current models
Eric Sherman:chicago: 2:01 PM
but i think every page model inherits from JanisPage, which inherits from JanisBasePage anyways?
maybe ill try consolidating them and spin up a branch and see if anything breaks
