### PR TITLE
3035 pull request template

### DIFF
--- a/pull_request_guide.md
+++ b/pull_request_guide.md
@@ -1,0 +1,31 @@
+# Pull Request(PR) Guide, Resources and Checklists
+
+### PR Description
+
+Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Additionally, adding *types of changes* can be a helpful descriptor.
+
+##### Types of changes
+
+- Bug fix (non-breaking change which fixes an issue)
+- New feature (non-breaking change which adds functionality)
+- Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- This change requires a documentation update
+
+### Links
+
+Please provide links to related issues and PRs. Also, it may be relevant to provide links to resources and documentation used. Example: "I used the [MDN Wed Docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date)" on the date index...."
+
+### How Has This Been Tested?
+
+Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
+
+### Helpful Checklist:
+
+- [ ] I have performed a self-review of my own code
+- [ ] I've reviewed and removed logs and testing variables
+- [ ] I have commented my code in particularly hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+
+### Incomplete PRs.
+* Apply a [wip] label for other developers to help and review.

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -17,3 +17,4 @@ Fixes # (issue)
 # Checklist:
 - [ ] Request reviewers
 - [ ] Slack-out message for review
+- [ ] Moved card to *review* in zenhub

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -4,17 +4,17 @@
 
 Fixes # (issue)
 
-* (Issue Link)[]
-* (Janis Related Pull Request Link)[]
-* (Joplin Related Pull Request Link)[]
+* [Issue Link]()
+* [Janis Related Pull Request Link]()
 
 # Testing Notes
 
 ... how can this be tested ?
 
-* (Deployed at)[]
+* [Deployed Link]()
 
 # Checklist:
 - [ ] Request reviewers
 - [ ] Slack-out message for review
+- [ ] Link this PR in the issue
 - [ ] Moved card to *review* in zenhub

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,19 @@
+# Description
+
+... Please include a summary of the change and what it fixes.
+
+Fixes # (issue)
+
+* (Issue Link)[]
+* (Janis Related Pull Request Link)[]
+* (Joplin Related Pull Request Link)[]
+
+# Testing Notes
+
+... how can this be tested ?
+
+* (Deployed at)[]
+
+# Checklist:
+- [ ] Request reviewers
+- [ ] Slack-out message for review


### PR DESCRIPTION
# Description

This PR will make it so when we create a *new* PR the `pull_request_template.md` will be *automatically* placed in the description field (ie, *this* field). Yes, this is a very *Meta* PR...🤓.
- See the [markdown file](https://github.com/cityofaustin/joplin/blob/d2bfa2f3de718870b7c456a7b38737d06c7ae24d/pull_request_template.md) to view what would currently be the default template, as an outline. 
- Also, this is just a rough-draft, and I suspect maybe y'all will have things you'd like to add and remove. 
- OR, maybe the auto-fill outline isn't want we want🤷‍♂️. And, that's ok.
- I also created `pull_request_guide.md`, which is a more traditional markdown that is mainly used as a PR resource. Nothing automated there.  

Fixes #3025

* [Issue Link](https://github.com/cityofaustin/techstack/issues/3035)
* [TBD: Janis Related Pull Request Link]()

# Testing Notes

Oddly Enough... we won't be able to truly test this until we merge it into master and create a new PR. What a catch 22 that is!

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Moved card to *review* in zenhub
- [ ] Create Duplicate for "Janis"(WARN: swap joplin to janis where needed)