### PR TITLE
fix publishing on guide pages

### DIFF
--- a/.circleci/vars/branch_overrides.py
+++ b/.circleci/vars/branch_overrides.py
@@ -20,5 +20,9 @@ branch_overrides = {
     "fixtures-and-previews": {
         "LOAD_DATA": "fixtures",
         "V3_WIP": True,
+    },
+    "4266-guide": {
+        "LOAD_DATA": "fixtures",
+        "V3_WIP": True,
     }
 }

--- a/joplin/pages/guide_page/models.py
+++ b/joplin/pages/guide_page/models.py
@@ -79,7 +79,7 @@ class GuidePage(JanisBasePageWithTopics):
 
     publish_requirements = (
         FieldPublishRequirement("description", message="A description is required for publishing", langs=["en"]),
-        RelationPublishRequirement("contacts", message="A contact is required for publishing."),
+        FieldPublishRequirement("contact", message="A contact is required for publishing."),
         StreamFieldPublishRequirement("sections", criteria=streamfield_has_pages),
         ConditionalPublishRequirement(
             RelationPublishRequirement("topics"),


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description
https://app.zenhub.com/workspaces/techstack-5a78b88e1ce69f3510b678ef/issues/cityofaustin/techstack/4266

- Change the requirement to "contact" from "contacts"
- It's also a FieldPublishRequirement now instead of a many to many sort of RelationPublishRequirement

<!--- include a summary of the change and what it fixes. -->

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->
http://joplin-pr-4266-guide.herokuapp.com/

- Test by building and publishing a guide page. It should work instead of breaking.
<!--- If there is a relevant Janis PR, link it here -->
<!--- [Janis Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
