### PR TITLE
Hide flashing text

### DIFF
--- a/joplin/templates/wagtailadmin/edit_handlers/tabbed_interface.html
+++ b/joplin/templates/wagtailadmin/edit_handlers/tabbed_interface.html
@@ -6,7 +6,7 @@
             <a href="#tab-{{ child.heading|cautious_slugify }}" class="{% if forloop.first %}active {% endif %}">
               {% if forloop.first %}
               <div class="content-tab">
-              {{ child.heading }}
+                English
               </div>
               <div id="language-select-wrapper" class="field choice_field select coa-language-select-wrapper">
                   <div class="field-content">


### PR DESCRIPTION
based on this note: https://github.com/cityofaustin/techstack/issues/2827#issuecomment-537265221

"No flash of "content" in the tab before it changes to "English" - this is just a band aid over what should be addressed in https://github.com/cityofaustin/techstack/issues/3081, but it gets us closer to pushing this 2827.