### PR TITLE
3371 - Add embed to WYSIWYG_GENERAL

### DIFF
--- a/joplin/base/models/__init__.py
+++ b/joplin/base/models/__init__.py
@@ -26,6 +26,7 @@ from .contact import Contact, ContactDayAndDuration, PhoneNumber
 from .day_and_duration import DayAndDuration
 from .location import Location
 from .map import Map
+from .constants import WYSIWYG_GENERAL, DEFAULT_MAX_LENGTH, SHORT_DESCRIPTION_LENGTH
 
 from .janis_page import JanisBasePage
 from .home_page import HomePage
@@ -40,10 +41,6 @@ from .guide_page import GuidePage, GuidePageTopic, GuidePageRelatedDepartments, 
 from .form_page import FormPage, FormPageRelatedDepartments, FormPageTopic
 from .widgets import countMe, countMeTextArea
 from .site_settings import JanisBranchSettings
-
-WYSIWYG_GENERAL = ['h1', 'h2', 'h3', 'h4', 'bold', 'link', 'ul', 'ol', 'code']
-DEFAULT_MAX_LENGTH = 255
-SHORT_DESCRIPTION_LENGTH = 300
 
 # TODO: Remove everything below this comment
 

--- a/joplin/base/models/constants.py
+++ b/joplin/base/models/constants.py
@@ -1,3 +1,3 @@
-WYSIWYG_GENERAL = ['h2', 'h3', 'h4', 'bold', 'link', 'ul', 'ol', 'code']
+WYSIWYG_GENERAL = ['h2', 'h3', 'h4', 'bold', 'link', 'ul', 'ol', 'code', 'embed']
 SHORT_DESCRIPTION_LENGTH = 300
 DEFAULT_MAX_LENGTH = 255


### PR DESCRIPTION
# Description
Now we can embed videos

Part of https://github.com/cityofaustin/techstack/issues/3371

Janis PR: https://github.com/cityofaustin/janis/pull/611
Janis App: https://janis-3371-video-embeds.netlify.com/en/health-safety/health-records-certificates-2/birth-death-certificates/video/

# Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How can this be tested?
Go to http://joplin-pr-3371-video-embeds.herokuapp.com/admin/pages/265/edit/#tab-content and see that adding a video works on https://janis-3371-video-embeds.netlify.com/en/health-safety/health-records-certificates-2/birth-death-certificates/video/
# Checklist:
- [x] Request reviewers
- [ ] Slack-out message for review
- [x] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
