### PR TITLE
Issue 4148: use custom home_page content type

### DIFF
--- a/.circleci/vars/branch_overrides.py
+++ b/.circleci/vars/branch_overrides.py
@@ -21,4 +21,8 @@ branch_overrides = {
         "LOAD_DATA": "",
         "V3_WIP": True,
     },
+    "4148-add-homepage": {
+        "LOAD_DATA": "",
+        "V3_WIP": True,
+    },
 }

--- a/joplin/base/views/joplin_search_views.py
+++ b/joplin/base/views/joplin_search_views.py
@@ -27,8 +27,8 @@ from django.views.decorators.vary import vary_on_headers
 @user_passes_test(user_has_any_page_permission)
 def search(request):
     # excluding wagtail 'page' pages and 'HomePages' from search (like home/root)
-    homepage_id = ContentType.objects.get(app_label="home_page", model="homepage").id
-    pages = all_pages = Page.objects.all().exclude(content_type_id__in=[1, homepage_id]).prefetch_related('content_type').specific()
+    homepage_content_type_id = ContentType.objects.get(app_label="home_page", model="homepage").id
+    pages = all_pages = Page.objects.all().exclude(content_type_id__in=[1, homepage_content_type_id]).prefetch_related('content_type').specific()
     q = MATCH_ALL
     content_types = []
     pagination_query_params = QueryDict({}, mutable=True)

--- a/joplin/base/views/joplin_search_views.py
+++ b/joplin/base/views/joplin_search_views.py
@@ -26,8 +26,9 @@ from django.views.decorators.vary import vary_on_headers
 @vary_on_headers('X-Requested-With')
 @user_passes_test(user_has_any_page_permission)
 def search(request):
-    # excluding wagtail 'page' type pages from search (like home/root)
-    pages = all_pages = Page.objects.all().exclude(content_type_id__in=[1]).prefetch_related('content_type').specific()
+    # excluding wagtail 'page' pages and 'HomePages' from search (like home/root)
+    homepage_id = ContentType.objects.get(app_label="home_page", model="homepage").id
+    pages = all_pages = Page.objects.all().exclude(content_type_id__in=[1, homepage_id]).prefetch_related('content_type').specific()
     q = MATCH_ALL
     content_types = []
     pagination_query_params = QueryDict({}, mutable=True)

--- a/joplin/base/views/new_page_from_modal.py
+++ b/joplin/base/views/new_page_from_modal.py
@@ -19,6 +19,7 @@ from pages.guide_page.models import GuidePage
 from pages.form_container.models import FormContainer
 from pages.location_page.models import LocationPage
 from pages.event_page.models import EventPage
+from pages.home_page.models import HomePage
 from groups.models import Department
 from importer.page_importer import PageImporter
 from base.models.site_settings import JanisBranchSettings
@@ -78,7 +79,7 @@ def new_page_from_modal(request):
             page = EventPage(**data)
 
         # Add it as a child of home
-        home = Page.objects.get(id=2)
+        home = HomePage.objects.first()
         home.add_child(instance=page)
 
         # Save our draft

--- a/joplin/pages/home_page/migrations/0002_create_homepage.py
+++ b/joplin/pages/home_page/migrations/0002_create_homepage.py
@@ -1,0 +1,44 @@
+from django.db import migrations
+
+
+def create_homepage(apps, schema_editor):
+    # Get models
+    ContentType = apps.get_model('contenttypes.ContentType')
+    Page = apps.get_model('wagtailcore.Page')
+    Site = apps.get_model('wagtailcore.Site')
+    HomePage = apps.get_model('home_page.HomePage')
+
+    # Delete the default homepage
+    # If migration is run multiple times, it may have already been deleted
+    Page.objects.filter(id=2).delete()
+
+    # Create content type for homepage model
+    homepage_content_type, __ = ContentType.objects.get_or_create(
+        model='homepage', app_label='home_page')
+
+    # Create a new homepage
+    homepage = HomePage.objects.create(
+        title="Home",
+        draft_title="Home",
+        slug='home',
+        content_type=homepage_content_type,
+        path='00010001',
+        depth=2,
+        numchild=0,
+        url_path='/home/',
+    )
+
+    # Create a site with the new homepage set as the root
+    Site.objects.create(
+        hostname='localhost', port=80, root_page=homepage, is_default_site=True
+    )
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('home_page', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(create_homepage),
+    ]

