### PR TITLE
add location page to styleguide

### DIFF
--- a/joplin/base/templatetags/joplin_tags.py
+++ b/joplin/base/templatetags/joplin_tags.py
@@ -24,6 +24,7 @@ STYLEGUIDE_PAGES = {
     'process page': '/pick-the-perfect-content-type/process-page',
     'information page': '/pick-the-perfect-content-type/information-page',
     'department page': '/pick-the-perfect-content-type/department-page',
+    'location page': '/pick-the-perfect-content-type/location-page',
     'topic page': '',
     'topic collection page': '',
     'official document page': '/pick-the-perfect-content-type/official-documents-page',


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description

Links location pages to appropriate section in the styleguide. 

At the moment, the nav for the styleguide is hard-coded, so this:
https://github.com/cityofaustin/digital-services-style-guide/commit/189662fd7acf69d5e5a77011cd4178a40e870ef5

Is the accompanying change to make the section browseable inside joplin

<!--- include a summary of the change and what it fixes. -->

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->

<!--- If there is a relevant Janis PR, link it here -->
<!--- [Janis Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
