### PR TITLE
no more s3 css

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,4 @@ media/*/*.jpeg
 *.log
 joplin/db/smuggler/*
 env.sh
-./staticfiles/
+/staticfiles/

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ media/*/*.jpeg
 *.log
 joplin/db/smuggler/*
 env.sh
+./staticfiles/

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -53,11 +53,11 @@ case "${DEPLOYMENT_MODE}" in
     load_backup_data
     # Let's try being reckless and doing that static thing here too.
     echo "Collecting static files"
-    python ./joplin/manage.py collectstatic --noinput;
+    python ./joplin/manage.py collectstatic --noinput --verbosity 2;
   ;;
   STAGING|PRODUCTION)
     echo "Collecting static files"
-    python ./joplin/manage.py collectstatic --noinput;
+    python ./joplin/manage.py collectstatic --noinput --verbosity 2;
   ;;
 esac
 

--- a/joplin/settings.py
+++ b/joplin/settings.py
@@ -28,7 +28,8 @@ BASE_DIR = os.path.dirname(PROJECT_DIR)
 
 DEBUG = bool(strtobool(os.environ.get('DEBUG', str(False))))
 MODELTRANSLATION_DEBUG = DEBUG
-USE_ANALYTICS = bool(strtobool(os.environ.get('USE_ANALYTICS', str(not DEBUG))))
+USE_ANALYTICS = bool(
+    strtobool(os.environ.get('USE_ANALYTICS', str(not DEBUG))))
 
 
 # Application definition
@@ -155,13 +156,13 @@ SUPPORTED_LANGS = (
     'vi',
     'ar',
 )
-LANGUAGES = [lang for lang in global_settings.LANGUAGES if lang[0] in SUPPORTED_LANGS]
+LANGUAGES = [lang for lang in global_settings.LANGUAGES if lang[0]
+             in SUPPORTED_LANGS]
 
 TIME_ZONE = 'UTC'
 USE_TZ = True
 
 MODELTRANSLATION_DEFAULT_LANGUAGE = 'en'
-
 
 
 # Static files (CSS, JavaScript, Images)
@@ -184,8 +185,8 @@ WEBPACK_LOADER = {
 }
 
 SMUGGLER_FIXTURE_DIR = os.path.join(BASE_DIR, 'joplin/db/smuggler')
-
-STATIC_ROOT = os.path.join(BASE_DIR, 'static')
+# The absolute path to the directory where collectstatic will collect static files for deployment.
+STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
 STATIC_URL = '/static/'
 
 MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
@@ -250,7 +251,6 @@ DBBACKUP_CONNECTORS = {
 }
 
 
-
 #
 # Production, Staging & Review Apps
 #
@@ -286,16 +286,15 @@ if(ISPRODUCTION or ISSTAGING or ISREVIEWAPP):
         'location': AWS_BACKUPS_LOCATION + "/" + APPLICATION_NAME
     }
 
-    # Specifying the location of files
+    # Specifying the location of files used for AWS s3
     STATICFILES_LOCATION = 'static'
     MEDIAFILES_LOCATION = 'media'
 
     # We now change the storage mode to S3 via Boto for default, static and dbbackup
-    STATICFILES_STORAGE = 'custom_storages.StaticStorage'
     DEFAULT_FILE_STORAGE = 'custom_storages.MediaStorage'
     DBBACKUP_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
 
-JANIS_SLUG_URL=""
+JANIS_SLUG_URL = ""
 
 if ISPRODUCTION:
     JANIS_SLUG_URL = 'https://api.github.com/repos/cityofaustin/janis/tarball/production'
@@ -303,8 +302,8 @@ if ISPRODUCTION:
 if ISSTAGING:
     JANIS_SLUG_URL = 'https://api.github.com/repos/cityofaustin/janis/tarball/master'
 
-### security logout ward after half of expire value (four hours currently)
-SESSION_SECURITY_WARN_AFTER=14400/2
-SESSION_SECURITY_EXPIRE_AFTER=14400
+# security logout ward after half of expire value (four hours currently)
+SESSION_SECURITY_WARN_AFTER = 14400 / 2
+SESSION_SECURITY_EXPIRE_AFTER = 14400
 # lets us run timeout while staying logged in with closed browser tab (for now)
-SESSION_SECURITY_INSECURE=True
+SESSION_SECURITY_INSECURE = True

--- a/joplin/settings.py
+++ b/joplin/settings.py
@@ -185,7 +185,7 @@ WEBPACK_LOADER = {
 }
 
 SMUGGLER_FIXTURE_DIR = os.path.join(BASE_DIR, 'joplin/db/smuggler')
-# The absolute path to the directory where collectstatic will collect static files for deployment.
+# The absolute path to the directory where django.contrib.staticfiles will collect static files for deployment.
 STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
 STATIC_URL = '/static/'
 
@@ -291,6 +291,7 @@ if(ISPRODUCTION or ISSTAGING or ISREVIEWAPP):
     MEDIAFILES_LOCATION = 'media'
 
     # We now change the storage mode to S3 via Boto for default, static and dbbackup
+    STATICFILE_STORAGE = 'django.contrib.staticfiles.storage.StaticFilesStorage'
     DEFAULT_FILE_STORAGE = 'custom_storages.MediaStorage'
     DBBACKUP_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
 


### PR DESCRIPTION
this may affect circleCI, but we probably want to leave the buckets in place for images
i changed the directoy to 'staticfiles' where the files are actually gathered to distinguish it
i added this directoy to .gitignore becuase I'm assuming it would be annoying to see diffs of changes to that folder and we run collectstatic as part of the build/deploy process