### PR TITLE
3974 - clean up page ordering

### DIFF
--- a/joplin/base/views/joplin_search_views.py
+++ b/joplin/base/views/joplin_search_views.py
@@ -37,6 +37,12 @@ def search(request):
         if request.GET['ordering'] in ['content_type', '-content_type', 'owner', '-owner', 'title', '-title', 'latest_revision_created_at', '-latest_revision_created_at', 'live', '-live']:
             ordering = request.GET['ordering']
             pages = pages.order_by(ordering)
+    else:
+        # If we don't have an order, do reverse chronological by latest revision
+        # https://github.com/cityofaustin/techstack/issues/3974
+        ordering = '-latest_revision_created_at'
+        pages = pages.order_by(ordering)
+
 
     if 'content_type' in request.GET:
         pagination_query_params['content_type'] = request.GET['content_type']

--- a/joplin/templates/wagtailadmin/pages/search_results.html
+++ b/joplin/templates/wagtailadmin/pages/search_results.html
@@ -44,7 +44,7 @@
           This is where Joplin search results are modified for the UI for search results
           on our search results page.
         -->
-        {% include "wagtailadmin/pages/listing/_list_explore.html" with show_parent=0 sortable=1 sortable_by_type=0 full_width=1 ordering=request.GET.ordering show_ordering_column=1 orderable=1 %}
+        {% include "wagtailadmin/pages/listing/_list_explore.html" with show_parent=0 sortable=1 sortable_by_type=0 full_width=1 ordering=ordering show_ordering_column=1 orderable=1 %}
 
         {% url 'wagtailadmin_pages:search' as pagination_base_url %}
         {% paginate pages base_url=pagination_base_url %}


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description

<!--- include a summary of the change and what it fixes. -->

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->
https://github.com/cityofaustin/techstack/issues/3974

<!--- If there is a relevant Janis PR, link it here -->
<!--- [Janis Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 
1. Go to https://joplin-pr-3974-list-order.herokuapp.com/admin/pages/search/
2. See that it's sorting by last updated
3. Try playing with page filters and searching and see if the pages are ordered as expected

# Checklist:
- [x] Request reviewers
- [ ] Slack-out message for review
- [x] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
