### PR TITLE
4223 - topic collections resolve their topics and top pages

### DIFF
--- a/.circleci/vars/branch_overrides.py
+++ b/.circleci/vars/branch_overrides.py
@@ -13,7 +13,7 @@ branch_overrides = {
         # "DEBUG_TOOLBAR": True,
         # "DEBUG": 1,
     },
-    "4224-resolve-dept": {
+    "4223-resolve-tc": {
         "LOAD_DATA": "",
         "V3_WIP": True,
     },

--- a/joplin/api/schema.py
+++ b/joplin/api/schema.py
@@ -17,7 +17,7 @@ from wagtail.core.rich_text import expand_db_html
 from snippets.contact.models import Contact, PhoneNumber, ContactDayAndDuration
 from base.models import TranslatedImage, Theme
 
-from pages.topic_collection_page.models import TopicCollectionPage, JanisBasePageWithTopicCollections
+from pages.topic_collection_page.models import TopicCollectionPage, JanisBasePageWithTopicCollections, JanisBasePageTopicCollection
 from pages.topic_page.models import TopicPage, TopicPageTopPage, JanisBasePageWithTopics
 from pages.service_page.models import ServicePage
 from pages.information_page.models import InformationPage
@@ -248,6 +248,14 @@ class TopicNode(DjangoObjectType):
         for t in self.topic_collections.values():
             tc.append(TopicCollectionPage.objects.get(id=t['topic_collection_id']))
         return tc
+
+
+class JanisBasePageTopicCollectionNode(DjangoObjectType):
+    class Meta:
+        model = JanisBasePageTopicCollection
+        filter_fields = ['topic_collection']
+        fields = '__all__'
+        interfaces = [graphene.Node]
 
 
 class LocationPageNode(DjangoObjectType):
@@ -838,6 +846,7 @@ class Query(graphene.ObjectType):
     all_form_containers = DjangoFilterConnectionField(FormContainerNode)
     all_location_pages = DjangoFilterConnectionField(LocationPageNode)
     all_event_pages = DjangoFilterConnectionField(EventPageNode, filterset_class=EventFilter)
+    topic_collection_topics = DjangoFilterConnectionField(JanisBasePageTopicCollectionNode)
 
     def resolve_page_revision(self, resolve_info, id=None):
         revision = graphene.Node.get_node_from_global_id(resolve_info, id)


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description

Janis needs topic collections to be able to query their topics and those topics' top pages. 

<!--- include a summary of the change and what it fixes. -->

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->

<!--- If there is a relevant Janis PR, link it here -->
<!--- [Janis Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 
https://joplin-pr-4223-resolve-tc.herokuapp.com/admin/pages/search/

https://joplin-pr-4223-resolve-tc.herokuapp.com/api/graphql
  "id" : "VG9waWNDb2xsZWN0aW9uTm9kZTo1"
```
query getTopicCollectionTopics($topicCollection: ID) {
  topicCollectionTopics(topicCollection: $topicCollection) {
    edges {
      node {
        page {
          topicpage {
            id
            title
            topPages {
              edges {
                node {
                  id
                  title
                }
              }
            }
          }
        }
      }
    }
  }
}
```

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
