### PR TITLE
clean up importer queries

### DIFF
--- a/joplin/importer/queries.py
+++ b/joplin/importer/queries.py
@@ -1,178 +1,219 @@
+import sys
+import re
+from string import Template
 from gql import gql
 
-queries = {
-    'topiccollection': gql('''
-    query getTopicCollectionPageRevision($id: ID) {
-      allPageRevisions(id: $id) {
-        edges {
-          node {
-            asTopicCollectionPage {
-              title
-              slug
-              description
-              theme {
-                slug
-                text
-                description
-              }
-            }
+
+# Allows us to use '$$$' as a delimiter for string substitution
+class GraphqlParser(Template):
+    delimiter="$$$"
+
+fragments = {}
+
+fragments["topiccollection"] = '''
+      title
+      slug
+      description
+      liveRevision {
+        id
+      }
+      theme {
+        slug
+        text
+        description
+      }
+'''
+
+fragments["topic"] = GraphqlParser('''
+    title
+    slug
+    description
+    liveRevision {
+        id
+     }
+    topiccollections {
+      edges {
+        node {
+          topiccollection {
+              $$$topiccollection
           }
         }
       }
     }
-    '''),
-    'topic': gql('''
+''').substitute(
+    topiccollection=fragments["topiccollection"]
+)
+
+fragments["contact"] = '''
+    id
+'''
+
+fragments["information"] = GraphqlParser('''
+    title
+    slug
+    coaGlobal
+    description
+    additionalContent
+    topics {
+      edges {
+        node {
+          topic {
+            $$$topic
+          }
+        }
+      }
+    }
+    contacts {
+      edges {
+        node {
+          contact {
+            $$$contact
+          }
+        }
+      }
+    }
+''').substitute(
+    topic=fragments["topic"],
+    contact=fragments["contact"],
+)
+
+fragments["services"] = GraphqlParser('''
+    title
+    slug
+    coaGlobal
+    shortDescription
+    steps
+    dynamicContent
+    additionalContent
+    topics {
+      edges {
+        node {
+          topic {
+            $$$topic
+          }
+        }
+      }
+    }
+    contacts {
+      edges {
+        node {
+          contact {
+            $$$contact
+          }
+        }
+      }
+    }
+''').substitute(
+    topic=fragments["topic"],
+    contact=fragments["contact"],
+)
+
+unparsed_query_strings = {
+    'topiccollection': '''
+        query getTopicCollectionPageRevision($id: ID) {
+          allPageRevisions(id: $id) {
+            edges {
+              node {
+                asTopicCollectionPage {
+                  $$$topiccollection
+                }
+              }
+            }
+          }
+        }
+    ''',
+    'topic': '''
         query getTopicPageRevision($id: ID) {
           allPageRevisions(id: $id) {
             edges {
               node {
                 asTopicPage {
-                  title
-                  slug
-                  description
-                  topiccollections {
-                    edges {
-                      node {
-                        topiccollection {
-                          title
-                          slug
-                          description
-                          theme {
-                            slug
-                            text
-                            description
-                          }
-                          liveRevision {
-                            id
-                          }
-                        }
-                      }
-                    }
-                  }
+                  $$$topic
                 }
               }
             }
           }
         }
-    '''),
-    'information': gql('''
-    query getInformationPageRevision($id: ID) {
-      allPageRevisions(id: $id) {
-        edges {
-          node {
-            asInformationPage {
-              title
-              slug
-              description
-              topics {
-                edges {
-                  node {
-                    topic {
-                      title
-                      slug
-                      description
-                      topiccollections {
-                        edges {
-                          node {
-                            topiccollection {
-                              title
-                              slug
-                              description
-                              theme {
-                                slug
-                                text
-                                description
-                              }
-                              liveRevision {
-                                id
-                              }
-                            }
-                          }
-                        }
-                      }
-                      liveRevision {
-                        id
-                      }
-                    }
-                  }
+    ''',
+    'information': '''
+        query getInformationPageRevision($id: ID) {
+          allPageRevisions(id: $id) {
+            edges {
+              node {
+                asInformationPage {
+                  $$$information
                 }
               }
-              additionalContent
-              contacts {
-                edges {
-                  node {
-                    contact {
-                      id
-                    }
-                  }
-                }
-              }
-              coaGlobal
             }
           }
         }
-      }
-    }
-    '''),
-    'services': gql('''
-    query getServicePageRevision($id: ID) {
-      allPageRevisions(id: $id) {
-        edges {
-          node {
-            asServicePage {
-              title
-              slug
-              shortDescription
-              dynamicContent
-              steps
-              topics {
-                edges {
-                  node {
-                    topic {
-                      title
-                      slug
-                      description
-                      topiccollections {
-                        edges {
-                          node {
-                            topiccollection {
-                              title
-                              slug
-                              description
-                              theme {
-                                slug
-                                text
-                                description
-                              }
-                              liveRevision {
-                                id
-                              }
-                            }
-                          }
-                        }
-                      }
-                      liveRevision {
-                        id
-                      }
-                    }
-                  }
+    ''',
+    'services': '''
+        query getServicePageRevision($id: ID) {
+          allPageRevisions(id: $id) {
+            edges {
+              node {
+                asServicePage {
+                  $$$services
                 }
               }
-              additionalContent
-              contacts {
-                edges {
-                  node {
-                    contact {
-                      id
-                    }
-                  }
-                }
-              }
-              coaGlobal
             }
           }
         }
-      }
-    }
-    '''),
+    ''',
 }
+
+query_strings = {
+    k: GraphqlParser(v).substitute(**fragments)
+    for (k,v) in unparsed_query_strings.items()
+}
+
+queries = {
+    k: gql(v)
+    for (k,v) in query_strings.items()
+}
+
+
+'''
+Helper for devs who want to see what each complete query looks like.
+
+Pass query_name to see 1 content type's query:
+pipenv run python joplin/importer/queries.py services
+
+Pass no arguments to see all queries:
+pipenv run python joplin/importer/queries.py
+'''
+if __name__ == '__main__':
+    # Print query_string with proper indentation
+    def pretty_print_graphql(qs):
+        # Remove whitespace after newlines
+        qs = re.sub(r'(\n)(\s+)', lambda match: '%s' % match.group(1), qs)
+        pretty_qs = ""
+        indent = 0
+        add_spacing = False
+        for i in iter(qs):
+            if i == "{":
+                indent += 1
+            if i == "}":
+                indent -= 1
+            if add_spacing:
+                pretty_qs += ("  " * indent)
+                add_spacing = False
+            if i == "\n":
+                add_spacing = True
+            pretty_qs += i
+        return pretty_qs
+
+    if len(sys.argv) > 1:
+        query_name = sys.argv[1]
+        qs = query_strings[query_name]
+        pretty_qs = pretty_print_graphql(qs)
+        print(pretty_qs)
+    else:
+        for (name, query_string) in query_strings.items():
+            print("######")
+            print(f"{name}")
+            print("######")
+            pretty_qs = pretty_print_graphql(query_string)
+            print(pretty_qs)
+            print("\n")


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description

As a prelude to making an importer for department groups/pages, I decided to clean up our importer's graphql queries. This eliminates copypasta in our graphql queries.

The downside of eliminating copypasta is that we can no longer copypasta those queries right into Insomnia or graphiql, which is kind of nice for testing. So I created a helper function that will print the complete querystrings into the console for you. Test with: `pipenv run python joplin/importer/queries.py`

<!--- include a summary of the change and what it fixes. -->

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->

<!--- If there is a relevant Janis PR, link it here -->
<!--- [Janis Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
