### PR TITLE
3535 - location pages - api changes

### DIFF
--- a/joplin/api/content_type_map.py
+++ b/joplin/api/content_type_map.py
@@ -3,7 +3,11 @@ from base.models import (
     InformationPage,
     OfficialDocumentPage,
     GuidePage,
-    FormContainer,
+    FormContainer
+)
+
+from locations.models import (
+    LocationPage
 )
 
 # Gain access to a content_type's node and model if you have it's name.
@@ -29,4 +33,8 @@ content_type_map = {
         "node": "FormContainerNode",
         "model": FormContainer,
     },
+    "location page": {
+        "node": "LocationPageNode",
+        "model": LocationPage
+    }
 }

--- a/joplin/api/schema.py
+++ b/joplin/api/schema.py
@@ -204,6 +204,7 @@ class LocationPageRelatedServices(DjangoObjectType):
         interfaces = [graphene.Node]
 
 
+
 class ContactNode(DjangoObjectType):
     class Meta:
         model = Contact
@@ -293,6 +294,7 @@ class Language(graphene.Enum):
 
 class ServicePageNode(DjangoObjectType):
     page_type = graphene.String()
+    janis_url = graphene.String()
 
     class Meta:
         model = ServicePage
@@ -301,6 +303,9 @@ class ServicePageNode(DjangoObjectType):
 
     def resolve_page_type(self, info):
         return ServicePage.get_verbose_name().lower()
+
+    def resolve_janis_url(self, info):
+        return self.janis_url()
 
 
 class InformationPageNode(DjangoObjectType):

--- a/joplin/api/schema.py
+++ b/joplin/api/schema.py
@@ -545,6 +545,11 @@ def get_structure_for_content_type(content_type):
 
                     page_topic_tc_global_id = graphene.Node.to_global_id('TopicCollectionNode', tc.topiccollection.id)
                     site_structure.append({'url': f'/{tc.topiccollection.theme.slug}/{tc.topiccollection.slug}/{page_topic.topic.slug}/{page.slug}/', 'type': content_type, 'id': page_global_id, 'parent_topic': page_topic_global_id, 'grandparent_topic_collection': page_topic_tc_global_id})
+
+        # Location pages need urls
+        if content_type == 'location page':
+            site_structure.append({'url': f'/location/{page.slug}/', 'type': content_type, 'id': page_global_id})
+
     return site_structure
 
 
@@ -586,6 +591,7 @@ class SiteStructure(graphene.ObjectType):
         site_structure.extend(get_structure_for_content_type('official document page'))
         site_structure.extend(get_structure_for_content_type('guide page'))
         site_structure.extend(get_structure_for_content_type('form container'))
+        site_structure.extend(get_structure_for_content_type('location page'))
 
         return site_structure
 

--- a/joplin/api/schema.py
+++ b/joplin/api/schema.py
@@ -487,6 +487,7 @@ class PageRevisionNode(DjangoObjectType):
     as_official_document_page = graphene.NonNull(OfficialDocumentPageNode)
     as_guide_page = graphene.NonNull(GuidePageNode)
     as_form_container = graphene.NonNull(FormContainerNode)
+    as_location_page = graphene.NonNull(LocationPageNode)
 
     def resolve_as_service_page(self, resolve_info, *args, **kwargs):
         return self.as_page_object()
@@ -510,6 +511,9 @@ class PageRevisionNode(DjangoObjectType):
         return self.as_page_object()
 
     def resolve_as_form_container(self, resolve_info, *args, **kwargs):
+        return self.as_page_object()
+
+    def resolve_as_location_page(self, resolve_info, *args, **kwargs):
         return self.as_page_object()
 
     class Meta:


### PR DESCRIPTION
# Description

* Update site structure to include location pages
* Update page revisions to work with location pages

https://github.com/cityofaustin/techstack/issues/3535
[Janis Related Pull Request Link](https://github.com/cityofaustin/janis/pull/645)

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
Joplin edit: http://joplin-pr-3535-location-pages.herokuapp.com/admin/pages/278/edit/#tab-content
Janis Preview: https://janis-3535-location-page.netlify.com/en/preview/location/UGFnZVJldmlzaW9uTm9kZToyMzk5?CMS_API=https://joplin-pr-3535-location-pages.herokuapp.com/api/graphql
Janis live: https://janis-3535-location-page.netlify.com/en/location/faulk/

# Checklist:
- [x] Request reviewers
- [ ] Slack-out message for review
- [x] Link this PR in the issue
- [x] Moved card to *review* in zenhub
