### PR TITLE
styling tabs speratly in page and user edit

### DIFF
--- a/joplin/css/pages/edit.scss
+++ b/joplin/css/pages/edit.scss
@@ -80,16 +80,21 @@
 
 .tab-nav {
     // this is also giving position fixed to the tab nav in add user
-    position: fixed;
     top: $edit-page-tab-bar-top;
     border-top: none;
     color: black;
     height: 40px;
 }
 
+#page-edit-form > ul {
+  position: fixed;
+}
+
 .tab-nav a {
     background-color: inherit;
     border-color: #e5e4de;
+    border-top: none;
+    padding-bottom: 1em;
     color: black;
     text-transform: none;
     font-size: 14px;
@@ -97,14 +102,13 @@
 }
 
 .tab-nav a:hover {
-    border-top: 0.3em solid $coa-color-lightest-blue;
     background-color: $coa-color-lightest-blue;
     color: black;
 }
 .tab-nav li.active a {
     background-color: #ffffff;
     border-color: #ffffff;
-    border-bottom: 0.2em solid #fff;
+    border-top: none;
     border-radius: 3px 3px 0px 0px;
     border-radius: 0;
 }


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->
Zenhub Issue Link: https://app.zenhub.com/workspaces/techstack-5a78b88e1ce69f3510b678ef/issues/cityofaustin/techstack/3499

# Description

The display as fixed for the edit pages tab, was the culpret. So, that means we need to style them seperatly. I used the already existing id to target the ul (`#page-edit-form > ul`) so i can remove the fixed position of the *user* edit tabs👍
- And... some border issues needed to be cleaned up.

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

# How can this be tested?

Deployed: https://joplin-pr-3499-floating-tab.herokuapp.com/

- Edit User Link: https://joplin-pr-3499-floating-tab.herokuapp.com/admin/users/3/#account

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