--- a/joplin/pages/information_page/factories.py
+++ b/joplin/pages/information_page/factories.py
@@ -8,6 +8,7 @@ from base.models import Contact
 from pytest_factoryboy import register
 from wagtail.core.models import Page
 from pages.topic_page.factories import JanisBasePageWithTopicsFactory, create_topic_page_from_page_dictionary
+from pages.home_page.models import HomePage
 
 
 class InformationPageFactory(JanisBasePageWithTopicsFactory):
@@ -47,9 +48,8 @@ def create_information_page_from_page_dictionary(page_dictionary, revision_id):
     related_departments = ['just a string']
 
     # Set home as parent
-    # todo: not hardcode home
     # todo: move this to base page factory?
-    home = Page.objects.get(id=2)
+    home = HomePage.objects.first()
 
     # make the page
     page = InformationPageFactory.create(imported_revision_id=revision_id, title=page_dictionary['title'],

--- a/joplin/pages/topic_collection_page/factories.py
+++ b/joplin/pages/topic_collection_page/factories.py
@@ -2,6 +2,7 @@ import factory
 from pages.topic_collection_page.models import TopicCollectionPage, JanisBasePageTopicCollection, JanisBasePageWithTopicCollections
 from pages.base_page.factories import JanisBasePageFactory
 from pages.factory import PageFactory
+from pages.home_page.models import HomePage
 from base.models import Theme
 from wagtail.core.models import Page
 
@@ -84,9 +85,8 @@ def create_topic_collection_page_from_page_dictionary(page_dictionary, revision_
                                     description=page_dictionary['theme']['description'])
 
     # Set home as parent
-    # todo: not hardcode home
     # todo: move this to base page factory?
-    home = Page.objects.get(id=2)
+    home = HomePage.objects.first()
 
     # make the page
     page = TopicCollectionPageFactory.create(imported_revision_id=revision_id, title=page_dictionary['title'],

--- a/joplin/pages/topic_page/factories.py
+++ b/joplin/pages/topic_page/factories.py
@@ -2,6 +2,7 @@ import factory
 from pages.topic_page.models import TopicPage, JanisBasePageTopic, JanisBasePageWithTopics
 from pages.topic_collection_page.factories import JanisBasePageWithTopicCollectionsFactory, \
     create_topic_collection_page_from_page_dictionary
+from pages.home_page.models import HomePage
 from wagtail.core.models import Page
 
 from pages.base_page.factories import JanisBasePageFactory
@@ -73,9 +74,8 @@ def create_topic_page_from_page_dictionary(page_dictionary, revision_id):
     related_departments = ['just a string']
 
     # Set home as parent
-    # todo: not hardcode home
     # todo: move this to base page factory?
-    home = Page.objects.get(id=2)
+    home = HomePage.objects.first()
 
     # make the page
     page = TopicPageFactory.create(imported_revision_id=revision_id, title=page_dictionary['title'],


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->
Issue: cityofaustin/techstack#4148

# Description

The first step for multiple sites is having 1 site. We had the create_homepage migration in Joplin v2, and now we have it here. Having a custom homepage type will help many things, like moving site_settings into the home page.

<!--- include a summary of the change and what it fixes. -->
<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->

<!--- If there is a relevant Janis PR, link it here -->
<!--- [Janis Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 

See if you can make a page. If this doesn't break anything, we should be good to go.
https://joplin-pr-4148-add-homepage.herokuapp.com/

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
