### PR TITLE
3943 - places incorrect zip code

### DIFF
--- a/.circleci/vars/heroku_pr_vars.py
+++ b/.circleci/vars/heroku_pr_vars.py
@@ -23,7 +23,7 @@ from branch_overrides import branch_overrides
         Whatever you set in that object will not contaminate the environment vars of any other branch.
         You're allowed to override any environment var (even ones in vars_from_circleci),
         though you probably don't want to.
-        branch_overrides are not requried for every branch.
+        branch_overrides are not required for every branch.
 '''
 # Dictionary of all environment variables to be set within your Heroku PR App
 config = {}
@@ -41,6 +41,9 @@ vars_from_circleci = [
     "STYLEGUIDE_URL",  # CircleCI
     "CIRCLE_BRANCH",  # CircleCI
     "COA_PUBLISHER_URL",  # CircleCI
+    "DJANGO_SECRET_KEY",  # CircleCI
+    "ALGOLIA_APP_ID",  # CircleCI
+    "ALGOLIA_API_KEY",  # CircleCI
 ]
 for v in vars_from_circleci:
     config[v] = os.getenv(v, "")
@@ -68,7 +71,7 @@ headers = {
     "Authorization": f"Bearer {os.getenv('HEROKU_API_KEY')}"
 }
 response = requests.patch(f'https://api.heroku.com/apps/{os.getenv("APPNAME")}/config-vars', headers=headers, data=config)
-if (response.status_code != 200):
+if response.status_code != 200:
     print(f"{response.status_code} Error: {response.content.decode('utf-8')}")
     sys.exit(1)
 else:

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ __pycache__/
 .vscode/
 venv
 .idea/*
-!.idea/runConfigurations/*
+.idea/runConfigurations/*
 *node_modules
 *webpack_bundles
 *webpack-stats.json

--- a/joplin/js/editor.js
+++ b/joplin/js/editor.js
@@ -412,34 +412,33 @@ $(function() {
   });
 
   // autocomplete for places
-  (function() {
-    var latlng = {
-      lat: 30.26,
-      lng: -97.73,
-    };
-    var placesAutocomplete = places({
-      appId: 'plHX3G9C5GRN',
-      apiKey: 'd9275f5f90784eb5ba59ff8ec581d9bb',
-      container: document.querySelector('#id_physical_street'),
-      templates: {
-        value: function(suggestion) {
-          return suggestion.name;
-        },
-      },
-    }).configure({
-      aroundLatLng: latlng.lat + ',' + latlng.lng,
-      aroundRadius: 10 * 4000, // 40km radius
-      type: 'address',
-    });
-    placesAutocomplete.on('change', function resultSelected(e) {
-      document.querySelector('#id_physical_state').value =
-        e.suggestion.administrative || '';
-      document.querySelector('#id_physical_city').value =
-        e.suggestion.city || '';
-      document.querySelector('#id_physical_zip').value =
-        e.suggestion.postcode || '';
-      document.querySelector('#id_physical_country').value =
-        e.suggestion.country || '';
-    });
-  })();
+  // Algolia is returning the incorrect zip code for some addresses in austin
+//  (function() {
+//    var latlng = {
+//      lat: 30.26,
+//      lng: -97.73,
+//    };
+//    var placesAutocomplete = places({
+//      appId: 'plHX3G9C5GRN',
+//      apiKey: 'd9275f5f90784eb5ba59ff8ec581d9bb',
+//      container: document.querySelector('#id_physical_street'),
+//      templates: {
+//        value: function(suggestion) {
+//          return suggestion.name;
+//        },
+//      },
+//    }).configure({
+//      aroundLatLng: latlng.lat + ',' + latlng.lng,
+//      aroundRadius: 10 * 4000, // 40km radius
+//      type: 'address',
+//    });
+//    placesAutocomplete.on('change', function resultSelected(e) {
+//      document.querySelector('#id_physical_state').value =
+//        e.suggestion.administrative || '';
+//      document.querySelector('#id_physical_city').value =
+//        e.suggestion.city || '';
+//      document.querySelector('#id_physical_zip').value =
+//        e.suggestion.postcode || '';
+//    });
+//  })();
 });

--- a/joplin/settings.py
+++ b/joplin/settings.py
@@ -303,7 +303,7 @@ WAGTAIL_AUTO_UPDATE_PREVIEW = True
 BASE_URL = 'https://austintexas.io'
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = '1iq1u6gs+xh3!bvrl-5$jqne%gpj)!wv5^h0$dc0y84xsdr-95'
+SECRET_KEY = os.getenv('DJANGO_SECRET_KEY')
 
 
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description

Sometimes when we enter in an address for a location, the autosuggest will say an incorrect zip code. 

<img width="1058" alt="Screen Shot 2020-02-27 at 2 31 32 PM" src="https://user-images.githubusercontent.com/12474808/75489561-1b77b900-5978-11ea-8128-c4186ec5ba8e.png">
800 Guadalupe's zipcode is 78701.


For now, we are commenting out the autosuggest until they fix it. 

<!--- include a summary of the change and what it fixes. -->

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->

<!--- If there is a relevant Janis PR, link it here -->
<!--- [Janis Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
