### PR TITLE
3977 snippet labels

### DIFF
--- a/joplin/css/pages/edit.scss
+++ b/joplin/css/pages/edit.scss
@@ -168,6 +168,7 @@
 // Fix formatting to allow PublishPreflight errors to be inserted below field titles
 .object>.title-wrapper {
   padding-left: 0;
+  // here it is, can I remove it?
   position: inherit;
 }
 

--- a/joplin/css/pages/edit.scss
+++ b/joplin/css/pages/edit.scss
@@ -165,11 +165,14 @@
   font-weight: bold;
 }
 
-// Fix formatting to allow PublishPreflight errors to be inserted below field titles
 .object>.title-wrapper {
-  // padding-left: 0;
-  // here it is, can I remove it?
   position: inherit;
+}
+
+// Fix formatting to allow PublishPreflight errors to be inserted below field titles
+// .tab-content makes sure to only select the formatting on the page edit view
+.tab-content .object>.title-wrapper {
+  padding-left: 0;
 }
 
 // Clean up weird whitespace on Relation InlinePanels that results from .title-wrapper no longer being position:absolute

--- a/joplin/css/pages/edit.scss
+++ b/joplin/css/pages/edit.scss
@@ -167,7 +167,7 @@
 
 // Fix formatting to allow PublishPreflight errors to be inserted below field titles
 .object>.title-wrapper {
-  padding-left: 0;
+  // padding-left: 0;
   // here it is, can I remove it?
   position: inherit;
 }


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description

Fixes a style bug introduced when we moved some divs around for the publish error messages. 

So note! some of the class names on the page edit view overlap with the class names on the snippet edit view. 

<!--- include a summary of the change and what it fixes. -->

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->

<!--- If there is a relevant Janis PR, link it here -->
<!--- [Janis Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?

https://joplin-pr-3977-snippet-labels.herokuapp.com/admin/snippets/base/contact/1/

check a snippet, check that you can see the whole title wrapper per field
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 

# Checklist:
- [x] Request reviewers
- [ ] Slack-out message for review
- [x] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
