### PR TITLE
3363 Main search alert & styling fixes

### DIFF
--- a/joplin/base/views/joplin_search_views.py
+++ b/joplin/base/views/joplin_search_views.py
@@ -94,7 +94,7 @@ def search(request):
         return render(request, "wagtailadmin/pages/search_results.html", {
             'pages': pages,
             'all_pages': all_pages,
-            'query_string': q,
+            'query_string': query,
             'content_types': content_types,
             'selected_content_type': selected_content_type,
             'ordering': ordering,

--- a/joplin/css/layouts/headers.scss
+++ b/joplin/css/layouts/headers.scss
@@ -48,9 +48,24 @@
   height: 40px !important;
 }
 
-.coa-nav-search li {
-  margin: 0px !important;
-  padding: 0px !important;
+.nav-search li {
+  margin: 0px;
+  padding: 0px;
+  list-style-type: none;
+}
+
+.icon-search:before {
+  margin-top: 5px !important;
+  color: #777 !important;
+}
+
+.icon-search input {
+  color: #262626 !important;
+  background-color: hsla(0,0%,39%,.15) !important;
+}
+
+.icon-search input::placeholder {
+  color: #aaa !important;
 }
 
 .listing-filter {

--- a/joplin/css/layouts/headers.scss
+++ b/joplin/css/layouts/headers.scss
@@ -48,6 +48,11 @@
   height: 40px !important;
 }
 
+.coa-nav-search li {
+  margin: 0px !important;
+  padding: 0px !important;
+}
+
 .listing-filter {
   margin: 0 !important;
   padding: 20px !important;

--- a/joplin/templates/wagtailadmin/pages/search_header.html
+++ b/joplin/templates/wagtailadmin/pages/search_header.html
@@ -12,11 +12,15 @@
         <!-- From wagtail/admin/templates/wagtailadmin/shared/menu_search.html -->
         {% if search_url %}
             <form class="col search-form nav-search" action="{% url search_url %}{% if query_parameters %}?{{ query_parameters }}{% endif %}" method="get" novalidate>
-                <ul class="fields">
+            <!-- <form class="col search-form nav-search" action="{% url search_url %}{% if query_parameters %}?{{ query_parameters }}{% endif %}" method="get" novalidate> -->
+                <ul class="fields coa-nav-search">
                     {% for field in search_form %}
                         {% include "wagtailadmin/shared/field_as_li.html" with field=field field_classes="field-small iconfield" input_classes="icon-search" %}
                     {% endfor %}
-                    <li class="submit visuallyhidden"><input type="submit" value="Search" class="button" /></li>
+                    <!-- 👀 BOB you noted this out to fixe hidden element blocking content_type -->
+                    <!-- <li class="submit visuallyhidden">
+                      <input type="submit" value="Search" class="button" />
+                    </li> -->
                 </ul>
             </form>
         {% endif %}

--- a/joplin/templates/wagtailadmin/pages/search_header.html
+++ b/joplin/templates/wagtailadmin/pages/search_header.html
@@ -11,26 +11,12 @@
     <div>
         <!-- From wagtail/admin/templates/wagtailadmin/shared/menu_search.html -->
         {% if search_url %}
-            <form class="col search-form nav-search" action="{% url search_url %}{% if query_parameters %}?{{ query_parameters }}{% endif %}" method="get" novalidate>
-            <!-- <form class="col search-form nav-search" action="{% url search_url %}{% if query_parameters %}?{{ query_parameters }}{% endif %}" method="get" novalidate> -->
-                <ul class="fields coa-nav-search">
-                    {% for field in search_form %}
-                        {% include "wagtailadmin/shared/field_as_li.html" with field=field field_classes="field-small iconfield" input_classes="icon-search" %}
-                    {% endfor %}
-                    <!-- 👀 BOB you noted this out to fixe hidden element blocking content_type -->
-                    <!-- <li class="submit visuallyhidden">
-                      <input type="submit" value="Search" class="button" />
-                    </li> -->
-                </ul>
-            </form>
-        {% endif %}
-        <!-- <form class="nav-search" action="{% url 'wagtailadmin_pages:search' %}" method="get">
-            <div>
-                <label for="menu-search-q">{% trans "Search" %}</label>
-                <input type="text" id="menu-search-q" name="q" placeholder="{% trans 'Search' %}" />
-                <button class="button" type="submit">{% trans "Search" %}</button>
+            <div class="col search-form nav-search">
+                {% for field in search_form %}
+                    {% include "wagtailadmin/shared/field_as_li.html" with field=field field_classes="field-small iconfield" input_classes="icon-search" %}
+                {% endfor %}
             </div>
-        </form> -->
+        {% endif %}
     </div>
 
     <div class="actions">

--- a/joplin/templates/wagtailadmin/pages/search_results.html
+++ b/joplin/templates/wagtailadmin/pages/search_results.html
@@ -33,7 +33,17 @@
                       {% if content_type == selected_content_type %}
                           <li style="background-color: #E6E6E6">{{ content_type.model_class.get_verbose_name }} ({{ count }})</li>
                       {% else %}
-                          <li><a href="{% url 'wagtailadmin_pages:search' %}?q={{ query_string|urlencode }}&amp;content_type={{ content_type.app_label }}.{{ content_type.model|lower }}">{{ content_type.model_class.get_verbose_name }} ({{ count }})</a></li>
+                          <li>
+                            <!-- <form class="col search-form nav-search" action="?q={{ query_string|urlencode }}&amp;content_type={{ content_type.app_label }}.{{ content_type.model|lower }}" method="get" novalidate>
+                              <button type="submit">
+
+                                {{ content_type.model_class.get_verbose_name }} ({{ count }})
+                              </button>
+                            </form> -->
+                            <a href="{% url 'wagtailadmin_pages:search' %}?q={{ query_string|urlencode }}&amp;content_type={{ content_type.app_label }}.{{ content_type.model|lower }}">
+                              {{ content_type.model_class.get_verbose_name }} ({{ count }})
+                            </a>
+                          </li>
                       {% endif %}
                   {% endfor %}
               </ul>

--- a/joplin/templates/wagtailadmin/pages/search_results.html
+++ b/joplin/templates/wagtailadmin/pages/search_results.html
@@ -33,17 +33,7 @@
                       {% if content_type == selected_content_type %}
                           <li style="background-color: #E6E6E6">{{ content_type.model_class.get_verbose_name }} ({{ count }})</li>
                       {% else %}
-                          <li>
-                            <!-- <form class="col search-form nav-search" action="?q={{ query_string|urlencode }}&amp;content_type={{ content_type.app_label }}.{{ content_type.model|lower }}" method="get" novalidate>
-                              <button type="submit">
-
-                                {{ content_type.model_class.get_verbose_name }} ({{ count }})
-                              </button>
-                            </form> -->
-                            <a href="{% url 'wagtailadmin_pages:search' %}?q={{ query_string|urlencode }}&amp;content_type={{ content_type.app_label }}.{{ content_type.model|lower }}">
-                              {{ content_type.model_class.get_verbose_name }} ({{ count }})
-                            </a>
-                          </li>
+                          <li><a href="{% url 'wagtailadmin_pages:search' %}?q={{ query_string|urlencode }}&amp;content_type={{ content_type.app_label }}.{{ content_type.model|lower }}">{{ content_type.model_class.get_verbose_name }} ({{ count }})</a></li>
                       {% endif %}
                   {% endfor %}
               </ul>

--- a/joplin/templates/wagtailadmin/shared/field.html
+++ b/joplin/templates/wagtailadmin/shared/field.html
@@ -1,0 +1,21 @@
+<!--
+Joplin edited from Original file: https://github.com/wagtail/wagtail/blob/master/wagtail/admin/templates/wagtailadmin/shared/field.html
+-->
+{% load wagtailadmin_tags %}
+<div class="field {{ field|fieldtype }} {{ field|widgettype }} {{ field_classes }}">
+    {% if show_label|default_if_none:True %}{{ field.label_tag }}{% endif %}
+    <div class="field-content">
+        <div class="input {{ input_classes }} ">
+            {% block form_field %}
+                {{ field|render_with_errors }}
+            {% endblock %}
+
+            {# This span only used on rare occasions by certain types of input #}
+            <span></span>
+        </div>
+        {% if show_help_text|default_if_none:True and field.help_text %}
+            <p class="help">{{ field.help_text }}</p>
+        {% endif %}
+
+    </div>
+</div>

--- a/joplin/templates/wagtailadmin/shared/field.html
+++ b/joplin/templates/wagtailadmin/shared/field.html
@@ -1,9 +1,6 @@
 <!--
 Joplin edited from Original file: https://github.com/wagtail/wagtail/blob/master/wagtail/admin/templates/wagtailadmin/shared/field.html
-<<<<<<< HEAD
-=======
-- We extended it here to modify the error messages out of display. 
->>>>>>> master
+- We extended it here to modify the error messages out of display.
 -->
 {% load wagtailadmin_tags %}
 <div class="field {{ field|fieldtype }} {{ field|widgettype }} {{ field_classes }}">
@@ -20,9 +17,5 @@ Joplin edited from Original file: https://github.com/wagtail/wagtail/blob/master
         {% if show_help_text|default_if_none:True and field.help_text %}
             <p class="help">{{ field.help_text }}</p>
         {% endif %}
-<<<<<<< HEAD
-
-=======
->>>>>>> master
     </div>
 </div>


### PR DESCRIPTION
# Description

Issue: https://github.com/cityofaustin/techstack/issues/3363

Styling 

* [x] Styling for search box isn't centered. 
* [x] The header is covering part of the content_types as a transparent padding. 
* [x] Make Search Icon and font color fixed until design can give feedback/set style

<img width="589" alt="Click search box after typing" src="https://user-images.githubusercontent.com/15821138/68125365-12e60900-fed7-11e9-95bd-976888f57c8d.png">
<img width="615" alt="Initial" src="https://user-images.githubusercontent.com/15821138/68125411-31e49b00-fed7-11e9-9c61-f37e54549de9.png">

Behavior Issues

* [x] No search + content_type = "This field is required." error
* [x] Search by Autocompolete (don't hit enter) click content_type filter, see error.
  * "Changes you made may not be saved"

<img width="1169" alt="Search style fix" src="https://user-images.githubusercontent.com/15821138/68125451-488af200-fed7-11e9-9ca2-353929c6a970.png">

# Testing Notes

... Search for something by typing into search box 
- the page should update while you type (no need to hit enter or select a "search" icon.

Now, with the search results return, filter by content types
- The content type should now be filtered without an error message or alert. 

* [Deployed Link](https://joplin-pr-search-fixes.herokuapp.com/admin/pages/search/)

# Checklist:
- [x] Request reviewers
- [x] Slack-out message for review