### PR TITLE
add official document pages as an option for top services on dept pages

### DIFF
--- a/joplin/api/schema.py
+++ b/joplin/api/schema.py
@@ -366,6 +366,7 @@ class DepartmentPageTopServiceNode(DjangoObjectType):
     service_page = graphene.Field(ServicePageNode)
     information_page = graphene.Field(InformationPageNode)
     guide_page = graphene.Field(GuidePageNode)
+    official_document_page = graphene.Field(OfficialDocumentPageNode)
 
     def resolve_service_page(self, info):
         service_page = None
@@ -396,6 +397,16 @@ class DepartmentPageTopServiceNode(DjangoObjectType):
             pass
 
         return guide_page
+
+    def resolve_official_document_page(self, info):
+        official_document_page = None
+        # TODO: don't catch everything
+        try:
+            official_document_page = OfficialDocumentPage.objects.get(id=self.page_id)
+        except Exception as e:
+            pass
+
+        return official_document_page
 
     class Meta:
         model = DepartmentPageTopService

--- a/joplin/base/models/department_page.py
+++ b/joplin/base/models/department_page.py
@@ -15,6 +15,7 @@ from .janis_page import JanisBasePage
 from .information_page import InformationPage
 from .service_page import ServicePage
 from .guide_page import GuidePage
+from .official_documents_page import OfficialDocumentPage
 from .translated_image import TranslatedImage
 from .contact import Contact
 from .widgets import countMe, countMeTextArea
@@ -107,7 +108,7 @@ class DepartmentPageTopService(Orderable):
     page = models.ForeignKey('wagtailcore.Page',  verbose_name='Select a page', related_name='+', on_delete=models.CASCADE)
 
     panels = [
-        PageChooserPanel('page', page_type=[InformationPage, ServicePage, GuidePage]),
+        PageChooserPanel('page', page_type=[InformationPage, ServicePage, GuidePage, OfficialDocumentPage]),
     ]
 
     def __str__(self):


### PR DESCRIPTION
This only covers a little bit of https://github.com/cityofaustin/techstack/issues/2855, but is required to ensure our OPO content doesn't need to change from what is currently in production.