### PR TITLE
stylish

### DIFF
--- a/joplin/api/schema.py
+++ b/joplin/api/schema.py
@@ -230,7 +230,7 @@ class GuidePageSectionPageBlock(graphene.ObjectType):
         # TODO: don't catch everything
         try:
             service_page = ServicePage.objects.get(id=self.value)
-        except:
+        except BaseException:
             pass
             # print("Looks like this one isn't a service page")
 
@@ -241,7 +241,7 @@ class GuidePageSectionPageBlock(graphene.ObjectType):
         # TODO: don't catch everything
         try:
             information_page = InformationPage.objects.get(id=self.value)
-        except:
+        except BaseException:
             pass
             # print("Looks like this one isn't an info page")
 

--- a/joplin/base/forms.py
+++ b/joplin/base/forms.py
@@ -5,29 +5,36 @@ class ServicePageForm(WagtailAdminPageForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+
 class ProcessPageForm(WagtailAdminPageForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
 
 class InformationPageForm(WagtailAdminPageForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+
 class DepartmentPageForm(WagtailAdminPageForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
 
 class TopicPageForm(WagtailAdminPageForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+
 class TopicCollectionPageForm(WagtailAdminPageForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+
 class OfficialDocumentPageForm(WagtailAdminPageForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
 
 class GuidePageForm(WagtailAdminPageForm):
     def __init__(self, *args, **kwargs):

--- a/joplin/base/migrations/0033_auto_20180927_0500.py
+++ b/joplin/base/migrations/0033_auto_20180927_0500.py
@@ -4,6 +4,7 @@ from django.db import migrations
 from pprint import pprint
 from wagtail.core.blocks.stream_block import StreamValue
 
+
 def better_steps(apps, schema_editor):
     '''
     We can't import the models directly as they may be a newer
@@ -13,17 +14,17 @@ def better_steps(apps, schema_editor):
     ServicePageStep = apps.get_model('base', 'ServicePageStep')
 
     for page in ServicePage.objects.all():
-      pageSteps = []
-      for step in ServicePageStep.objects.all():
-        if step.page_id == page.id:
-          streamStep = {
-            'type': 'basic_step',
-            'value': step.step_description
-          }
-          pageSteps.append(streamStep)
-      stream_block = page.steps.stream_block
-      page.steps = StreamValue(stream_block, pageSteps, is_lazy=True)
-      page.save()
+        pageSteps = []
+        for step in ServicePageStep.objects.all():
+            if step.page_id == page.id:
+                streamStep = {
+                    'type': 'basic_step',
+                    'value': step.step_description
+                }
+                pageSteps.append(streamStep)
+        stream_block = page.steps.stream_block
+        page.steps = StreamValue(stream_block, pageSteps, is_lazy=True)
+        page.save()
 
 
 class Migration(migrations.Migration):

--- a/joplin/base/models/__init__.py
+++ b/joplin/base/models/__init__.py
@@ -48,7 +48,7 @@ SHORT_DESCRIPTION_LENGTH = 300
 class TopicCollectionPageTopicCollection(ClusterableModel):
     page = ParentalKey(TopicCollectionPage, related_name='topiccollections')
     topiccollection = models.ForeignKey(
-        'base.TopicCollectionPage',  verbose_name='Select a Topic Collection', related_name='+', on_delete=models.CASCADE)
+        'base.TopicCollectionPage', verbose_name='Select a Topic Collection', related_name='+', on_delete=models.CASCADE)
 
     panels = [
         PageChooserPanel('topiccollection'),
@@ -137,7 +137,7 @@ class ProcessPageContact(ClusterableModel):
 class ProcessPageTopic(ClusterableModel):
     page = ParentalKey(ProcessPage, related_name='topics')
     topic = models.ForeignKey(
-        'base.TopicPage',  verbose_name='Select a Topic', related_name='+', on_delete=models.CASCADE)
+        'base.TopicPage', verbose_name='Select a Topic', related_name='+', on_delete=models.CASCADE)
 
     panels = [
         PageChooserPanel('topic'),

--- a/joplin/base/models/day_and_duration.py
+++ b/joplin/base/models/day_and_duration.py
@@ -4,6 +4,7 @@ from modelcluster.models import ClusterableModel
 
 from wagtail.admin.edit_handlers import FieldPanel
 
+
 class DayAndDuration(ClusterableModel):
     MONDAY = 'Monday'
     TUESDAY = 'Tuesday'

--- a/joplin/base/models/department_page.py
+++ b/joplin/base/models/department_page.py
@@ -18,6 +18,7 @@ from .contact import Contact
 
 from .constants import DEFAULT_MAX_LENGTH, WYSIWYG_GENERAL
 
+
 class DepartmentPage(JanisBasePage):
     janis_url_page_type = "department"
 
@@ -84,6 +85,7 @@ class DepartmentPage(JanisBasePage):
         StreamFieldPanel('top_services'),
     ]
 
+
 class DepartmentPageDirector(Orderable):
     page = ParentalKey(DepartmentPage, related_name='department_directors')
     name = models.CharField(max_length=DEFAULT_MAX_LENGTH)
@@ -97,6 +99,7 @@ class DepartmentPageDirector(Orderable):
         ImageChooserPanel('photo'),
         FieldPanel('about'),
     ]
+
 
 class DepartmentPageContact(ClusterableModel):
     page = ParentalKey(DepartmentPage, related_name='contacts')

--- a/joplin/base/models/guide_page.py
+++ b/joplin/base/models/guide_page.py
@@ -20,6 +20,7 @@ from .translated_image import TranslatedImage
 
 from .constants import WYSIWYG_GENERAL
 
+
 class GuidePage(JanisBasePage):
     janis_url_page_type = "guide"
 
@@ -36,7 +37,7 @@ class GuidePage(JanisBasePage):
                 label="Section"
             )),
         ],
-        verbose_name='Add a section header and pages to each section', 
+        verbose_name='Add a section header and pages to each section',
         blank=True
     )
 
@@ -55,9 +56,10 @@ class GuidePage(JanisBasePage):
         InlinePanel('contacts', label='Contacts'),
     ]
 
+
 class GuidePageTopic(ClusterableModel):
     page = ParentalKey(GuidePage, related_name='topics')
-    topic = models.ForeignKey('base.TopicPage',  verbose_name='Select a Topic', related_name='+', on_delete=models.CASCADE)
+    topic = models.ForeignKey('base.TopicPage', verbose_name='Select a Topic', related_name='+', on_delete=models.CASCADE)
     toplink = models.BooleanField(default=False, verbose_name='Make this page a top link for this topic')
 
     panels = [
@@ -72,6 +74,7 @@ class GuidePageTopic(ClusterableModel):
     def __str__(self):
         return self.topic.text
 
+
 class GuidePageRelatedDepartments(ClusterableModel):
     page = ParentalKey(GuidePage, related_name='related_departments', default=None)
     related_department = models.ForeignKey(
@@ -84,6 +87,7 @@ class GuidePageRelatedDepartments(ClusterableModel):
         PageChooserPanel("related_department"),
     ]
 
+
 class GuidePageContact(ClusterableModel):
     page = ParentalKey(GuidePage, related_name='contacts')
     contact = models.ForeignKey(Contact, related_name='+', on_delete=models.CASCADE)
@@ -94,5 +98,3 @@ class GuidePageContact(ClusterableModel):
 
     def __str__(self):
         return self.contact.name
-
-

--- a/joplin/base/models/home_page.py
+++ b/joplin/base/models/home_page.py
@@ -4,6 +4,7 @@ from wagtail.core.models import Page
 
 from .translated_image import TranslatedImage
 
+
 class HomePage(Page):
     parent_page_types = []
     # subpage_types = ['base.ServicePage', 'base.ProcessPage', 'base.InformationPage', 'base.DepartmentPage']

--- a/joplin/base/models/information_page.py
+++ b/joplin/base/models/information_page.py
@@ -15,6 +15,7 @@ from .contact import Contact
 
 from .constants import WYSIWYG_GENERAL
 
+
 class InformationPage(JanisBasePage):
     janis_url_page_type = "information"
 
@@ -54,6 +55,7 @@ class InformationPage(JanisBasePage):
         InlinePanel('contacts', label='Contacts'),
     ]
 
+
 class InformationPageRelatedDepartments(ClusterableModel):
     page = ParentalKey(InformationPage, related_name='related_departments', default=None)
     related_department = models.ForeignKey(
@@ -66,6 +68,7 @@ class InformationPageRelatedDepartments(ClusterableModel):
         PageChooserPanel("related_department"),
     ]
 
+
 class InformationPageContact(ClusterableModel):
     page = ParentalKey(InformationPage, related_name='contacts')
     contact = models.ForeignKey(Contact, related_name='+', on_delete=models.CASCADE)
@@ -77,9 +80,10 @@ class InformationPageContact(ClusterableModel):
     def __str__(self):
         return self.contact.name
 
+
 class InformationPageTopic(ClusterableModel):
     page = ParentalKey(InformationPage, related_name='topics')
-    topic = models.ForeignKey('base.TopicPage',  verbose_name='Select a Topic', related_name='+', on_delete=models.CASCADE)
+    topic = models.ForeignKey('base.TopicPage', verbose_name='Select a Topic', related_name='+', on_delete=models.CASCADE)
     toplink = models.BooleanField(default=False, verbose_name='Make this page a top link for this topic')
 
     panels = [

--- a/joplin/base/models/location.py
+++ b/joplin/base/models/location.py
@@ -7,6 +7,7 @@ from wagtail.admin.edit_handlers import FieldPanel, MultiFieldPanel
 
 from .constants import DEFAULT_MAX_LENGTH
 
+
 @register_snippet
 class Location(ClusterableModel):
     TX = 'TX'

--- a/joplin/base/models/map.py
+++ b/joplin/base/models/map.py
@@ -4,6 +4,7 @@ from modelcluster.models import ClusterableModel
 
 from wagtail.snippets.models import register_snippet
 
+
 @register_snippet
 class Map(ClusterableModel):
     description = models.TextField()

--- a/joplin/base/models/official_documents_page.py
+++ b/joplin/base/models/official_documents_page.py
@@ -18,6 +18,8 @@ This page can be assigned to multiple topics or departments.
 The Documents will be displayed in date descending order (newest first by the "date" field).
 Eventually the OfficialDocumentPageOfficialDocument should be replaced by a model using Wagtail Documents
 """
+
+
 class OfficialDocumentPage(JanisBasePage):
     janis_url_page_type = "official_document"
     base_form_class = OfficialDocumentPageForm
@@ -35,10 +37,13 @@ class OfficialDocumentPage(JanisBasePage):
         InlinePanel('official_documents', label="Documents", heading="Entries will be listed by document date (newest first)."),
     ]
 
+
 """
 An OfficialDocumentPageOfficialDocument is an Official Document belonging to a single OfficialDocumentPage.
 One OfficialDocumentPage can have many OfficialDocumentPageOfficialDocuments.
 """
+
+
 class OfficialDocumentPageOfficialDocument(Orderable):
     page = ParentalKey(OfficialDocumentPage, related_name='official_documents')
     date = models.DateField(verbose_name="Document date", null=True)
@@ -75,7 +80,7 @@ class OfficialDocumentPageRelatedDepartments(ClusterableModel):
 
 class OfficialDocumentPageTopic(ClusterableModel):
     page = ParentalKey(OfficialDocumentPage, related_name='topics')
-    topic = models.ForeignKey('base.TopicPage',  verbose_name='Select a Topic', related_name='+', on_delete=models.CASCADE)
+    topic = models.ForeignKey('base.TopicPage', verbose_name='Select a Topic', related_name='+', on_delete=models.CASCADE)
     toplink = models.BooleanField(default=False, verbose_name='Make this list a top link for this topic')
 
     panels = [

--- a/joplin/base/models/service_page.py
+++ b/joplin/base/models/service_page.py
@@ -110,7 +110,7 @@ class ServicePage(JanisBasePage):
 class ServicePageTopic(ClusterableModel):
     page = ParentalKey(ServicePage, related_name='topics')
     topic = models.ForeignKey(
-        'base.TopicPage',  verbose_name='Select a Topic', related_name='+', on_delete=models.CASCADE)
+        'base.TopicPage', verbose_name='Select a Topic', related_name='+', on_delete=models.CASCADE)
     toplink = models.BooleanField(
         default=False, verbose_name='Make this service a top link for this topic')
 

--- a/joplin/base/models/theme.py
+++ b/joplin/base/models/theme.py
@@ -5,6 +5,7 @@ from modelcluster.models import ClusterableModel
 
 from .constants import DEFAULT_MAX_LENGTH
 
+
 @register_snippet
 class Theme(ClusterableModel):
     slug = models.SlugField()

--- a/joplin/base/models/topic_collection_page.py
+++ b/joplin/base/models/topic_collection_page.py
@@ -8,11 +8,11 @@ from base.forms import TopicCollectionPageForm
 from .janis_page import JanisBasePage
 from .translated_image import TranslatedImage
 
+
 class TopicCollectionPage(JanisBasePage):
     janis_url_page_type = "topiccollection"
 
     description = models.TextField(blank=True)
-
 
     theme = models.ForeignKey(
         'base.Theme',

--- a/joplin/base/models/topic_page.py
+++ b/joplin/base/models/topic_page.py
@@ -13,6 +13,7 @@ from base.forms import TopicPageForm
 from .janis_page import JanisBasePage
 from .translated_image import TranslatedImage
 
+
 class TopicPage(JanisBasePage):
     janis_url_page_type = "topic"
 
@@ -56,9 +57,10 @@ class TopicPage(JanisBasePage):
         InlinePanel('topiccollections', label='Topic Collections this page belongs to'),
     ]
 
+
 class TopicPageTopicCollection(ClusterableModel):
     page = ParentalKey(TopicPage, related_name='topiccollections')
-    topiccollection = models.ForeignKey('base.TopicCollectionPage',  verbose_name='Select a Topic Collection', related_name='+', on_delete=models.CASCADE)
+    topiccollection = models.ForeignKey('base.TopicCollectionPage', verbose_name='Select a Topic Collection', related_name='+', on_delete=models.CASCADE)
 
     panels = [
         PageChooserPanel('topiccollection'),

--- a/joplin/base/models/translated_image.py
+++ b/joplin/base/models/translated_image.py
@@ -2,6 +2,7 @@ from django.db import models
 
 from wagtail.images.models import AbstractImage, Image, AbstractRendition
 
+
 class TranslatedImage(AbstractImage):
     admin_form_fields = Image.admin_form_fields
 

--- a/joplin/base/signals.py
+++ b/joplin/base/signals.py
@@ -32,6 +32,7 @@ def generate_responsive_images(sender, **kwargs):
         logger.debug(f'Generating image rendition for {width}px')
         image.get_rendition(f'width-{width}')
 
+
 def create_build_aws(instance, publish=False, request=None):
     """
         Triggers a build in Amazon Elastic Container Service, it requires:
@@ -59,7 +60,7 @@ def create_build_aws(instance, publish=False, request=None):
     try:
         slack_message = "'%s' was %s by user: %s " % (instance.title, publish_action, request.user.email)
         print(slack_message)
-    except:
+    except BaseException:
         slack_message = ""
 
     logger.debug("create_build_aws() Message: " + slack_message)
@@ -68,15 +69,15 @@ def create_build_aws(instance, publish=False, request=None):
 
         # First we initialize our AWS handler (client)
         client = boto3.client(
-             'ecs',
-             aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
-             aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY
+            'ecs',
+            aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
+            aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY
         )
 
         # Now we request to run a container (task) on AWS ECS on Fargate
         response = client.run_task(
             cluster='janis-cluster',
-            taskDefinition=settings.AWS_ECS_TASK_DEFINITION, # ie. 'janis-worker:10'
+            taskDefinition=settings.AWS_ECS_TASK_DEFINITION,  # ie. 'janis-worker:10'
             launchType='FARGATE',
             count=1,
             platformVersion='LATEST',
@@ -94,15 +95,15 @@ def create_build_aws(instance, publish=False, request=None):
                         'environment': [
                             {
                                 'name': 'DEPLOYMENT_MODE',
-                                'value': settings.DEPLOYMENT_MODE # 'PRODUCTION' OR 'STAGING'
+                                'value': settings.DEPLOYMENT_MODE  # 'PRODUCTION' OR 'STAGING'
                             },
                             {
                                 'name': 'AWS_BUCKET_NAME',
-                                'value': settings.AWS_ECS_DEPLOYMENT_BUCKET # ie. 'janis-lab'
+                                'value': settings.AWS_ECS_DEPLOYMENT_BUCKET  # ie. 'janis-lab'
                             },
                             {
                                 'name': 'AWS_CF_DISTRO',
-                                'value': settings.AWS_CLOUDFRONT_DISTRIBUTION #'E455RV7LE5UVG'
+                                'value': settings.AWS_CLOUDFRONT_DISTRIBUTION  # 'E455RV7LE5UVG'
                             },
                             {
                                 'name': 'CMS_API',
@@ -189,12 +190,12 @@ def get_http_request():
 @receiver(page_published)
 def page_published_signal(sender, **kwargs):
     logger.debug(f'page_published {sender}')
-    #create_build_if_configured()
+    # create_build_if_configured()
     create_build_aws(kwargs['instance'], publish=True, request=get_http_request())
 
 
 @receiver(page_unpublished)
 def page_unpublished_signal(sender, **kwargs):
     logger.debug(f'page_unpublished {sender}')
-    #create_build_if_configured()
+    # create_build_if_configured()
     create_build_aws(kwargs['instance'], publish=False, request=get_http_request())

--- a/joplin/base/templatetags/joplin_tags.py
+++ b/joplin/base/templatetags/joplin_tags.py
@@ -9,6 +9,7 @@ import itertools
 
 register = template.Library()
 
+
 @register.simple_tag
 def get_revision_preview_url(*args, **kwargs):
     revision = kwargs['revision']
@@ -18,21 +19,24 @@ def get_revision_preview_url(*args, **kwargs):
     # TODO: Add other languages
     return os.environ["JANIS_URL"] + "/en/preview/" + url_page_type + "/" + global_id
 
+
 STYLEGUIDE_PAGES = {
-  'service page': '/pick-the-perfect-content-type/service-page',
-  'process page': '/pick-the-perfect-content-type/process-page',
-  'information page': '/pick-the-perfect-content-type/information-page',
-  'department page': 'pick-the-perfect-content-type/department-page',
-  'topic page': '',
-  'topic collection page': '',
-  'official document page': '',
-  'guide page': ''
+    'service page': '/pick-the-perfect-content-type/service-page',
+    'process page': '/pick-the-perfect-content-type/process-page',
+    'information page': '/pick-the-perfect-content-type/information-page',
+    'department page': 'pick-the-perfect-content-type/department-page',
+    'topic page': '',
+    'topic collection page': '',
+    'official document page': '',
+    'guide page': ''
 }
+
 
 @register.simple_tag
 def get_style_guide_url(*args, **kwargs):
-  content_type = kwargs['content_type'].name
-  return os.environ['STYLEGUIDE_URL'] + STYLEGUIDE_PAGES[content_type]
+    content_type = kwargs['content_type'].name
+    return os.environ['STYLEGUIDE_URL'] + STYLEGUIDE_PAGES[content_type]
+
 
 @register.inclusion_tag('wagtailadmin/themes_topics_tree.html', takes_context=True)
 def themes_topics_tree(context):
@@ -49,6 +53,7 @@ def themes_topics_tree(context):
     return {
         'themes': json.dumps(themes)
     }
+
 
 @register.inclusion_tag('wagtailadmin/departments_list.html', takes_context=True)
 def departments_list(context):

--- a/joplin/base/translation.py
+++ b/joplin/base/translation.py
@@ -30,6 +30,7 @@ class TopicPageTranslationOptions(TranslationOptions):
         'description',
     )
 
+
 @register(TopicCollectionPage)
 class TopicCollectionPageTranslationOptions(TranslationOptions):
     fields = (
@@ -64,6 +65,7 @@ class MapTranslationOptions(TranslationOptions):
 class HomePageTranslationOptions(TranslationOptions):
     pass
 
+
 @register(ServicePage)
 class ServicePageTranslationOptions(TranslationOptions):
     fields = (
@@ -72,11 +74,13 @@ class ServicePageTranslationOptions(TranslationOptions):
         'short_description',
     )
 
+
 @register(ProcessPage)
 class ProcessPageTranslationOptions(TranslationOptions):
     fields = (
         'description',
     )
+
 
 @register(ProcessPageStep)
 class ProcessPageStepTranslationOptions(TranslationOptions):
@@ -90,6 +94,7 @@ class ProcessPageStepTranslationOptions(TranslationOptions):
         'quote',
     )
 
+
 @register(DepartmentPage)
 class DepartmentPageTranslationOptions(TranslationOptions):
     fields = (
@@ -97,12 +102,14 @@ class DepartmentPageTranslationOptions(TranslationOptions):
         'mission',
     )
 
+
 @register(DepartmentPageDirector)
 class DepartmentPageDirectorTranslationOptions(TranslationOptions):
     fields = (
         'about',
         'title'
     )
+
 
 @register(InformationPage)
 class InformationPageTranslationOptions(TranslationOptions):
@@ -112,11 +119,13 @@ class InformationPageTranslationOptions(TranslationOptions):
         'additional_content',
     )
 
+
 @register(OfficialDocumentPage)
 class OfficialDocumentPageTranslationOptions(TranslationOptions):
     fields = (
         'description',
     )
+
 
 @register(OfficialDocumentPageOfficialDocument)
 class OfficialDocumentPageOfficialDocumentTranslationOptions(TranslationOptions):
@@ -126,6 +135,7 @@ class OfficialDocumentPageOfficialDocumentTranslationOptions(TranslationOptions)
         'name',
         'authoring_office'
     )
+
 
 @register(GuidePage)
 class GuidePageTranslationOptions(TranslationOptions):

--- a/joplin/base/views/joplin_views.py
+++ b/joplin/base/views/joplin_views.py
@@ -8,6 +8,7 @@ from django.urls import reverse
 from base.models import ServicePage, ProcessPage, InformationPage, TopicPage, TopicCollectionPage, DepartmentPage, Theme, OfficialDocumentPage, GuidePage
 import json
 
+
 def publish(request, page_id):
     page = get_object_or_404(Page, id=page_id).specific
 
@@ -34,6 +35,7 @@ def publish(request, page_id):
         'next': next_url,
     })
 
+
 def new_page_from_modal(request):
     user_perms = UserPagePermissionsProxy(request.user)
     if not user_perms.can_edit_pages():
@@ -58,7 +60,7 @@ def new_page_from_modal(request):
         if body['type'] == 'topic':
             page = TopicPage(**data)
         if body['type'] == 'topiccollection':
-            if body['theme'] != None:
+            if body['theme'] is not None:
                 data['theme'] = Theme.objects.get(id=body['theme'])
             page = TopicCollectionPage(**data)
         if body['type'] == 'department':
@@ -76,7 +78,7 @@ def new_page_from_modal(request):
 
         # Save our draft
         page.save_revision()
-        page.unpublish() # Not sure why it seems to go live by default
+        page.unpublish()  # Not sure why it seems to go live by default
 
         # Respond with the id of the new page
         response = HttpResponse(json.dumps({'id': page.id}), content_type="application/json")

--- a/joplin/base/wagtail_hooks.py
+++ b/joplin/base/wagtail_hooks.py
@@ -18,7 +18,6 @@ import wagtail.admin.rich_text.editors.draftail.features as draftail_features
 from wagtail.admin.rich_text.converters.html_to_contentstate import BlockElementHandler
 
 
-
 # Following this: https://docs.python.org/3/library/html.parser.html#examples
 class CheckForDataInHTMLParser(HTMLParser):
     has_data = False
@@ -48,35 +47,40 @@ def configure_main_menu(request, menu_items):
     Users: "account_circle"
     """
     menu_items[:] = [item for item in menu_items if item.name not in
-    # here were excluding some default generated menu items per UX
-        [
-        'explorer',
-        'documents',
-        'settings',
-        'snippets'
-        ]
-    ]
+                     # here were excluding some default generated menu items per UX
+                     [
+                         'explorer',
+                         'documents',
+                         'settings',
+                         'snippets'
+                     ]
+                     ]
 
     # replace wagtail icon with material-icons class to use that font
     for item in menu_items:
-            item.classnames = item.classnames.replace('icon ', 'material-icons ', 1)
+        item.classnames = item.classnames.replace('icon ', 'material-icons ', 1)
+
 
 @hooks.register('register_admin_menu_item')
 def register_page_list_menu_item():
     home = HomePage.objects.first()
     return MenuItem('Pages', reverse('wagtailadmin_explore', args=[home.pk]), classnames='icon icon-home', order=10)
 
+
 @hooks.register('register_admin_menu_item')
 def register_map_menu_item():
     return MenuItem('Maps', "/admin/snippets/base/map/", classnames='material-icons icon-maps', order=20)
+
 
 @hooks.register('register_admin_menu_item')
 def register_locations_menu_item():
     return MenuItem('Locations', "/admin/snippets/base/location/", classnames='material-icons icon-locations', order=30)
 
+
 @hooks.register('register_admin_menu_item')
 def register_contacts_menu_item():
     return MenuItem('Contacts', "/admin/snippets/base/contact/", classnames='material-icons icon-contacts', order=40)
+
 
 @hooks.register('register_admin_menu_item')
 def register_users_menu_item():
@@ -141,7 +145,7 @@ def joplin_page_listing_buttons(page, page_perms, is_parent=False):
             yield Button(
                 _('📝'),
                 'javascript:null;',
-                attrs={'title': _("Notes for authors entered"), 'class':'has-author-notes'},
+                attrs={'title': _("Notes for authors entered"), 'class': 'has-author-notes'},
                 priority=70
             )
 
@@ -199,7 +203,6 @@ def joplin_page_listing_more_buttons(page, page_perms, is_parent=False):
             reverse('wagtailadmin_pages:delete', args=[page.id]),
             attrs={'title': _("Delete page '{title}'").format(title=page.get_admin_display_title())},
         )
-
 
 
 @hooks.register('register_rich_text_features')

--- a/joplin/custom_storages.py
+++ b/joplin/custom_storages.py
@@ -1,9 +1,10 @@
 from django.conf import settings
 from storages.backends.s3boto3 import S3Boto3Storage
 
+
 class StaticStorage(S3Boto3Storage):
     location = settings.STATICFILES_LOCATION
 
+
 class MediaStorage(S3Boto3Storage):
     location = settings.MEDIAFILES_LOCATION
-

--- a/joplin/users/models.py
+++ b/joplin/users/models.py
@@ -10,14 +10,13 @@ class UserManager(BaseUserManager):
 
     use_in_migrations = True
 
-    
     def get_by_natural_key(self, email):
-        """ 
+        """
         uses Django serializer to perform a case insensitive query
         https://docs.djangoproject.com/en/2.2/topics/serialization/
         https://docs.djangoproject.com/en/2.2/ref/models/querysets/#iexact
         """
-        return self.get(email__iexact = email)
+        return self.get(email__iexact=email)
 
     def _create_user(self, email, password, **extra_fields):
         """Create and save a User with the given email and password."""


### PR DESCRIPTION
``` autopep8 -r --in-place --aggressive --aggressive ./ ```

Overall this makes code easier to read. 
It also preps us to be a better Open Source project by following standards. 
It also caught a couple code smells (instances using ``` except ``` without ``` Exception ``` or ``` BaseException```, which is a big no-no)