### PR TITLE
Fixing typo and clearing logs

### DIFF
--- a/joplin/css/editor.scss
+++ b/joplin/css/editor.scss
@@ -69,6 +69,6 @@ label {
     width: 100% !important;
 }
 
-.coa-placeolder-elm {
+.coa-placeholder-elm {
   color: $coa-color-dark-gray2 !important;
 }

--- a/joplin/js/EditPage/richTextPlaceholder.js
+++ b/joplin/js/EditPage/richTextPlaceholder.js
@@ -12,7 +12,6 @@ export default function (){
   const callback = function(mutationsList) {
 
     for (let mutation of mutationsList) {
-      console.log("mutation :", mutation)
       if (mutation.type === 'childList') {
         let placeholder = mutation.target.querySelector('.public-DraftEditorPlaceholder-inner');
         if (placeholder) {
@@ -34,7 +33,7 @@ export default function (){
         parent.classList &&
         parent.classList.contains(wagtailFlaggedClassname)
       ) {
-         placeholder.classList.add("coa-placeolder-elm")
+         placeholder.classList.add("coa-placeholder-elm")
          placeholder.innerText = "Option description"
         break;
       }


### PR DESCRIPTION
This will remove some unnecessary logs as well as fix a small typo 
- "placeolder" 👉"placeholder" 👍