### PR TITLE
3622 "Location name" in content type title fields

### DIFF
--- a/joplin/locations/models.py
+++ b/joplin/locations/models.py
@@ -194,4 +194,5 @@ LocationPageRelatedServices.panels += [add_hours_by_day_and_exceptions(LocationP
 LocationPage.content_panels += [add_hours_by_day_and_exceptions(LocationPage), InlinePanel('related_services', label='Related Services'), ]
 # override title field to change verbose name
 # NOTE: this may break/cause problems if we ever make JanisBasePage NOT absctract
-LocationPage._meta.get_field('title').verbose_name = 'Location name'
+# commenting out for now since this is making *every* content type have the field name Location name
+# LocationPage._meta.get_field('title').verbose_name = 'Location name'

--- a/joplin/locations/models.py
+++ b/joplin/locations/models.py
@@ -195,4 +195,6 @@ LocationPage.content_panels += [add_hours_by_day_and_exceptions(LocationPage), I
 # override title field to change verbose name
 # NOTE: this may break/cause problems if we ever make JanisBasePage NOT absctract
 # commenting out for now since this is making *every* content type have the field name Location name
+# the problem seems to be that title comes from the wagtail Page model, and is not absctract.
+# we then inherit that non abstract model with janisbasepage which IS abstract, then this page inherits that and is NOT abstract
 # LocationPage._meta.get_field('title').verbose_name = 'Location name'


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description

I commented out the line that was changing all the title fields to say Location name and left a note as to why.

<!--- include a summary of the change and what it fixes. -->

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->

<!--- If there is a relevant Janis PR, link it here -->
<!--- [Janis Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 

https://joplin-pr-3622-title-fields.herokuapp.com/

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [x] Link this PR in the issue
- [x] Moved card to *review* in zenhub
