### PR TITLE
Fixed height fix for layout

### DIFF
--- a/joplin/css/layouts/headers.scss
+++ b/joplin/css/layouts/headers.scss
@@ -21,6 +21,7 @@
     width: calc(100% - #{$nav-wrapper-width});
     background: $coa-color-gray;
     position: fixed;
+    height: 80px;
     padding: 1rem 1.5rem;
     z-index: 3;
     display: flex;
@@ -44,8 +45,7 @@
     position: fixed;
     z-index: 30;
     display: flex;
-    top: 175px;
-    padding-left: 1rem ;
+    top: $edit-page-tab-bar-top;
+    padding-left: 1rem;
     height: 40px;
-
 }

--- a/joplin/css/pages/edit.scss
+++ b/joplin/css/pages/edit.scss
@@ -73,7 +73,7 @@
 
 .tab-nav {
     position: fixed;
-    top: 175px;
+    top: $edit-page-tab-bar-top;
     border-top: none;
     color: black;
     height: 40px;

--- a/joplin/css/preview.scss
+++ b/joplin/css/preview.scss
@@ -1,6 +1,6 @@
 @import './variables';
 
-$flexcontainer-margin: 135px;
+$flexcontainer-margin: 150px;
 $preview-height: calc(100vh - #{$flexcontainer-margin});
 $fixedcontent-width: 375px;
 $sidebar-width: 377px;

--- a/joplin/css/variables.scss
+++ b/joplin/css/variables.scss
@@ -22,3 +22,5 @@ $coa-color-white: #FFFFFF;
 $nav-wrapper-width: 140px;
 $header-height: 89px;
 $secondary-header-height: 100px;
+
+$edit-page-tab-bar-top: 200px;

--- a/joplin/css/variables.scss
+++ b/joplin/css/variables.scss
@@ -21,6 +21,6 @@ $coa-color-white: #FFFFFF;
 
 $nav-wrapper-width: 140px;
 $header-height: 89px;
-$secondary-header-height: 100px;
+$secondary-header-height: 112px;
 
 $edit-page-tab-bar-top: 200px;


### PR DESCRIPTION
based on this note: https://github.com/cityofaustin/techstack/issues/2827#issuecomment-537265221

"When page title breaks to two lines, the tab row still displays as expected"

This just used a fixed height for the header to avoid odd rearrangement issues. This should not be considered a permanent fix