### PR TITLE
make sure the modal template is included on results page

### DIFF
--- a/joplin/templates/wagtailadmin/pages/search_results.html
+++ b/joplin/templates/wagtailadmin/pages/search_results.html
@@ -51,7 +51,7 @@
     {% else %}
         {% if query_string %}
             <h2>{% blocktrans %}Sorry, no pages match <em>"{{ query_string }}"</em>{% endblocktrans %}</h2>
-
+            {% include "wagtailadmin/shared/create_content_modal/index.html" %}
             {% search_other %}
         {% else %}
             <p>{% trans 'Enter a search term above' %}</p>


### PR DESCRIPTION
This one is prettty self-explanatory. 

The modal wasn't opening because the elements weren't on the results page to open onto. 
