### PR TITLE
collect static into subfolders based on environment 

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -47,6 +47,8 @@ case "${DEPLOYMENT_MODE}" in
       load_backup_data
     else
       load_test_admin
+    echo "Collecting static files"
+    python ./joplin/manage.py collectstatic --noinput;
     fi
   ;;
   REVIEW)

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -48,18 +48,18 @@ case "${DEPLOYMENT_MODE}" in
     else
       load_test_admin
     echo "Collecting static files"
-    python ./joplin/manage.py collectstatic --noinput;
+    python ./joplin/manage.py collectstatic --noinput --verbosity 2;
     fi
   ;;
   REVIEW)
     load_backup_data
     # Let's try being reckless and doing that static thing here too.
     echo "Collecting static files"
-    python ./joplin/manage.py collectstatic --noinput;
+    python ./joplin/manage.py collectstatic --noinput --verbosity 2;
   ;;
   STAGING|PRODUCTION)
     echo "Collecting static files"
-    python ./joplin/manage.py collectstatic --noinput;
+    python ./joplin/manage.py collectstatic --noinput --verbosity 2;
   ;;
 esac
 

--- a/joplin/settings.py
+++ b/joplin/settings.py
@@ -128,6 +128,7 @@ DEPLOYMENT_MODE = os.environ.get('DEPLOYMENT_MODE', 'LOCAL')
 ISPRODUCTION = DEPLOYMENT_MODE == "PRODUCTION"
 ISSTAGING = DEPLOYMENT_MODE == "STAGING"
 ISREVIEWAPP = DEPLOYMENT_MODE == "REVIEW"
+ISLOCAL = DEPLOYMENT_MODE == "LOCAL"
 
 
 # Database
@@ -193,7 +194,7 @@ if ISPRODUCTION:
     STATIC_ROOT = os.path.join(BASE_DIR, 'static/production')
 if ISREVIEWAPP:
     STATIC_ROOT = os.path.join(BASE_DIR, 'static/reviewapp')
-else:
+if ISLOCAL:
     STATIC_ROOT = os.path.join(BASE_DIR, 'static/local')
 STATIC_URL = '/static/'
 

