### PR TITLE
content type filtering for search

### DIFF
--- a/joplin/base/views/joplin_search_views.py
+++ b/joplin/base/views/joplin_search_views.py
@@ -26,8 +26,8 @@ from django.views.decorators.vary import vary_on_headers
 @vary_on_headers('X-Requested-With')
 @user_passes_test(user_has_any_page_permission)
 def search(request):
-    # excluding Root(1) and Home(3) pages from search
-    pages = all_pages = Page.objects.all().exclude(id__in=[1, 3]).prefetch_related('content_type').specific()
+    # excluding wagtail 'page' type pages from search (like home/root)
+    pages = all_pages = Page.objects.all().exclude(content_type_id__in=[1]).prefetch_related('content_type').specific()
     q = MATCH_ALL
     content_types = []
     pagination_query_params = QueryDict({}, mutable=True)


### PR DESCRIPTION
instead of filtering out magic number page ids let's filter out using a magic number content type id!

https://github.com/cityofaustin/techstack/issues/4143