### PR TITLE
fix redirect to search home page

### DIFF
--- a/joplin/base/views/joplin_search_views.py
+++ b/joplin/base/views/joplin_search_views.py
@@ -5,6 +5,11 @@ from django.core.paginator import Paginator
 from wagtail.core.models import Page
 from wagtail.search.query import MATCH_ALL
 from wagtail.admin.forms.search import SearchForm
+from wagtail.admin.utils import user_has_any_page_permission
+# wagtail.admin.utils.user_passes_test does not redirect to settings.LOGIN_URL
+# So we must use django.contrib.auth.decorators.user_passes_test
+from django.contrib.auth.decorators import user_passes_test
+from django.views.decorators.vary import vary_on_headers
 
 """
  Joplin Note:
@@ -16,10 +21,10 @@ from wagtail.admin.forms.search import SearchForm
  - we 'run' the query as soon as you visit the page (before any search),
    so we can populate it with summary counts and sort stuff
  - excluding certain pages from the pages to query
-
 """
 
-
+@vary_on_headers('X-Requested-With')
+@user_passes_test(user_has_any_page_permission)
 def search(request):
     # excluding Root(1) and Home(3) pages from search
     pages = all_pages = Page.objects.all().exclude(id__in=[1, 3]).prefetch_related('content_type').specific()

--- a/joplin/settings.py
+++ b/joplin/settings.py
@@ -390,3 +390,8 @@ if ISLOCAL:
     CMS_API = f"http://localhost:{os.getenv('JOPLIN_APP_HOST_PORT')}/api/graphql"
 else:
     CMS_API = f"https://{os.getenv('APPLICATION_NAME','')}.herokuapp.com/api/graphql"
+
+
+# Sets the login_url redirect for "from django.contrib.auth.decorators import user_passes_test"
+# https://kite.com/python/docs/django.contrib.auth.decorators.user_passes_test
+LOGIN_URL = '/admin/login/'


### PR DESCRIPTION
# Description

When we go to /admin or /admin/pages/search/ it'll now redirect us back to the login page if we're not properly authenticated.

# Fixes

* [Issue 3351](https://github.com/cityofaustin/techstack/issues/3351)
* And incidentally happens to fix [3339](https://github.com/cityofaustin/techstack/issues/3339)

# Testing Notes

- Go to https://joplin-pr-3351-login.herokuapp.com/admin. See that you are redirected to the login page rather than the zombie search page.
- Go to https://joplin-pr-3351-login.herokuapp.com/admin/pages/search. See that you are redirected to the login page rather than the zombie search page (this was the actual cause of the bug).

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