--- a/joplin/settings.py
+++ b/joplin/settings.py
@@ -186,7 +186,15 @@ WEBPACK_LOADER = {
 
 SMUGGLER_FIXTURE_DIR = os.path.join(BASE_DIR, 'joplin/db/smuggler')
 
-STATIC_ROOT = os.path.join(BASE_DIR, 'static')
+
+if ISSTAGING:
+    STATIC_ROOT = os.path.join(BASE_DIR, 'static/staging')
+if ISPRODUCTION:
+    STATIC_ROOT = os.path.join(BASE_DIR, 'static/production')
+if ISREVIEWAPP:
+    STATIC_ROOT = os.path.join(BASE_DIR, 'static/reviewapp')
+else:
+    STATIC_ROOT = os.path.join(BASE_DIR, 'static/local')
 STATIC_URL = '/static/'
 
 MEDIA_ROOT = os.path.join(BASE_DIR, 'media')

--- a/joplin/settings.py
+++ b/joplin/settings.py
@@ -77,7 +77,8 @@ INSTALLED_APPS = [
     'webpack_loader',
     'dbbackup',
     'smuggler',
-    'session_security'
+    'session_security',
+    'storages'
 ]
 
 MIDDLEWARE = [

--- a/joplin/settings.py
+++ b/joplin/settings.py
@@ -303,6 +303,8 @@ if(ISPRODUCTION or ISSTAGING or ISREVIEWAPP):
         STATICFILES_LOCATION = 'static/production'
     if ISREVIEWAPP:
         STATICFILES_LOCATION = 'static/reviewapp'
+    if ISREVIEWAPP:
+        STATICFILES_LOCATION = 'static/local'
     MEDIAFILES_LOCATION = 'media'
 
     # We now change the storage mode to S3 via Boto for default, static and dbbackup

--- a/joplin/settings.py
+++ b/joplin/settings.py
@@ -28,7 +28,8 @@ BASE_DIR = os.path.dirname(PROJECT_DIR)
 
 DEBUG = bool(strtobool(os.environ.get('DEBUG', str(False))))
 MODELTRANSLATION_DEBUG = DEBUG
-USE_ANALYTICS = bool(strtobool(os.environ.get('USE_ANALYTICS', str(not DEBUG))))
+USE_ANALYTICS = bool(
+    strtobool(os.environ.get('USE_ANALYTICS', str(not DEBUG))))
 
 
 # Application definition
@@ -155,13 +156,13 @@ SUPPORTED_LANGS = (
     'vi',
     'ar',
 )
-LANGUAGES = [lang for lang in global_settings.LANGUAGES if lang[0] in SUPPORTED_LANGS]
+LANGUAGES = [lang for lang in global_settings.LANGUAGES if lang[0]
+             in SUPPORTED_LANGS]
 
 TIME_ZONE = 'UTC'
 USE_TZ = True
 
 MODELTRANSLATION_DEFAULT_LANGUAGE = 'en'
-
 
 
 # Static files (CSS, JavaScript, Images)
@@ -250,7 +251,6 @@ DBBACKUP_CONNECTORS = {
 }
 
 
-
 #
 # Production, Staging & Review Apps
 #
@@ -287,7 +287,12 @@ if(ISPRODUCTION or ISSTAGING or ISREVIEWAPP):
     }
 
     # Specifying the location of files
-    STATICFILES_LOCATION = 'static'
+    if ISSTAGING:
+        STATICFILES_LOCATION = 'static/staging'
+    if ISPRODUCTION:
+        STATICFILES_LOCATION = 'static/production'
+    if ISREVIEWAPP:
+        STATICFILES_LOCATION = 'static/reviewapp'
     MEDIAFILES_LOCATION = 'media'
 
     # We now change the storage mode to S3 via Boto for default, static and dbbackup
@@ -295,7 +300,7 @@ if(ISPRODUCTION or ISSTAGING or ISREVIEWAPP):
     DEFAULT_FILE_STORAGE = 'custom_storages.MediaStorage'
     DBBACKUP_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
 
-JANIS_SLUG_URL=""
+JANIS_SLUG_URL = ""
 
 if ISPRODUCTION:
     JANIS_SLUG_URL = 'https://api.github.com/repos/cityofaustin/janis/tarball/production'
@@ -303,8 +308,8 @@ if ISPRODUCTION:
 if ISSTAGING:
     JANIS_SLUG_URL = 'https://api.github.com/repos/cityofaustin/janis/tarball/master'
 
-### security logout ward after half of expire value (four hours currently)
-SESSION_SECURITY_WARN_AFTER=14400/2
-SESSION_SECURITY_EXPIRE_AFTER=14400
+# security logout ward after half of expire value (four hours currently)
+SESSION_SECURITY_WARN_AFTER = 14400 / 2
+SESSION_SECURITY_EXPIRE_AFTER = 14400
 # lets us run timeout while staying logged in with closed browser tab (for now)
-SESSION_SECURITY_INSECURE=True
+SESSION_SECURITY_INSECURE = True


### PR DESCRIPTION
Ok, pretty sure this is working as intended!

Locally: 
Locally we can't build straight to s3 at the moment, we would want to implement a way to set the environment variables. I think this would be a good idea because I think it's could to have consistent behavior between all environments, but for now running `collectstatic` locally just pops in your local folder. 
On a Review App:
This gets kinda confusing becuase we have multple layers of deployment. But TL;DR: 
* review app stuff is collected under `static/reviewapp`, 
* but you will find it in the `joplin-austin-gov-prs3` bucket, which is different from production or staging.
* you can test this(I did) by ssh-ing in or running heroku console and running the collectstatic command. (Note: I upped the verbosity for this command because it will skip if the files haven't been modified and that was tripping me up/is good to have a note of)
* browse to [https://joplin-pr-try-static-folders.herokuapp.com/admin/pages/106/edit/]( https://joplin-pr-try-static-folders.herokuapp.com/admin/pages/106/edit/) , inspect the imported css, and you'll see it comes from the right bucket and path.
*obvi next step for this would be to put it in a subfolder based on the name of each branch
On Staging or Production:
* atm the AWS bucket is hard-coded in Heroku! That's not a big deal, but it would probably be nice to modify it so that behavior is consistent. 
* that being said, I would expect collectstatic to deposit their css in static/staging and static/production respectively, based on how it is working for my review app. Testing it in staging would be the next logical step from here. 
