### PR TITLE
3874 - hide fees when event is free (js)

### DIFF
--- a/joplin/events/models.py
+++ b/joplin/events/models.py
@@ -106,7 +106,7 @@ class EventPage(JanisBasePage):
         ),
         StreamFieldPanel('location_blocks'),
         FieldPanel('event_is_free'),
-        InlinePanel('fees', label='Fees'),
+        InlinePanel('fees', label='Fees', classname='coa-eventFees'),
         MultiFieldPanel(
             [
                 HelpPanel(registration_url.help_text, classname="coa-helpPanel"),

--- a/joplin/js/editor.js
+++ b/joplin/js/editor.js
@@ -244,6 +244,15 @@ $(function() {
     }
   }
 
+  function updateFeeVisibility(visible) {
+    if(visible) {
+      $('.coa-eventFees').first().show()
+    } else {
+      $('.coa-eventFees').first().hide()
+    }
+  }
+  updateFeeVisibility(!($('#id_event_is_free').first().prop('checked')))
+
   // if we previously had a language stored in local storage, load the view for that language
   // otherwise, we default to english
   if (localStorage.selected_lang) {
@@ -372,6 +381,11 @@ $(function() {
     changeLanguage(state.currentLang);
     updateSelectedLanguageDropdown(state.currentLang);
   });
+
+  // When we change the value of the event is free checkbox
+  $('#id_event_is_free').change(function() {
+    updateFeeVisibility(!($('#id_event_is_free').first().prop('checked')))
+  })
 
   // Found this here: https://stackoverflow.com/a/31719339
   MutationObserver = window.MutationObserver || window.WebKitMutationObserver;

--- a/joplin/js/editor.js
+++ b/joplin/js/editor.js
@@ -246,9 +246,9 @@ $(function() {
 
   function updateFeeVisibility(visible) {
     if(visible) {
-      $('.coa-eventFees').first().show()
+      $('.coa-eventFees').first().show('slow')
     } else {
-      $('.coa-eventFees').first().hide()
+      $('.coa-eventFees').first().hide('slow')
     }
   }
   updateFeeVisibility(!($('#id_event_is_free').first().prop('checked')))


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description
When the "event is free" checkbox is checked, the fees are hidden.

<!--- include a summary of the change and what it fixes. -->

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->
https://github.com/cityofaustin/techstack/issues/3874

<!--- If there is a relevant Janis PR, link it here -->
<!--- [Janis Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 
1. Go here: http://joplin-pr-3874-hide-fees.herokuapp.com/admin/pages/362/edit/#tab-content
2. See fees are hidden
3. Play with event is free checkbox and watch fees show/hide

# Checklist:
- [x] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
