### PR TITLE
v3 api - add nodes for pages with topics and pages with topic collections

### DIFF
--- a/joplin/api/schema.py
+++ b/joplin/api/schema.py
@@ -16,8 +16,8 @@ from wagtail.documents.models import Document
 from wagtail.core.rich_text import expand_db_html
 from base.models import TranslatedImage, Theme, Contact, Location, PhoneNumber, ContactDayAndDuration
 
-from pages.topic_collection_page.models import TopicCollectionPage
-from pages.topic_page.models import TopicPage, TopicPageTopPage
+from pages.topic_collection_page.models import TopicCollectionPage, JanisBasePageWithTopicCollections
+from pages.topic_page.models import TopicPage, TopicPageTopPage, JanisBasePageWithTopics
 from pages.service_page.models import ServicePage, ServicePageContact
 from pages.information_page.models import InformationPage, InformationPageContact
 from pages.department_page.models import DepartmentPage, DepartmentPageDirector, DepartmentPageContact, DepartmentPageTopPage, DepartmentPageRelatedPage
@@ -171,6 +171,20 @@ class JanisBasePageNode(DjangoObjectType):
 
     def resolve_janis_urls(self, info):
         return self.specific.janis_urls()
+
+
+class JanisBasePageWithTopicCollectionsNode(DjangoObjectType):
+    class Meta:
+        model = JanisBasePageWithTopicCollections
+        filter_fields = ['id', 'slug', 'live']
+        interfaces = [graphene.Node]
+
+
+class JanisBasePageWithTopicsNode(DjangoObjectType):
+    class Meta:
+        model = JanisBasePageWithTopics
+        filter_fields = ['id', 'slug', 'live']
+        interfaces = [graphene.Node]
 
 
 class DepartmentPageNode(DjangoObjectType):


### PR DESCRIPTION
makes it so this works:
```
{
  allPages {
    edges {
      node {
        janisUrls
        eventpage {
          id
        }
        locationpage {
          id
        }
        departmentpage {
          id
        }
        topiccollectionpage {
          id
        }
        janisbasepagewithtopiccollections {
          topicpage {
            id
          }
        }
        janisbasepagewithtopics {
          guidepage {
            id
          }
          servicepage {
            id
          }
          informationpage {
            id
          }
          officialdocumentpage {
            id
          }
          formcontainer {
            id
          }
        }
      }
    }
  }
}
```