### PR TITLE
Issue 4047: separate roles and departments when creating new user

### DIFF
--- a/.circleci/vars/branch_overrides.py
+++ b/.circleci/vars/branch_overrides.py
@@ -25,8 +25,8 @@ branch_overrides = {
         "LOAD_DATA": "",
         "V3_WIP": True,
     },
-    "4142-db": {
-        "LOAD_DATA": "",
+    "4047-separate-groups": {
+        "LOAD_DATA": "dummy",
         "V3_WIP": True,
     },
     "4165-streamfields": {

--- a/README.md
+++ b/README.md
@@ -382,6 +382,7 @@ The migration process currently consists of 3 commands:
         # Then Rebuild (be sure to have the heroku cli installed in your machine)
         REBUILD=on ./scripts/serve-local.sh
         ```
+- `pipenv run ./joplin/manage.py shell_plus`
 
 ---
 

--- a/README/testing.md
+++ b/README/testing.md
@@ -13,7 +13,7 @@ Any file that matches the pattern specified in `pytest.ini`.
 
 Test data can be created with factories or by directly creating new instances of your model. Either way works, as long as you can test the thing you want to test.
 
-In the case of publish_preflight tests, we needed to create mock forms to validate against. To create mock forms, we needed to create mock POST requests (called `fake_request`s in code). There is no easy way I've found to automatically make mock POST requests. They were created by setting a breakpoint in pycharm and manually copying the `request.POST` objects from real requests.
+In the case of publish_preflight tests, we needed to create mock forms to validate against. To create mock forms, we needed to create mock POST requests (called `fake_request`s in code). There is no easy way I've found to automatically make mock POST requests. They were created by setting a breakpoint in pycharm and manually copying the `request.POST` objects from real requests in `wagtail/admin/views/pages.py`.
 
 You can experiment with the test data used in publish_preflight by running `pipenv run python joplin/manage.py load_test_data_publish_preflight` on an empty database (`DROP_DB=on scripts/undockered.py` for now, better empty database creation script to follow). This lets you interact directly with the same pages used to `setUp` the test data for `publish_preflight/tests/test_information_page_publish_preflight.py`. You can create your own new test `fake_request`s to test new criteria.
 

--- a/joplin/css/pages/edit.scss
+++ b/joplin/css/pages/edit.scss
@@ -165,6 +165,12 @@
   font-weight: bold;
 }
 
+// Error message for creating and editing Users
+.coa-user-form-error {
+  @extend .coa-publish-error;
+  padding-bottom: 1rem;
+}
+
 .object>.title-wrapper {
   position: inherit;
 }

--- a/joplin/groups/factories.py
+++ b/joplin/groups/factories.py
@@ -4,11 +4,18 @@ from wagtail.core.models import GroupPagePermission
 
 
 class DepartmentFactory(factory.DjangoModelFactory):
-    department_page = factory.SubFactory('pages.department_page.factories.DepartmentPageFactory')
     name = factory.Sequence(lambda n: f'Test Department {n}')
 
     class Meta:
         model = Department
+
+    @factory.post_generation
+    def add_department_page(self, create, extracted, **kwargs):
+        # pass "add_department_page__dummy"=True into Factory() to make dummy department page
+        if create:
+            if (kwargs.get("dummy", False)):
+                department_page = factory.SubFactory('pages.department_page.factories.DepartmentPageFactory')
+                # TODO, add it to group
 
 
 class GroupPagePermissionFactory(factory.django.DjangoModelFactory):

--- a/joplin/groups/factories.py
+++ b/joplin/groups/factories.py
@@ -1,6 +1,7 @@
 import factory
 from groups.models import Department
 from wagtail.core.models import GroupPagePermission
+from pages.department_page.factories import DepartmentPageFactory
 
 
 class DepartmentFactory(factory.DjangoModelFactory):
@@ -14,13 +15,12 @@ class DepartmentFactory(factory.DjangoModelFactory):
         # pass "add_department_page__dummy"=True into Factory() to make dummy department page
         if create:
             if (kwargs.get("dummy", False)):
-                department_page = factory.SubFactory('pages.department_page.factories.DepartmentPageFactory')
-                # TODO, add it to group
+                self.department_page = DepartmentPageFactory(title=self.name)
 
 
 class GroupPagePermissionFactory(factory.django.DjangoModelFactory):
     page = factory.SubFactory('base_page.factories.JanisBasePageFactory')
-    group = factory.SubFactory(DepartmentFactory)
+    group = factory.SubFactory(DepartmentFactory, add_department_page__dummy=True)
 
     class Meta:
         model = GroupPagePermission

--- a/joplin/groups/fixtures/__init__.py
+++ b/joplin/groups/fixtures/__init__.py
@@ -1,0 +1,7 @@
+from .test_cases.title import title
+
+
+# You can import any test_case fixture individually
+# Or you can load them all with this function
+def load_all():
+    title()

--- a/joplin/groups/fixtures/helpers/create_fixture.py
+++ b/joplin/groups/fixtures/helpers/create_fixture.py
@@ -1,0 +1,17 @@
+from groups.models import Department
+from groups.factories import DepartmentFactory
+
+
+# Skips creating fixture if Group with slug already exists
+def create_fixture(group_data, fixture_name):
+    try:
+        group = Department.objects.get(name=group_data['name'])
+    except Department.DoesNotExist:
+        group = None
+    if group:
+        print(f"Skipping {fixture_name}")
+        return None
+
+    group = DepartmentFactory.create(**group_data)
+    print(f"Built {fixture_name}")
+    return group

--- a/joplin/groups/fixtures/helpers/create_fixture.py
+++ b/joplin/groups/fixtures/helpers/create_fixture.py
@@ -2,7 +2,7 @@ from groups.models import Department
 from groups.factories import DepartmentFactory
 
 
-# Skips creating fixture if Group with slug already exists
+# Skips creating fixture if Group with name already exists
 def create_fixture(group_data, fixture_name):
     try:
         group = Department.objects.get(name=group_data['name'])

--- a/joplin/groups/fixtures/test_cases/title.py
+++ b/joplin/groups/fixtures/test_cases/title.py
@@ -1,0 +1,11 @@
+import os
+from groups.fixtures.helpers.create_fixture import create_fixture
+
+
+# A Department group with only a title
+def title():
+    group_data = {
+        "name": "Municipal Court"
+    }
+
+    return create_fixture(group_data, os.path.basename(__file__))

--- a/joplin/pages/base_page/factories.py
+++ b/joplin/pages/base_page/factories.py
@@ -11,7 +11,7 @@ class JanisBasePageFactory(PageFactory):
         model = JanisBasePage
 
     @factory.post_generation
-    def add_related_departments(self, create, extracted, **kwargs):
+    def add_department(self, create, extracted, **kwargs):
         # TODO: add option to pass in already created departments
         if extracted:
             # A list of departments were passed in, use them
@@ -20,26 +20,7 @@ class JanisBasePageFactory(PageFactory):
                 # GroupPagePermissionFactory.create(page=self, topic_collection=topic_collection)
             return
 
-        # pass "add_related_departments__dummy"=True into Factory() to make dummy departments
+        # pass "add_department__dummy"=True into Factory() to make dummy departments
         if create:
             if (kwargs.get("dummy", False)):
-                GroupPagePermissionFactory.create_batch(2, page=self)
-
-
-
-# class JanisBasePageTopicFactory(factory.django.DjangoModelFactory):
-#     page = factory.SubFactory('base_page.factories.JanisBasePageWithTopicsFactory')
-#     topic = factory.SubFactory('pages.topic_page.factories.TopicPageFactory')
-#
-#     class Meta:
-#         model = JanisBasePageTopic
-#
-#
-# class JanisBasePageWithTopicsFactory(JanisBasePageFactory):
-#     class Meta:
-#         model = JanisBasePageWithTopics
-#
-#     @factory.post_generation
-#     def create_parent_topics(self, create, extracted, **kwargs):
-#         if create:
-#             JanisBasePageTopicFactory.create_batch(2, page=self)
+                GroupPagePermissionFactory.create(page=self)

--- a/joplin/pages/base_page/tests.py
+++ b/joplin/pages/base_page/tests.py
@@ -51,7 +51,7 @@ def test_base_page_with_department_not_global_urls():
     page = JanisBasePageFactory.create(
         slug="page_slug",
         coa_global=False,
-        add_related_departments__dummy=True,
+        add_department__dummy=True,
     )
 
     # Set expected urls using group page permission department slugs
@@ -105,7 +105,6 @@ def test_base_page_with_topics_with_department_not_global_urls():
     page = JanisBasePageWithTopicsFactory.create(
         slug="page_slug",
         coa_global=False,
-        add_related_departments__dummy=True,
         add_topics__dummy=True
     )
 

--- a/joplin/pages/department_page/tests.py
+++ b/joplin/pages/department_page/tests.py
@@ -18,7 +18,7 @@ def test_department_page_no_department_group():
 # If we don't have any associated department group
 @pytest.mark.django_db
 def test_department_page_with_department_group():
-    department = DepartmentFactory.create()
+    department = DepartmentFactory.create(add_department_page__dummy=True)
     page = department.department_page
 
     urls = page.janis_urls()

--- a/joplin/pages/information_page/factories.py
+++ b/joplin/pages/information_page/factories.py
@@ -74,7 +74,7 @@ def create_information_page_from_importer_dictionaries(page_dictionaries, revisi
                 combined_dictionary[field.column] = page_dictionaries['es'][field.column[:-3]]
 
     # todo: actually get departments here
-    # combined_dictionary['add_related_departments'] = ['just a string']
+    # combined_dictionary['add_department'] = ['just a string']
 
     page = InformationPageFactory.create(**combined_dictionary)
     return page

--- a/joplin/pages/service_page/factories.py
+++ b/joplin/pages/service_page/factories.py
@@ -89,7 +89,7 @@ def create_service_page_from_importer_dictionaries(page_dictionaries, revision_i
 
 
     # todo: actually get departments here
-    # combined_dictionary['add_related_departments'] = ['just a string']
+    # combined_dictionary['add_department'] = ['just a string']
 
     page = ServicePageFactory.create(**combined_dictionary)
     return page

--- a/joplin/pages/topic_collection_page/factories.py
+++ b/joplin/pages/topic_collection_page/factories.py
@@ -14,7 +14,7 @@ class ThemeFactory(factory.django.DjangoModelFactory):
         model = Theme
 
 
-class TopicCollectionPageFactory(PageFactory):
+class TopicCollectionPageFactory(JanisBasePageFactory):
     theme = factory.SubFactory(ThemeFactory)
 
     class Meta:
@@ -22,8 +22,14 @@ class TopicCollectionPageFactory(PageFactory):
 
 
 class JanisBasePageTopicCollectionFactory(factory.django.DjangoModelFactory):
-    page = factory.SubFactory('base_page.factories.JanisBasePageWithTopicCollectionsFactory')
-    topic_collection = factory.SubFactory(TopicCollectionPageFactory)
+    page = factory.SubFactory(
+        'base_page.factories.JanisBasePageWithTopicCollectionsFactory',
+        add_department__dummy=True
+    )
+    topic_collection = factory.SubFactory(
+        TopicCollectionPageFactory,
+        add_department__dummy=True
+    )
 
     class Meta:
         model = JanisBasePageTopicCollection

--- a/joplin/pages/topic_page/factories.py
+++ b/joplin/pages/topic_page/factories.py
@@ -14,8 +14,14 @@ class TopicPageFactory(JanisBasePageWithTopicCollectionsFactory):
 
 
 class JanisBasePageTopicFactory(factory.django.DjangoModelFactory):
-    page = factory.SubFactory('base_page.factories.JanisBasePageWithTopicsFactory')
-    topic = factory.SubFactory(TopicPageFactory)
+    page = factory.SubFactory(
+        'base_page.factories.JanisBasePageWithTopicsFactory',
+        add_department__dummy=True,
+    )
+    topic = factory.SubFactory(
+        TopicPageFactory,
+        add_department__dummy=True,
+    )
 
     class Meta:
         model = JanisBasePageTopic
@@ -100,7 +106,7 @@ def create_topic_page_from_importer_dictionaries(page_dictionaries, revision_id)
                 combined_dictionary[field.column] = page_dictionaries['es'][field.column[:-3]]
 
     # todo: actually get departments here
-    combined_dictionary['add_related_departments'] = ['just a string']
+    combined_dictionary['add_department'] = ['just a string']
 
     page = TopicPageFactory.create(**combined_dictionary)
     return page

--- a/joplin/publish_preflight/tests/utils/make_form.py
+++ b/joplin/publish_preflight/tests/utils/make_form.py
@@ -1,5 +1,7 @@
 from django.contrib.contenttypes.models import ContentType
 
+
+# Logic extracted from wagtail/admin/views/pages.py
 def make_form(page, fake_request):
     parent = page.get_parent()
     content_type = ContentType.objects.get_for_model(page)

--- a/joplin/settings.py
+++ b/joplin/settings.py
@@ -501,4 +501,3 @@ V3_WIP = bool(strtobool(os.environ.get('V3_WIP', str(False))))
 AUTH_USER_MODEL = 'users.User'
 WAGTAIL_USER_EDIT_FORM = 'users.forms.CustomUserEditForm'
 WAGTAIL_USER_CREATION_FORM = 'users.forms.CustomUserCreationForm'
-# WAGTAIL_USER_CUSTOM_FIELDS = ['roles', 'department']

--- a/joplin/settings.py
+++ b/joplin/settings.py
@@ -246,8 +246,6 @@ WAGTAILDOCS_SERVE_METHOD = 'direct'
 MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
 MEDIA_URL = '/media/'
 
-AUTH_USER_MODEL = 'users.User'
-
 CORS_ORIGIN_ALLOW_ALL = True
 ALLOWED_HOSTS = [
     'localhost',
@@ -498,3 +496,9 @@ LOGGING = {
 
 # Temporary variables to toggle features for v3 while its still in development
 V3_WIP = bool(strtobool(os.environ.get('V3_WIP', str(False))))
+
+# Custom User Form Settings
+AUTH_USER_MODEL = 'users.User'
+WAGTAIL_USER_EDIT_FORM = 'users.forms.CustomUserEditForm'
+WAGTAIL_USER_CREATION_FORM = 'users.forms.CustomUserCreationForm'
+# WAGTAIL_USER_CUSTOM_FIELDS = ['roles', 'department']

--- a/joplin/templates/wagtailusers/users/create.html
+++ b/joplin/templates/wagtailusers/users/create.html
@@ -1,4 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
+{% load render_bundle from webpack_loader %}
 {% load wagtailimages_tags %}
 {% load i18n %}
 {% block titletag %}{% trans "Add user" %}{% endblock %}
@@ -7,6 +8,9 @@
 
     {% trans "Add user" as add_user_str %}
     {% include "wagtailadmin/shared/header.html" with title=add_user_str merged=1 tabbed=1 icon="user" %}
+    <!-- COA Change: Instead of choosing all groups on one level, we split groups up into "roles" and "departments" -->
+    {{ form|get_user_errors|json_script:"user-errors" }}
+    {% render_bundle 'user' %}
     <ul class="tab-nav merged">
         <li class="active"><a href="#account">{% trans "Account" %}</a></li>
         <li><a href="#roles">{% trans "Roles" %}</a></li>

--- a/joplin/templates/wagtailusers/users/create.html
+++ b/joplin/templates/wagtailusers/users/create.html
@@ -1,0 +1,61 @@
+{% extends "wagtailadmin/base.html" %}
+{% load wagtailimages_tags %}
+{% load i18n %}
+{% block titletag %}{% trans "Add user" %}{% endblock %}
+{% block content %}
+{% load user_tags %}
+
+    {% trans "Add user" as add_user_str %}
+    {% include "wagtailadmin/shared/header.html" with title=add_user_str merged=1 tabbed=1 icon="user" %}
+    <ul class="tab-nav merged">
+        <li class="active"><a href="#account">{% trans "Account" %}</a></li>
+        <li><a href="#roles">{% trans "Roles" %}</a></li>
+    </ul>
+
+    <form action="{% url 'wagtailusers_users:add' %}" method="POST" novalidate{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
+        <div class="tab-content">
+            {% csrf_token %}
+            <section id="account" class="active nice-padding">
+                <ul class="fields">
+                    {% block fields %}
+                        {% if form.separate_username_field %}
+                            {% include "wagtailadmin/shared/field_as_li.html" with field=form.username_field %}
+                        {% endif %}
+                        {% include "wagtailadmin/shared/field_as_li.html" with field=form.email %}
+                        {% include "wagtailadmin/shared/field_as_li.html" with field=form.first_name %}
+                        {% include "wagtailadmin/shared/field_as_li.html" with field=form.last_name %}
+                        {% block extra_fields %}{% endblock extra_fields %}
+                        {% if form.password1 %}
+                            {% include "wagtailadmin/shared/field_as_li.html" with field=form.password1 %}
+                        {% endif %}
+                        {% if form.password2 %}
+                            {% include "wagtailadmin/shared/field_as_li.html" with field=form.password2 %}
+                        {% endif %}
+                    {% endblock fields %}
+
+                    <li><a href="#roles" class="button lowpriority tab-toggle icon icon-arrow-right-after">{% trans "Roles" %}</a></li>
+                </ul>
+            </section>
+            <section id="roles" class="nice-padding">
+                <ul class="fields">
+                    {% include "wagtailadmin/shared/field_as_li.html" with field=form.is_superuser %}
+                    <!-- COA Change: Instead of choosing all groups on one level, we split groups up into "roles" and "departments" -->
+                    {% include "wagtailadmin/shared/field_as_li.html" with field=form.roles %}
+                    {% include "wagtailadmin/shared/field_as_li.html" with field=form.department %}
+                    <li><button class="button">{% trans "Add user" %}</button></li>
+                </ul>
+            </section>
+        </div>
+    </form>
+{% endblock %}
+
+{% block extra_css %}
+    {{ block.super }}
+    {% include "wagtailadmin/pages/_editor_css.html" %}
+    {{ form.media.css }}
+{% endblock %}
+{% block extra_js %}
+    {{ block.super }}
+    {% include "wagtailadmin/pages/_editor_js.html" %}
+    {{ form.media.js }}
+{% endblock %}

--- a/joplin/templates/wagtailusers/users/edit.html
+++ b/joplin/templates/wagtailusers/users/edit.html
@@ -1,0 +1,80 @@
+{% extends "wagtailadmin/base.html" %}
+{% load render_bundle from webpack_loader %}
+{% load wagtailimages_tags %}
+{% load i18n %}
+{% block titletag %}{% trans "Editing" %} {{ user.get_username}}{% endblock %}
+{% block content %}
+{% load user_tags %}
+
+    {% trans "Editing" as editing_str %}
+    {% include "wagtailadmin/shared/header.html" with title=editing_str subtitle=user.get_username merged=1 tabbed=1 icon="user" %}
+    <!-- COA Change: Instead of choosing all groups on one level, we split groups up into "roles" and "departments" -->
+    {{ form|get_user_groups|json_script:"user-groups" }}
+    {% render_bundle 'user' %}
+    <ul class="tab-nav merged">
+        <li class="active"><a href="#account">{% trans "Account" %}</a></li>
+        <li><a href="#roles">{% trans "Roles" %}</a></li>
+    </ul>
+
+    <form action="{% url 'wagtailusers_users:edit' user.pk %}" method="POST" novalidate{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
+        <div class="tab-content">
+            {% csrf_token %}
+
+            <section id="account" class="active nice-padding">
+                <ul class="fields">
+                    {% block fields %}
+                        {% if form.separate_username_field %}
+                            {% include "wagtailadmin/shared/field_as_li.html" with field=form.username_field %}
+                        {% endif %}
+                        {% include "wagtailadmin/shared/field_as_li.html" with field=form.email %}
+                        {% include "wagtailadmin/shared/field_as_li.html" with field=form.first_name %}
+                        {% include "wagtailadmin/shared/field_as_li.html" with field=form.last_name %}
+                        {% block extra_fields %}{% endblock extra_fields %}
+                        {% if form.password1 %}
+                            {% include "wagtailadmin/shared/field_as_li.html" with field=form.password1 %}
+                        {% endif %}
+                        {% if form.password2 %}
+                            {% include "wagtailadmin/shared/field_as_li.html" with field=form.password2 %}
+                        {% endif %}
+                        {% if form.is_active %}
+                            {% include "wagtailadmin/shared/field_as_li.html" with field=form.is_active %}
+                        {% endif %}
+                    {% endblock fields %}
+                    <li>
+                        <input type="submit" value="{% trans 'Save' %}" class="button" />
+                        {% if can_delete %}
+                            <a href="{% url 'wagtailusers_users:delete' user.pk %}" class="button button-secondary no">{% trans "Delete user" %}</a>
+                        {% endif %}
+                    </li>
+                </ul>
+            </section>
+            <section id="roles" class="nice-padding">
+                <ul class="fields">
+                    {% if form.is_superuser %}
+                        {% include "wagtailadmin/shared/field_as_li.html" with field=form.is_superuser %}
+                    {% endif %}
+                    <!-- COA Change: Instead of choosing all groups on one level, we split groups up into "roles" and "departments" -->
+                    {% include "wagtailadmin/shared/field_as_li.html" with field=form.roles %}
+                    {% include "wagtailadmin/shared/field_as_li.html" with field=form.department %}
+                    <li>
+                        <input type="submit" value="{% trans 'Save' %}" class="button" />
+                        {% if can_delete %}
+                            <a href="{% url 'wagtailusers_users:delete' user.pk %}" class="button button-secondary no">{% trans "Delete user" %}</a>
+                        {% endif %}
+                    </li>
+                </ul>
+            </section>
+        </div>
+    </form>
+{% endblock %}
+
+{% block extra_css %}
+    {{ block.super }}
+    {% include "wagtailadmin/pages/_editor_css.html" %}
+    {{ form.media.css }}
+{% endblock %}
+{% block extra_js %}
+    {{ block.super }}
+    {% include "wagtailadmin/pages/_editor_js.html" %}
+    {{ form.media.js }}
+{% endblock %}

--- a/joplin/templates/wagtailusers/users/edit.html
+++ b/joplin/templates/wagtailusers/users/edit.html
@@ -10,6 +10,7 @@
     {% include "wagtailadmin/shared/header.html" with title=editing_str subtitle=user.get_username merged=1 tabbed=1 icon="user" %}
     <!-- COA Change: Instead of choosing all groups on one level, we split groups up into "roles" and "departments" -->
     {{ form|get_user_groups|json_script:"user-groups" }}
+    {{ form|get_user_errors|json_script:"user-errors" }}
     {% render_bundle 'user' %}
     <ul class="tab-nav merged">
         <li class="active"><a href="#account">{% trans "Account" %}</a></li>

--- a/joplin/users/forms.py
+++ b/joplin/users/forms.py
@@ -1,0 +1,50 @@
+from django import forms
+from django.utils.translation import ugettext_lazy as _
+from wagtail.users.forms import UserEditForm, UserCreationForm
+from django.core.exceptions import ValidationError
+
+from django.contrib.auth.models import Group
+from groups.models import Department
+
+
+'''
+    Overwrite clean() method for Users.
+    Ensure that non-admins choose both a Role and a Department.
+    Set user-selected "Roles" and "Department" into "Groups".
+'''
+def custom_user_clean(self, cleaned_data):
+    # Consolidate "roles" and "department" into "groups"
+    group_pks = []
+    if cleaned_data["department"]:
+        group_pks.append(cleaned_data["department"].pk)
+    elif not cleaned_data["is_superuser"]:
+        self.add_error("department", ValidationError("Non-Administrators must belong to one Department."))
+    if cleaned_data["roles"]:
+        for role in cleaned_data["roles"]:
+            group_pks.append(role.pk)
+    elif not cleaned_data["is_superuser"]:
+        self.add_error("roles", ValidationError("Non-Administrators must have at least one Role."))
+    if group_pks:
+        cleaned_data["groups"] = Group.objects.filter(pk__in=group_pks)
+
+    return cleaned_data
+
+# "Roles" are either "Editor" or "Moderator"
+roles_form = forms.ModelMultipleChoiceField(queryset=Group.objects.filter(pk__in=[1, 2]), widget=forms.CheckboxSelectMultiple, required=False, label=_("Roles"))
+department_form = forms.ModelChoiceField(queryset=Department.objects, required=False, label=_("Department"))
+
+
+# Have to edit both classes, and both templates
+# http://docs.wagtail.io/en/v2.1.1/advanced_topics/customisation/custom_user_models.html
+class CustomUserEditForm(UserEditForm):
+    def clean(self):
+        return custom_user_clean(self, super(CustomUserEditForm, self).clean())
+    roles = roles_form
+    department = department_form
+
+
+class CustomUserCreationForm(UserCreationForm):
+    def clean(self):
+        return custom_user_clean(self, super(CustomUserCreationForm, self).clean())
+    roles = roles_form
+    department = department_form

--- a/joplin/users/js/index.js
+++ b/joplin/users/js/index.js
@@ -1,0 +1,24 @@
+$(function() {
+  const userGroups = JSON.parse(document.getElementById('user-groups').textContent);
+  /**
+    Our User form only knows about values for "Groups".
+    So we need to parse the Groups that are set for that user,
+    and set the values for "Roles" and "Departments" on the Form's UI.
+
+    This only needs to be done for "wagtailusers/users/edit" template.
+    The "wagtailusers/users/create" template will not have existing Group data,
+    because its creating a new user.
+
+    Groups 1 and 2 are the "Editor" and "Moderator" groups.
+    Those are selected by the "Roles" input checkbox fields.
+    A Group larger than 2 will be a Department.
+    That is selected by entering the value in the dropdown select field.
+  **/
+  userGroups.forEach(group => {
+    if ([1,2].includes(group)) {
+      $(`input[name='roles'][value=${group}]`).prop("checked", true)
+    } else if (group > 2) {
+      $("select[name='department']").val(group)
+    }
+  })
+})

--- a/joplin/users/js/index.js
+++ b/joplin/users/js/index.js
@@ -1,11 +1,10 @@
 $(function() {
-  const userGroups = JSON.parse(document.getElementById('user-groups').textContent);
   /**
     Our User form only knows about values for "Groups".
     So we need to parse the Groups that are set for that user,
     and set the values for "Roles" and "Departments" on the Form's UI.
 
-    This only needs to be done for "wagtailusers/users/edit" template.
+    This code will only impact the "wagtailusers/users/edit" template.
     The "wagtailusers/users/create" template will not have existing Group data,
     because its creating a new user.
 
@@ -14,11 +13,31 @@ $(function() {
     A Group larger than 2 will be a Department.
     That is selected by entering the value in the dropdown select field.
   **/
-  userGroups.forEach(group => {
-    if ([1,2].includes(group)) {
-      $(`input[name='roles'][value=${group}]`).prop("checked", true)
-    } else if (group > 2) {
-      $("select[name='department']").val(group)
+  const userGroupsRaw = $('#user-groups').text()
+  if (userGroupsRaw) {
+    const userGroups = JSON.parse(userGroupsRaw);
+    userGroups.forEach(group => {
+      if ([1,2].includes(group)) {
+        $(`input[name='roles'][value=${group}]`).prop("checked", true)
+      } else if (group > 2) {
+        $("select[name='department']").val(group)
+      }
+    })
+  }
+
+  // Insert error messages into form
+  const userErrorsRaw = $('#user-errors').text()
+  if (userErrorsRaw) {
+    const userErrors = JSON.parse(userErrorsRaw);
+    if (userErrors.department) {
+      const departmentParent = $($('label:contains("Department:")')[0]).parent()
+      const departmentMessage = $(`<div class='coa-user-form-error'>${userErrors.department}</div>`)
+      departmentMessage.insertBefore(departmentParent)
     }
-  })
+    if (userErrors.roles) {
+      const rolesParent = $($('label:contains("Roles:")')[0]).parent()
+      const rolesMessage = $(`<div class='coa-user-form-error'>${userErrors.roles}</div>`)
+      rolesMessage.insertBefore(rolesParent)
+    }
+  }
 })

--- a/joplin/users/templatetags/user_tags.py
+++ b/joplin/users/templatetags/user_tags.py
@@ -2,6 +2,24 @@ from django import template
 
 register = template.Library()
 
+
+# Get the groups for a user
 @register.filter(name='get_user_groups')
 def get_user_groups(form):
     return form['groups'].value() or []
+
+
+# Get custom validation errors from our "department" and "roles" fields.
+@register.filter(name='get_user_errors')
+def get_user_errors(form):
+    error_messages = {}
+    if hasattr(form, "_errors") and form._errors:
+        form_errors = form._errors
+        if form_errors:
+            department_errors = form_errors.get('department')
+            if department_errors:
+                error_messages["department"] = department_errors.data[0].message
+            role_errors = form_errors.get('roles')
+            if role_errors:
+                error_messages["roles"] = role_errors.data[0].message
+    return error_messages

--- a/joplin/users/templatetags/user_tags.py
+++ b/joplin/users/templatetags/user_tags.py
@@ -1,0 +1,7 @@
+from django import template
+
+register = template.Library()
+
+@register.filter(name='get_user_groups')
+def get_user_groups(form):
+    return form['groups'].value() or []

--- a/joplin/users/tests/conftest.py
+++ b/joplin/users/tests/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+import groups.fixtures as department_fixtures
+
+
+@pytest.fixture()
+def department():
+    return department_fixtures.title()

--- a/joplin/users/tests/tests.py
+++ b/joplin/users/tests/tests.py
@@ -1,0 +1,135 @@
+import pytest
+from django.core.exceptions import ValidationError
+from users.tests.utils.make_user_form import make_user_form
+
+
+@pytest.mark.django_db
+def test_make_user_without_department():
+    user_data = {
+      "email": "faker@austintexas.io",
+      "first_name": "Fake",
+      "last_name": "User",
+      "password1": "123",
+      "password2": "123",
+      "roles": "2",
+      "department": ""
+    }
+    form = make_user_form(user_data)
+    is_valid = form.is_valid()
+    assert is_valid is False
+    assert type(form._errors['department'].data[0]) is ValidationError
+
+
+@pytest.mark.django_db
+def test_make_superuser_without_department():
+    user_data = {
+      "email": "faker@austintexas.io",
+      "first_name": "Fake",
+      "last_name": "User",
+      "password1": "123",
+      "password2": "123",
+      "roles": "2",
+      "department": "",
+      "is_superuser": "on",
+    }
+    form = make_user_form(user_data)
+    is_valid = form.is_valid()
+    assert is_valid is True
+
+
+@pytest.mark.django_db
+def test_make_user_without_roles(department):
+    user_data = {
+      "email": "faker@austintexas.io",
+      "first_name": "Fake",
+      "last_name": "User",
+      "password1": "123",
+      "password2": "123",
+      "department": department.pk,
+    }
+    form = make_user_form(user_data)
+    is_valid = form.is_valid()
+    assert is_valid is False
+    assert type(form._errors['roles'].data[0]) is ValidationError
+
+
+@pytest.mark.django_db
+def test_make_superuser_without_roles(department):
+    user_data = {
+      "email": "faker@austintexas.io",
+      "first_name": "Fake",
+      "last_name": "User",
+      "password1": "123",
+      "password2": "123",
+      "department": department.pk,
+      "is_superuser": "on",
+    }
+    form = make_user_form(user_data)
+    is_valid = form.is_valid()
+    assert is_valid is True
+
+
+@pytest.mark.django_db
+def test_make_user_without_roles_or_department():
+    user_data = {
+      "email": "faker@austintexas.io",
+      "first_name": "Fake",
+      "last_name": "User",
+      "password1": "123",
+      "password2": "123",
+      "department": "",
+    }
+    form = make_user_form(user_data)
+    is_valid = form.is_valid()
+    assert is_valid is False
+    assert type(form._errors['department'].data[0]) is ValidationError
+    assert type(form._errors['roles'].data[0]) is ValidationError
+
+
+@pytest.mark.django_db
+def test_make_superuser_without_roles_or_department():
+    user_data = {
+      "email": "faker@austintexas.io",
+      "first_name": "Fake",
+      "last_name": "User",
+      "password1": "123",
+      "password2": "123",
+      "department": "",
+      "is_superuser": "on",
+    }
+    form = make_user_form(user_data)
+    is_valid = form.is_valid()
+    assert is_valid is True
+
+
+@pytest.mark.django_db
+def test_make_user_with_roles_and_department(department):
+    user_data = {
+      "email": "faker@austintexas.io",
+      "first_name": "Fake",
+      "last_name": "User",
+      "password1": "123",
+      "password2": "123",
+      "roles": "2",
+      "department": department.pk,
+    }
+    form = make_user_form(user_data)
+    is_valid = form.is_valid()
+    assert is_valid is True
+
+
+@pytest.mark.django_db
+def test_make_superuser_with_roles_and_department(department):
+    user_data = {
+      "email": "faker@austintexas.io",
+      "first_name": "Fake",
+      "last_name": "User",
+      "password1": "123",
+      "password2": "123",
+      "roles": "2",
+      "department": department.pk,
+      "is_superuser": "on",
+    }
+    form = make_user_form(user_data)
+    is_valid = form.is_valid()
+    assert is_valid is True

--- a/joplin/users/tests/utils/make_user_form.py
+++ b/joplin/users/tests/utils/make_user_form.py
@@ -1,0 +1,18 @@
+from urllib.parse import urlencode
+from django.http import QueryDict
+from users.forms import CustomUserCreationForm
+
+
+'''
+    Logic within make_user_form() is extracted from joplin/users/views/users.py
+
+    user_data is a mock of request.POST data from Joplin.
+    user_data must follow the exact structure that request.POST uses in order for tests to be valid.
+    To get an accurate example of user_data:
+        1. Set a breakpoint in pycharm in the create() function of joplin/users/views/users.py, where you can access request.POST.
+        2. Submit a new user from the Joplin UI.
+        3. Make a copy of the request.POST data to make your new user_data test case.
+'''
+def make_user_form(user_data):
+    query_dict = QueryDict(urlencode(user_data))
+    return CustomUserCreationForm(query_dict)

--- a/joplin/users/views/users.py
+++ b/joplin/users/views/users.py
@@ -118,7 +118,8 @@ def create(request):
         if hasattr(result, 'status_code'):
             return result
     if request.method == 'POST':
-        form = get_user_creation_form()(request.POST, request.FILES)
+        form_maker = get_user_creation_form()
+        form = form_maker(request.POST, request.FILES)
         if form.is_valid():
             user = form.save()
             messages.success(request, _("User '{0}' created.").format(user), buttons=[

--- a/joplin/webpack.base.js
+++ b/joplin/webpack.base.js
@@ -16,6 +16,7 @@ module.exports = {
     janisBranchSettings: path.resolve(__dirname, "./js/janisBranchSettings.js"),
     theme: path.resolve(__dirname, "./js/theme.js"),
     publishPreflight: path.resolve(__dirname, "./js/PublishPreflight/index.js"),
+    user: path.resolve(__dirname, "./users/js/index.js"),
   },
   module: {
     rules: [


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description

Oh cool we got a twofer.
- https://github.com/cityofaustin/techstack/issues/4046: Editors/moderators MUST belong to a department
- https://github.com/cityofaustin/techstack/issues/4047: Create new user: Separate editor/moderator from departments

<img width="910" alt="Screen Shot 2020-03-30 at 10 38 40 PM" src="https://user-images.githubusercontent.com/14187277/77984619-b5b08100-72d7-11ea-91e9-fbbca2a9da89.png">

<!--- include a summary of the change and what it fixes. -->

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->

<!--- If there is a relevant Janis PR, link it here -->
<!--- [Janis Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 

If you don't believe me, try it here:
https://joplin-pr-4047-separate-groups.herokuapp.com/admin/users/

Behold, roles and departments are separated, per cityofaustin/techstack#4047

And, it won't let you save if you don't choose both a role and a department in accordance with cityofaustin/techstack#4046

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
