### PR TITLE
Issue 4142: fix spontaneous pytest breakings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
           key: deps-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
       - run:
           name: Run tests
-          command: pipenv run pytest
+          command: pipenv run pytest --reuse-db
   deploy:
     docker:
       - image: cityofaustin/joplin-ci:e228591

--- a/.circleci/vars/branch_overrides.py
+++ b/.circleci/vars/branch_overrides.py
@@ -25,4 +25,8 @@ branch_overrides = {
         "LOAD_DATA": "",
         "V3_WIP": True,
     },
+    "4142-db": {
+        "LOAD_DATA": "",
+        "V3_WIP": True,
+    }
 }

--- a/joplin/groups/factories.py
+++ b/joplin/groups/factories.py
@@ -5,7 +5,7 @@ from wagtail.core.models import GroupPagePermission
 
 class DepartmentFactory(factory.DjangoModelFactory):
     department_page = factory.SubFactory('pages.department_page.factories.DepartmentPageFactory')
-    name = factory.Faker('first_name')
+    name = factory.Sequence(lambda n: f'Test Department {n}')
 
     class Meta:
         model = Department

--- a/joplin/pages/base_page/tests.py
+++ b/joplin/pages/base_page/tests.py
@@ -77,19 +77,18 @@ def test_base_page_with_topics_no_topic_no_department_not_global_urls():
     assert url == '#'
 
 
-# todo figure out db error stuff and uncomment this one
 # # If we don't have any associated department,
 # # and we don't have any associated topic pages
 # # and coa_global=True (top level page is checked)
-# @pytest.mark.django_db
-# def test_base_page_with_topics_no_topic_no_department_coa_global_urls():
-#     page = JanisBasePageWithTopicsFactory.build(slug="global_slug", coa_global=True)
-#
-#     urls = page.janis_urls()
-#     url = page.janis_url()
-#
-#     assert urls == ['http://fake.base.url/global_slug/']
-#     assert url == 'http://fake.base.url/global_slug/'
+@pytest.mark.django_db
+def test_base_page_with_topics_no_topic_no_department_coa_global_urls():
+    page = JanisBasePageWithTopicsFactory.build(slug="global_slug", coa_global=True)
+
+    urls = page.janis_urls()
+    url = page.janis_url()
+
+    assert urls == ['http://fake.base.url/global_slug/']
+    assert url == 'http://fake.base.url/global_slug/'
 
 
 # If we have associated departments,
@@ -132,4 +131,3 @@ def test_base_page_with_topics_with_department_not_global_urls():
 #
 #     assert urls == ['http://fake.base.url/global_slug_2/']
 #     assert url == 'http://fake.base.url/global_slug_2/'
-


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->
https://github.com/cityofaustin/techstack/issues/4142

# Description

Faker randomly generates names for us. Unfortunately, some of those random names turn up duplicates. This was problematic for our DepartmentFactory because it has a uniqueness requirement on the "name" field. Fortunately we could use factory.Sequence() to guarantee uniqueness. This is basically how people do it in the real world: https://github.com/FactoryBoy/factory_boy/issues/305
 
<!--- include a summary of the change and what it fixes. -->

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->

<!--- If there is a relevant Janis PR, link it here -->
<!--- [Janis Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
