### PR TITLE
4219 import location page related service hours

### DIFF
--- a/joplin/importer/queries.py
+++ b/joplin/importer/queries.py
@@ -165,19 +165,19 @@ fragments["location"] = GraphqlParser('''
       filename
       title
     }
+    relatedServices {
+      edges {
+        node {
+          relatedService {
+            title
+          }
+          hoursSameAsLocation
+          $$$hours
+        }
+      }
+    }
     $$$hours
 ''').substitute(
-    # relatedServices {
-    #   edges {
-    #     node {
-    #       relatedService {
-    #         title
-    #       }
-    #       hoursSameAsLocation
-    #       $$$hours
-    #     }
-    #   }
-    # }
     hours=fragments["hours"],
 )
 

--- a/joplin/importer/tests.py
+++ b/joplin/importer/tests.py
@@ -245,8 +245,7 @@ def test_get_dummy_service_page_from_revision(remote_staging_preview_url, remote
                   'the week.</p>'}
     ]
     assert page_dictionaries['en']['topics'] == {'edges': []}
-    assert page_dictionaries['en'][
-               'additional_content'] == '<h2>Bulk item pickup do’s and don’ts</h2><p>Do not put bulk items in bags, boxes, or other containers. Bags will be treated as extra trash and are subject to extra trash fees.</p><p>Do not place any items under low hanging tree limbs or power lines.</p><p>Do not place items in an alley in any area in front of a vacant lot or in front of a business. Items will not be collected from these areas.</p><p>To prevent damage to your property, keep bulk items 5 feet away from your:</p><ul><li>Trash cart</li><li>Mailbox</li><li>Fences or walls</li><li>Water meter</li><li>Telephone connection box</li><li>Parked cars</li></ul>'
+    assert page_dictionaries['en']['additional_content'] == '<h2>Bulk item pickup do’s and don’ts</h2><p>Do not put bulk items in bags, boxes, or other containers. Bags will be treated as extra trash and are subject to extra trash fees.</p><p>Do not place any items under low hanging tree limbs or power lines.</p><p>Do not place items in an alley in any area in front of a vacant lot or in front of a business. Items will not be collected from these areas.</p><p>To prevent damage to your property, keep bulk items 5 feet away from your:</p><ul><li>Trash cart</li><li>Mailbox</li><li>Fences or walls</li><li>Water meter</li><li>Telephone connection box</li><li>Parked cars</li></ul>'
     assert not page_dictionaries['en']['coa_global']
 
 

--- a/joplin/importer/tests.py
+++ b/joplin/importer/tests.py
@@ -3,9 +3,6 @@ from importer.page_importer import PageImporter
 from django.core.exceptions import ValidationError
 
 
-# from unittest.mock import patch
-
-
 def test_parse_janis_preview_url(remote_pytest_preview_url, remote_pytest_api):
     preview_url = f'{remote_pytest_preview_url}/information/UGFnZVJldmlzaW9uTm9kZToyNjI4'
 

--- a/joplin/importer/tests.py
+++ b/joplin/importer/tests.py
@@ -2,6 +2,7 @@ import pytest
 from importer.page_importer import PageImporter
 from django.core.exceptions import ValidationError
 
+
 # from unittest.mock import patch
 
 
@@ -109,6 +110,7 @@ def test_get_dummy_topic_collection_page_from_revision(remote_staging_preview_ur
         'description': 'theme description [en]'
     }
 
+
 # this test will start breaking once we no longer have this revision in the db
 # todo: figure out a good way to mock api responses
 # https://docs.python.org/3/library/unittest.mock.html
