### PR TITLE
fixing svg directory issue

### DIFF
--- a/joplin/joplin_UI/application_banner.scss
+++ b/joplin/joplin_UI/application_banner.scss
@@ -78,6 +78,10 @@
   transition: opacity $coa-transition-delay ease-in-out !important;
   border-radius: 0 0 $coa-button-border-radius $coa-button-border-radius;
 }
+.open .coa-user-dropdown-menu > li > a:hover {
+  background-color: $coa-background-color;
+}
+
 .open .coa-user-dropdown-menu > li {
   background-color: $coa-background-color-secondary;
   border-top: solid 1px $coa-border-color;

--- a/joplin/templates/joplin_UI/application_banner.html
+++ b/joplin/templates/joplin_UI/application_banner.html
@@ -16,7 +16,7 @@
         <div class="avatar circle coa-avatar"><img src="{% avatar_url user %}" alt="avatar" /></div>
         <div class="user user-account-dropdown coa-user-name" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
           {{ request.user.first_name }} {{ request.user.last_name }}
-          <img class="coa-user-dropdown-arrow" src="/static/images/icon_down_arrow.svg" alt="Down Arrow Icon">
+          <img class="coa-user-dropdown-arrow" src="{% static 'images/icon_down_arrow.svg' %}" alt="Down Arrow Icon">
           <!-- ☝️Using the SVG here in place of -icons because animations are flighty and whimiscal with -icons. -->
           <ul class="coa-user-dropdown-menu" aria-labelledby="user-account-dropdown">
             <li><a href="{% url 'wagtailadmin_account' %}" >{% trans "Account settings" %}</a></li>


### PR DESCRIPTION
This is a patch for https://github.com/cityofaustin/joplin/pull/586

The new SVG file for the dropdown arrow wasn't pulling in environment directory variables. Which pulled a 404 when adding the image on staging (and probably prod)

Test Link: https://joplin-pr-dropdown-fix.herokuapp.com/
- login 
- click lamp.
- see arrow properly display... NOT like this 

<img width="331" alt="Screen Shot 2020-03-09 at 2 56 26 PM" src="https://user-images.githubusercontent.com/15821138/76257717-3bcd3080-6220-11ea-8320-60d5f489711b.png">

HOWEVER: we won't know if this worked until merged into staging.

----
* I also forgot to remove the blue hover color in the UI, so i snuck that in here...
