### PR TITLE
only get live pages in site structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+*for a build
+
 # Joplin - CMS for the City of Austin
 
 Joplin is the Authoring Interface for adding and editing content for alpha.austin.gov.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-*for a build
-
 # Joplin - CMS for the City of Austin
 
 Joplin is the Authoring Interface for adding and editing content for alpha.austin.gov.

--- a/joplin/api/schema.py
+++ b/joplin/api/schema.py
@@ -245,7 +245,6 @@ class EventFilter(FilterSet):
         model = EventPage
         fields = {
             'date': ['exact', 'lte', 'gte'],
-            'date': ['exact', 'lte', 'gte'],
             'live': ['exact'],
             'id': ['exact'],
             'canceled': ['exact'],
@@ -730,7 +729,7 @@ def get_structure_for_content_type(content_type):
 
         # Only publish event pages at the date based url
         if content_type == 'event page':
-            if page.date and page.live:
+            if page.date:
                 site_structure.append({'url': f'/event/{page.date.year}/{page.date.month}/{page.date.day}/{page.slug}/', 'type': content_type, 'id': page_global_id})
             continue
 

--- a/joplin/api/schema.py
+++ b/joplin/api/schema.py
@@ -245,6 +245,7 @@ class EventFilter(FilterSet):
         model = EventPage
         fields = {
             'date': ['exact', 'lte', 'gte'],
+            'date': ['exact', 'lte', 'gte'],
             'live': ['exact'],
             'id': ['exact'],
             'canceled': ['exact'],
@@ -723,13 +724,13 @@ def get_structure_for_content_type(content_type):
     if not content_type_data:
         raise Exception(f'content_type [{content_type}] is not included in content_type_map')
 
-    pages = content_type_data["model"].objects.all()
+    pages = content_type_data["model"].objects.filter(live=True)
     for page in pages:
         page_global_id = graphene.Node.to_global_id(content_type_data["node"], page.id)
 
         # Only publish event pages at the date based url
         if content_type == 'event page':
-            if page.date:
+            if page.date and page.live:
                 site_structure.append({'url': f'/event/{page.date.year}/{page.date.month}/{page.date.day}/{page.slug}/', 'type': content_type, 'id': page_global_id})
             continue
 


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description

Unpublished pages are currently showing up in site structure, which was breaking my events pages query on janis (only getting live pages)

This PR changes it so we filter on live pages, not getting all pages. 

note from @briaguya: looks like this should handle https://github.com/cityofaustin/techstack/issues/4027

<!--- include a summary of the change and what it fixes. -->

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->

<!--- If there is a relevant Janis PR, link it here -->
<!--- [Janis Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 

https://joplin-pr-3818-event-home2.herokuapp.com/

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
