### PR TITLE
new step for syncing prod data to staging

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,8 @@ HEROKU_JANIS_APP_NAME=janis-staging ./scripts/serve-local.sh
 
 #### Syncing prod data to staging
 
+1. ```heroku pg:copy joplin::DATABASE_URL DATABASE_URL -a joplin-staging```
+
 1. Create a new seeding data backup sourced from prod, using `LOAD_PROD_DATA=on migration_test.sh`
 2. Drop the staging database (go to heroku and delete the database on staging)
 3. Push code with with new backup to master. This will rebuild the database and then seed it with your latest seeding datadump

--- a/README.md
+++ b/README.md
@@ -472,7 +472,3 @@ HEROKU_JANIS_APP_NAME=janis-staging ./scripts/serve-local.sh
 #### Syncing prod data to staging
 
 1. ```heroku pg:copy joplin::DATABASE_URL DATABASE_URL -a joplin-staging```
-
-1. Create a new seeding data backup sourced from prod, using `LOAD_PROD_DATA=on migration_test.sh`
-2. Drop the staging database (go to heroku and delete the database on staging)
-3. Push code with with new backup to master. This will rebuild the database and then seed it with your latest seeding datadump


### PR DESCRIPTION
Postgres on heroku has been upgraded for staging in production. 

This PR is meant to open discussion on whether to revisit our process for syncing data to staging from prod. The heroku CLI does provide lots of handy features for syncing data, and an example command is proposed here being added to the Readme. 

Other TODOs; things to check:
* By default, if a database is missing our build process attaches a hobby-tier PG instance. 

However, I might suggest for staging and prod that we _don't_ manually drop the database for staging or prod, unless others can think of good or justifiable reasons where we'd want to do that. This could cause data loss and a bad user experience if someone happens to be using the app while you are dropping the database. 

Running Django's ```loaddata``` command should be sufficient to replace data in a database, that is what it is for ( vs migrations, which are for manipulating pre-existing data in a database).

So accommodating for this could look like:
* if on staging or prod and there is no database, attach a standard  level database
or
* we just dont drop db on staging or prod anymore, in which case you'd need to just run migration or loaddata instead (you can do this via heroku cli or through the heroku console in their GUI)
or
other options too that I haven't thought of

* how do we want to preserve users between environments?
using pg:copy means that user info would be copied from production to staging. Password stuff should remain secure, but do we want users from production copied into staging? I'm not sure if the copy would overwrite existing users completely or append them a bit more gracefully; we might want to test that. This also potentially ties into user roles and permission testing that is on the short-term horizon. 
* heroku has options to set up follower databases
In the future it might be good to set up a read replica of the database to use specifically for site builds. But for most ideal performance we'd also want a version of the joplin app that is tuned for large numbers of async requests vs more traditional app style behavior we'd expect from joplin for content authors. 
* the copy command _might_ fail if staging has data migrations in a different structure from production. 
I haven't tested this. This could happen both when removing/moving fields as well as adding new ones. The migration_test process we currently have runs newer migrations against an older database to see if anything breaks. Pretty sure the heroku copy command would just fail in a similar case; so we might be able to do migration tests in a quicker/less laborious way? But I probably haven't thought through other edge cases or opportunities for error. In either case we might want to test/have expected behavior for situations where data structures are changing between branches. 

The migration-test process itself may be unsustainable/inefficient for feature testing specific feature branches as the amount of content in prod (and therefore staging, with our current process) grows. Ideally we'd have factories or limited fixture data to load for specific test cases. In which case the full migration test process might only be run on staging as part of regression testing? 

* right now migration-test couples together our backup process as well as our build test process. Perhaps they should be split up?
Heroku makes backups of our DBs in a way that is pretty painless. We can also dump data from either prod or staging pretty much whenever we want using the CLI. Maybe it would be better to have either one set up as joplin managment commands in Django so that you can be more specific about calling a command based on what you need to actually do (am i syncing data, updating a backup, or trying to do a build/regression test?)