@@ -198,58 +200,121 @@ def test_get_dummy_service_page_from_revision(remote_staging_preview_url, remote
     page_dictionaries = PageImporter(preview_url).fetch_page_data().page_dictionaries
     assert page_dictionaries['en']['title'] == 'Get your bulk items collected'
     assert page_dictionaries['en']['slug'] == 'bulk-item-pickup'
-    assert page_dictionaries['en']['short_description'] == 'Twice a year, Austin residential trash and recycling customers can place large items out on the curb to be picked up. These items include appliances, furniture, and carpet.'
+    assert page_dictionaries['en'][
+               'short_description'] == 'Twice a year, Austin residential trash and recycling customers can place large items out on the curb to be picked up. These items include appliances, furniture, and carpet.'
     assert page_dictionaries['en']['dynamic_content'] == []
     assert page_dictionaries['en']['steps'] == [
-        {   'id': '8ae81673-200e-4ef9-a744-28b38752d7ac',
-            'type': 'basic_step',
-            'value': '<p>Use the this tool to see what bulk items can be picked '
-                     'up. Bulk items are items that are too large for your trash '
-                     'cart, such as appliances, furniture, and '
-                     'carpet.</p><p></p><p><code>APPBLOCK: What do I do '
-                     'with</code></p>'},
-        {   'id': 'c9ad6f3f-5acc-4d19-bbd0-7a9dd6fb847a',
-            'type': 'basic_step',
-            'value': '<p>Consider donating your items before placing them on the '
-                     'curb for pickup.</p>'},
-        {   'id': 'b69e6dda-c805-4547-b708-e4e09cf679fc',
-            'type': 'basic_step',
-            'value': '<p>Look up your bulk pickup weeks. We only collect bulk '
-                     'items from Austin residential trash and recycling customers '
-                     'twice a year, and customers have different pickup '
-                     'weeks.</p><p></p><p><code>APPBLOCK: Collection '
-                     'Schedule</code></p>'},
-        {   'id': '1f9762ad-1296-47fd-9623-bb1b8a659f6a',
-            'type': 'basic_step',
-            'value': '<p>Review the bulk item pickup do’s and don’ts below.</p>'},
-        {   'id': '2c8e26ed-4ac2-4a0b-a720-3b6c76098973',
-            'type': 'basic_step',
-            'value': '<p>Place bulk items at the curb in front of your house by '
-                     '6:30 am on the first day of your scheduled collection '
-                     'week.</p>'},
-        {   'id': '13fc4079-a860-45cf-96b4-1638caf0f154',
-            'type': 'basic_step',
-            'value': '<p>Separate items into three '
-                     'piles:</p><ul><li>Metal—includes appliances, doors must be '
-                     'removed</li><li>Passenger car tires—limit of eight tires per '
-                     'household, rims must be removed, no truck or tractor '
-                     'tires</li><li>Non-metal items—includes carpeting and '
-                     'nail-free lumber</li></ul>'},
-        {   'id': 'c41f1d29-2822-4ac8-8616-1e8846ec098f',
-            'type': 'basic_step',
-            'value': '<p>The three separate piles are collected by different '
-                     'trucks and may be collected at different times throughout '
-                     'the week.</p>'}
+        {'id': '8ae81673-200e-4ef9-a744-28b38752d7ac',
+         'type': 'basic_step',
+         'value': '<p>Use the this tool to see what bulk items can be picked '
+                  'up. Bulk items are items that are too large for your trash '
+                  'cart, such as appliances, furniture, and '
+                  'carpet.</p><p></p><p><code>APPBLOCK: What do I do '
+                  'with</code></p>'},
+        {'id': 'c9ad6f3f-5acc-4d19-bbd0-7a9dd6fb847a',
+         'type': 'basic_step',
+         'value': '<p>Consider donating your items before placing them on the '
+                  'curb for pickup.</p>'},
+        {'id': 'b69e6dda-c805-4547-b708-e4e09cf679fc',
+         'type': 'basic_step',
+         'value': '<p>Look up your bulk pickup weeks. We only collect bulk '
+                  'items from Austin residential trash and recycling customers '
+                  'twice a year, and customers have different pickup '
+                  'weeks.</p><p></p><p><code>APPBLOCK: Collection '
+                  'Schedule</code></p>'},
+        {'id': '1f9762ad-1296-47fd-9623-bb1b8a659f6a',
+         'type': 'basic_step',
+         'value': '<p>Review the bulk item pickup do’s and don’ts below.</p>'},
+        {'id': '2c8e26ed-4ac2-4a0b-a720-3b6c76098973',
+         'type': 'basic_step',
+         'value': '<p>Place bulk items at the curb in front of your house by '
+                  '6:30 am on the first day of your scheduled collection '
+                  'week.</p>'},
+        {'id': '13fc4079-a860-45cf-96b4-1638caf0f154',
+         'type': 'basic_step',
+         'value': '<p>Separate items into three '
+                  'piles:</p><ul><li>Metal—includes appliances, doors must be '
+                  'removed</li><li>Passenger car tires—limit of eight tires per '
+                  'household, rims must be removed, no truck or tractor '
+                  'tires</li><li>Non-metal items—includes carpeting and '
+                  'nail-free lumber</li></ul>'},
+        {'id': 'c41f1d29-2822-4ac8-8616-1e8846ec098f',
+         'type': 'basic_step',
+         'value': '<p>The three separate piles are collected by different '
+                  'trucks and may be collected at different times throughout '
+                  'the week.</p>'}
     ]
-    assert page_dictionaries['en']['topics'] == { 'edges': [] }
-    assert page_dictionaries['en']['additional_content'] == '<h2>Bulk item pickup do’s and don’ts</h2><p>Do not put bulk items in bags, boxes, or other containers. Bags will be treated as extra trash and are subject to extra trash fees.</p><p>Do not place any items under low hanging tree limbs or power lines.</p><p>Do not place items in an alley in any area in front of a vacant lot or in front of a business. Items will not be collected from these areas.</p><p>To prevent damage to your property, keep bulk items 5 feet away from your:</p><ul><li>Trash cart</li><li>Mailbox</li><li>Fences or walls</li><li>Water meter</li><li>Telephone connection box</li><li>Parked cars</li></ul>'
+    assert page_dictionaries['en']['topics'] == {'edges': []}
+    assert page_dictionaries['en'][
+               'additional_content'] == '<h2>Bulk item pickup do’s and don’ts</h2><p>Do not put bulk items in bags, boxes, or other containers. Bags will be treated as extra trash and are subject to extra trash fees.</p><p>Do not place any items under low hanging tree limbs or power lines.</p><p>Do not place items in an alley in any area in front of a vacant lot or in front of a business. Items will not be collected from these areas.</p><p>To prevent damage to your property, keep bulk items 5 feet away from your:</p><ul><li>Trash cart</li><li>Mailbox</li><li>Fences or walls</li><li>Water meter</li><li>Telephone connection box</li><li>Parked cars</li></ul>'
     assert not page_dictionaries['en']['coa_global']
 
 
 def test_get_dummy_location_page_from_revision(remote_staging_preview_url, remote_pytest_api):
-    preview_url = f'{remote_staging_preview_url}/location/UGFnZVJldmlzaW9uTm9kZToyMw==?CMS_API={remote_pytest_api}'
+    preview_url = f'{remote_staging_preview_url}/location/UGFnZVJldmlzaW9uTm9kZTozMA==?CMS_API={remote_pytest_api}'
 
     page_dictionaries = PageImporter(preview_url).fetch_page_data().page_dictionaries
     assert page_dictionaries['en']['title'] == 'Location name [en]'
+    assert page_dictionaries['en']['slug'] == 'location-name-en'
+    assert not page_dictionaries['en']['coa_global']
+    assert page_dictionaries['en']['physical_street'] == '123 Fake St.'
+    assert page_dictionaries['en']['physical_unit'] == ''
+    assert page_dictionaries['en']['physical_city'] == 'Austin'
+    assert page_dictionaries['en']['physical_state'] == 'TX'
+    assert page_dictionaries['en']['physical_zip'] == '78745'
+    assert page_dictionaries['en']['mailing_street'] == '456 Fake mailing address'
+    assert page_dictionaries['en']['mailing_city'] == 'Austin'
+    assert page_dictionaries['en']['mailing_state'] == 'TX'
+    assert page_dictionaries['en']['mailing_zip'] == '78745'
+    assert page_dictionaries['en']['phone_number'] == '+15128675309'
+    assert page_dictionaries['en']['phone_description'] == 'Jenny'
+    assert page_dictionaries['en']['email'] == 'tommy@tut.one'
+    assert page_dictionaries['en']['nearest_bus1'] == 1
+    assert page_dictionaries['en']['nearest_bus2'] == 2
+    assert page_dictionaries['en']['nearest_bus3'] == 3
+    assert page_dictionaries['en']['physical_location_photo'] is None
+    assert page_dictionaries['en']['related_services'] == {'edges': [{'node': {
+        'related_service': {'title': 'Service page with contact'}, 'hours_same_as_location': False,
+        'monday_start_time': '12:00:00', 'monday_end_time': '17:00:00', 'monday_start_time2': None,
+        'monday_end_time2': None, 'tuesday_start_time': '12:00:00', 'tuesday_end_time': '17:00:00',
+        'tuesday_start_time2': None, 'tuesday_end_time2': None, 'wednesday_start_time': '12:00:00',
+        'wednesday_end_time': '17:00:00', 'wednesday_start_time2': None,
+        'wednesday_end_time2': None, 'thursday_start_time': '12:00:00',
+        'thursday_end_time': '17:00:00', 'thursday_start_time2': None, 'thursday_end_time2': None,
+        'friday_start_time': '12:00:00', 'friday_end_time': '17:00:00', 'friday_start_time2': None,
+        'friday_end_time2': None, 'saturday_start_time': None, 'saturday_end_time': None,
+        'saturday_start_time2': None, 'saturday_end_time2': None, 'sunday_start_time': None,
+        'sunday_end_time': None, 'sunday_start_time2': None, 'sunday_end_time2': None,
+        'hours_exceptions': ''}}]}
+    assert page_dictionaries['en']['monday_start_time'] == '00:00:00'
+    assert page_dictionaries['en']['monday_end_time'] == '01:00:00'
+    assert page_dictionaries['en']['monday_start_time2'] == '02:00:00'
+    assert page_dictionaries['en']['monday_end_time2'] == '03:00:00'
+    assert page_dictionaries['en']['tuesday_start_time'] == '04:00:00'
+    assert page_dictionaries['en']['tuesday_end_time'] == '05:00:00'
+    assert page_dictionaries['en']['tuesday_start_time2'] == '06:00:00'
+    assert page_dictionaries['en']['tuesday_end_time2'] == '07:00:00'
+    assert page_dictionaries['en']['wednesday_start_time'] == '08:00:00'
+    assert page_dictionaries['en']['wednesday_end_time'] == '09:00:00'
+    assert page_dictionaries['en']['wednesday_start_time2'] == '10:00:00'
+    assert page_dictionaries['en']['wednesday_end_time2'] == '11:00:00'
+    assert page_dictionaries['en']['thursday_start_time'] == '12:00:00'
+    assert page_dictionaries['en']['thursday_end_time'] == '13:00:00'
+    assert page_dictionaries['en']['thursday_start_time2'] == '14:00:00'
+    assert page_dictionaries['en']['thursday_end_time2'] == '15:00:00'
+    assert page_dictionaries['en']['friday_start_time'] == '16:00:00'
+    assert page_dictionaries['en']['friday_end_time'] == '17:00:00'
+    assert page_dictionaries['en']['friday_start_time2'] == '18:00:00'
+    assert page_dictionaries['en']['friday_end_time2'] == '19:00:00'
+    assert page_dictionaries['en']['saturday_start_time'] == '20:00:00'
+    assert page_dictionaries['en']['saturday_end_time'] == '21:00:00'
+    assert page_dictionaries['en']['saturday_start_time2'] == '22:00:00'
+    assert page_dictionaries['en']['saturday_end_time2'] == '23:00:00'
+    assert page_dictionaries['en']['sunday_start_time'] is None
+    assert page_dictionaries['en']['sunday_end_time'] is None
+    assert page_dictionaries['en']['sunday_start_time2'] is None
+    assert page_dictionaries['en']['sunday_end_time2'] is None
+    assert page_dictionaries['en']['hours_exceptions'] == 'exceptions to hours'
+
     assert page_dictionaries['en']['slug'] == 'location-name-en'
     assert not page_dictionaries['en']['coa_global']

--- a/joplin/importer/tests.py
+++ b/joplin/importer/tests.py
@@ -107,7 +107,6 @@ def test_get_dummy_topic_collection_page_from_revision(remote_staging_preview_ur
         'description': 'theme description [en]'
     }
 
-
 # this test will start breaking once we no longer have this revision in the db
 # todo: figure out a good way to mock api responses
 # https://docs.python.org/3/library/unittest.mock.html

--- a/joplin/importer/tests.py
+++ b/joplin/importer/tests.py
@@ -200,8 +200,7 @@ def test_get_dummy_service_page_from_revision(remote_staging_preview_url, remote
     page_dictionaries = PageImporter(preview_url).fetch_page_data().page_dictionaries
     assert page_dictionaries['en']['title'] == 'Get your bulk items collected'
     assert page_dictionaries['en']['slug'] == 'bulk-item-pickup'
-    assert page_dictionaries['en'][
-               'short_description'] == 'Twice a year, Austin residential trash and recycling customers can place large items out on the curb to be picked up. These items include appliances, furniture, and carpet.'
+    assert page_dictionaries['en']['short_description'] == 'Twice a year, Austin residential trash and recycling customers can place large items out on the curb to be picked up. These items include appliances, furniture, and carpet.'
     assert page_dictionaries['en']['dynamic_content'] == []
     assert page_dictionaries['en']['steps'] == [
         {'id': '8ae81673-200e-4ef9-a744-28b38752d7ac',

--- a/joplin/pages/location_page/factories.py
+++ b/joplin/pages/location_page/factories.py
@@ -1,27 +1,15 @@
-import json
-
 import factory
 from pages.base_page.factories import JanisBasePageFactory
 from pages.home_page.models import HomePage
 from pages.service_page.models import ServicePage
 from pages.service_page.factories import ServicePageFactory
 from pages.location_page.models import LocationPage, LocationPageRelatedServices
-import pages.service_page.fixtures as service_page_fixtures
 
 
 class LocationPageRelatedServicesFactory(factory.django.DjangoModelFactory):
-    # find all your fields [f.name for f in MyModel._meta.get_fields()]
     page = factory.SubFactory('pages.location_page.factories.LocationPageFactory')
-    # page = factory.Iterator(models.LocationPage.objects.all())
     # todo: actually get the service page relation
     related_service = factory.SubFactory('pages.service_page.factories.ServicePageFactory')
-    # related_service = factory.Faker(ServicePage)
-    # hours_exceptions = factory.Faker('text')
-
-    # for field in models.LocationPageRelatedServices._meta.fields:
-    #      if field.get_internal_type() == 'TimeField':
-    #          locals()[field.name] = factory.Faker('time', pattern="%H:%M", end_datetime=None)
-    # del field
 
     class Meta:
         model = LocationPageRelatedServices
@@ -37,7 +25,6 @@ class LocationPageFactory(JanisBasePageFactory):
         if extracted:
             # A list of related services were passed in,
             # this includes info about hours for the related service
-            # todo: actually link the related service
             for location_page_related_service in extracted:
                 LocationPageRelatedServicesFactory.create(page=self, **location_page_related_service)
             return
@@ -106,8 +93,8 @@ def create_location_page_from_importer_dictionaries(page_dictionaries, revision_
     # # for now, just get the title from the page on related service and clear it out
     combined_dictionary['add_related_services'] = []
     for edge in combined_dictionary['related_services']['edges']:
-        service_to_add = edge['node']
-        service_to_add['hours_exceptions'] += service_to_add['related_service']['title']
+        location_page_related_service_to_add = edge['node']
+        location_page_related_service_to_add['hours_exceptions'] += location_page_related_service_to_add['related_service']['title']
 
         # We really are just trying to get hours imported here, but we can't save
         # without having a page FK'd out to, so we use a placeholder service for now.
@@ -124,9 +111,9 @@ def create_location_page_from_importer_dictionaries(page_dictionaries, revision_
                 'slug': 'placeholder_service_for_hours'
             }
             related_service = ServicePageFactory.create(**related_service_dictionary)
-        del service_to_add['related_service']
-        service_to_add['related_service'] = related_service
-        combined_dictionary['add_related_services'].append(service_to_add)
+        del location_page_related_service_to_add['related_service']
+        location_page_related_service_to_add['related_service'] = related_service
+        combined_dictionary['add_related_services'].append(location_page_related_service_to_add)
     del combined_dictionary['related_services']
 
     page = LocationPageFactory.create(**combined_dictionary)

--- a/joplin/pages/location_page/factories.py
+++ b/joplin/pages/location_page/factories.py
@@ -8,7 +8,6 @@ from pages.location_page.models import LocationPage, LocationPageRelatedServices
 
 class LocationPageRelatedServicesFactory(factory.django.DjangoModelFactory):
     page = factory.SubFactory('pages.location_page.factories.LocationPageFactory')
-    # todo: actually get the service page relation
     related_service = factory.SubFactory('pages.service_page.factories.ServicePageFactory')
 
     class Meta:

--- a/joplin/pages/location_page/factories.py
+++ b/joplin/pages/location_page/factories.py
@@ -108,11 +108,16 @@ def create_location_page_from_importer_dictionaries(page_dictionaries, revision_
     for edge in combined_dictionary['related_services']['edges']:
         service_to_add = edge['node']
         service_to_add['hours_exceptions'] += service_to_add['related_service']['title']
-        related_service = ServicePage.objects.first()
+
+        # We really are just trying to get hours imported here, but we can't save
+        # without having a page FK'd out to, so we use a placeholder service for now.
+        # In order to update this, we'll need to go into the location page and manually update the related service
+        related_service = ServicePage.objects.get(slug='placeholder_service_for_hours')
         if not related_service:
             related_service_dictionary = {
                 'parent': combined_dictionary['parent'],
-                'title': "related service"+service_to_add['related_service']['title']
+                'title': "placeholder service for hours",
+                'slug': "placeholder_service_for_hours"
             }
             related_service = ServicePageFactory.create(**related_service_dictionary)
         del service_to_add['related_service']

--- a/joplin/pages/location_page/factories.py
+++ b/joplin/pages/location_page/factories.py
@@ -4,6 +4,7 @@ import factory
 from pages.base_page.factories import JanisBasePageFactory
 from pages.home_page.models import HomePage
 from pages.service_page.models import ServicePage
+from pages.service_page.factories import ServicePageFactory
 from pages.location_page.models import LocationPage, LocationPageRelatedServices
 import pages.service_page.fixtures as service_page_fixtures
 
@@ -37,8 +38,8 @@ class LocationPageFactory(JanisBasePageFactory):
             # A list of related services were passed in,
             # this includes info about hours for the related service
             # todo: actually link the related service
-            for related_service in extracted:
-                LocationPageRelatedServicesFactory.create(page=self, **related_service)
+            for location_page_related_service in extracted:
+                LocationPageRelatedServicesFactory.create(page=self, **location_page_related_service)
             return
 
     class Meta:
@@ -107,7 +108,15 @@ def create_location_page_from_importer_dictionaries(page_dictionaries, revision_
     for edge in combined_dictionary['related_services']['edges']:
         service_to_add = edge['node']
         service_to_add['hours_exceptions'] += service_to_add['related_service']['title']
+        related_service = ServicePage.objects.first()
+        if not related_service:
+            related_service_dictionary = {
+                'parent': combined_dictionary['parent'],
+                'title': "related service"+service_to_add['related_service']['title']
+            }
+            related_service = ServicePageFactory.create(**related_service_dictionary)
         del service_to_add['related_service']
+        service_to_add['related_service'] = related_service
         combined_dictionary['add_related_services'].append(service_to_add)
     del combined_dictionary['related_services']
 

--- a/joplin/pages/location_page/factories.py
+++ b/joplin/pages/location_page/factories.py
@@ -93,6 +93,8 @@ def create_location_page_from_importer_dictionaries(page_dictionaries, revision_
     combined_dictionary['add_related_services'] = []
     for edge in combined_dictionary['related_services']['edges']:
         location_page_related_service_to_add = edge['node']
+
+        # since we're using a placeholder service, let's at least get the title somewhere to help us find the page
         location_page_related_service_to_add['hours_exceptions'] += location_page_related_service_to_add['related_service']['title']
 
         # We really are just trying to get hours imported here, but we can't save

--- a/joplin/pages/location_page/factories.py
+++ b/joplin/pages/location_page/factories.py
@@ -112,12 +112,16 @@ def create_location_page_from_importer_dictionaries(page_dictionaries, revision_
         # We really are just trying to get hours imported here, but we can't save
         # without having a page FK'd out to, so we use a placeholder service for now.
         # In order to update this, we'll need to go into the location page and manually update the related service
-        related_service = ServicePage.objects.get(slug='placeholder_service_for_hours')
+        # Check if page with (english) slug has already been imported
+        try:
+            related_service = ServicePage.objects.get(slug='placeholder_service_for_hours')
+        except ServicePage.DoesNotExist:
+            related_service = None
         if not related_service:
             related_service_dictionary = {
                 'parent': combined_dictionary['parent'],
-                'title': "placeholder service for hours",
-                'slug': "placeholder_service_for_hours"
+                'title': 'placeholder service for hours',
+                'slug': 'placeholder_service_for_hours'
             }
             related_service = ServicePageFactory.create(**related_service_dictionary)
         del service_to_add['related_service']

--- a/joplin/pages/location_page/factories.py
+++ b/joplin/pages/location_page/factories.py
@@ -3,14 +3,18 @@ import json
 import factory
 from pages.base_page.factories import JanisBasePageFactory
 from pages.home_page.models import HomePage
+from pages.service_page.models import ServicePage
 from pages.location_page.models import LocationPage, LocationPageRelatedServices
+import pages.service_page.fixtures as service_page_fixtures
 
 
 class LocationPageRelatedServicesFactory(factory.django.DjangoModelFactory):
     # find all your fields [f.name for f in MyModel._meta.get_fields()]
     page = factory.SubFactory('pages.location_page.factories.LocationPageFactory')
     # page = factory.Iterator(models.LocationPage.objects.all())
-    # related_service = factory.Iterator(ServicePage.objects.all())
+    # todo: actually get the service page relation
+    related_service = factory.SubFactory('pages.service_page.factories.ServicePageFactory')
+    # related_service = factory.Faker(ServicePage)
     # hours_exceptions = factory.Faker('text')
 
     # for field in models.LocationPageRelatedServices._meta.fields:

--- a/joplin/pages/location_page/factories.py
+++ b/joplin/pages/location_page/factories.py
@@ -10,7 +10,6 @@ class LocationPageFactory(JanisBasePageFactory):
         # todo: put some stuff for related service hours here
         return super(LocationPageFactory, cls).create(*args, **kwargs)
 
-
     class Meta:
         model = LocationPage
 

--- a/joplin/pages/location_page/tests.py
+++ b/joplin/pages/location_page/tests.py
@@ -8,7 +8,7 @@ from pages.location_page.factories import LocationPageFactory
 
 @pytest.mark.django_db
 def test_create_location_page_from_api(remote_staging_preview_url, remote_pytest_api):
-    url = f'{remote_staging_preview_url}/location/UGFnZVJldmlzaW9uTm9kZToyMw==?CMS_API={remote_pytest_api}'
+    url = f'{remote_staging_preview_url}/location/UGFnZVJldmlzaW9uTm9kZTozMA==?CMS_API={remote_pytest_api}'
     page = PageImporter(url).fetch_page_data().create_page()
     assert isinstance(page, LocationPage)
 


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description

<!--- include a summary of the change and what it fixes. -->
### What this does:
* When importing a location page, we also get service hours imported
### What this doesn't
* Actually connect the correct service page to the location page

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->
https://github.com/cityofaustin/techstack/issues/4219

<!--- If there is a relevant Janis PR, link it here -->
<!--- [Janis Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 
see tests pass
try importing location pages with related services that have hours

# Checklist:
- [x] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
