### PR TITLE
comment out info page options

### DIFF
--- a/joplin/base/models/information_page.py
+++ b/joplin/base/models/information_page.py
@@ -52,7 +52,7 @@ class InformationPage(JanisBasePage):
         InlinePanel('topics', label='Topics'),
         InlinePanel('related_departments', label='Related Departments'),
         FieldPanel('description', widget=countMeTextArea),
-        StreamFieldPanel('options'),
+        # StreamFieldPanel('options'),
         FieldPanel('additional_content'),
         InlinePanel('contacts', label='Contacts'),
     ]


### PR DESCRIPTION
# Description

Hide options from info pages until we decide if/how we're using it

Fixes # (issue)

https://github.com/cityofaustin/techstack/issues/3072