### PR TITLE
4257: import form_container

### DIFF
--- a/README/add_new_content_type.md
+++ b/README/add_new_content_type.md
@@ -1,0 +1,13 @@
+## Creating a new page model
+
+TODO.
+
+## Importer
+
+Importer imports from preview urls, so we use the model's `janis_url_page_type` as the key within `importer/queries.py` and `pages/base_page/fixtures/helpers/page_type_map.py`.
+
+1. Add a query to get revision for your page_type in `importer/queries.py`.
+  - Test that you have what you wanted by running `pipenv run python joplin/importer/queries.py your_page_type`.
+2. Add your page_type's model and factory to `pages/base_page/fixtures/helpers/page_type_map.py`.
+  - The create_fixture function in `pages/base_page/fixtures/helpers/create_fixture_map.py` will be automatically created for you.
+3. Make a test case within `importer/tests.py` or `pages/your_page_type/tests.py` to ensure that importing works as expected.

--- a/joplin/importer/queries.py
+++ b/joplin/importer/queries.py
@@ -273,6 +273,27 @@ fragments["location"] = GraphqlParser('''
     owner=fragments["owner"],
 )
 
+fragments['form'] = GraphqlParser('''
+    title
+    slug
+    coaGlobal
+    description
+    formUrl
+    $$$owner
+    topics {
+      edges {
+        node {
+          topic {
+            $$$topic
+          }
+        }
+      }
+    }
+''').substitute(
+    topic=fragments["topic"],
+    owner=fragments["owner"],
+)
+
 unparsed_query_strings = {
     'topiccollection': '''
         query getTopicCollectionPageRevision($id: ID) {
@@ -359,6 +380,19 @@ unparsed_query_strings = {
               node {
                 asDepartmentPage {
                   $$$department
+                }
+              }
+            }
+          }
+        }
+    ''',
+    'form': '''
+        query getFormContainerRevisionQuery($id: ID) {
+          allPageRevisions(id: $id) {
+            edges {
+              node {
+                asFormContainer {
+                  $$$form
                 }
               }
             }

--- a/joplin/pages/base_page/fixtures/helpers/page_type_map.py
+++ b/joplin/pages/base_page/fixtures/helpers/page_type_map.py
@@ -16,6 +16,8 @@ from pages.event_page.models import EventPage
 from pages.event_page.factories import EventPageFactory
 from snippets.theme.models import Theme
 from snippets.theme.factories import ThemeFactory
+from pages.form_container.models import FormContainer
+from pages.form_container.factories import FormContainerFactory
 
 
 # TODO: Perhaps there is a better way to organize this all in one place.
@@ -56,5 +58,9 @@ page_type_map = {
     "theme": {
         "model": Theme,
         "factory": ThemeFactory,
+    },
+    "form": {
+        "model": FormContainer,
+        "factory": FormContainerFactory,
     }
 }

--- a/joplin/pages/form_container/factories.py
+++ b/joplin/pages/form_container/factories.py
@@ -1,0 +1,7 @@
+from pages.form_container.models import FormContainer
+from pages.topic_page.factories import JanisBasePageWithTopicsFactory
+
+
+class FormContainerFactory(JanisBasePageWithTopicsFactory):
+    class Meta:
+        model = FormContainer

--- a/joplin/pages/form_container/tests.py
+++ b/joplin/pages/form_container/tests.py
@@ -1,3 +1,10 @@
-from django.test import TestCase
+import pytest
+from importer.page_importer import PageImporter
+from pages.form_container.models import FormContainer
 
-# Create your tests here.
+
+@pytest.mark.django_db
+def test_create_form_container_from_api(remote_staging_preview_url, test_api_url, test_api_jwt_token):
+    url = f'{remote_staging_preview_url}/form/UGFnZVJldmlzaW9uTm9kZToyOQ==?CMS_API={test_api_url}'
+    page = PageImporter(url, test_api_jwt_token).fetch_page_data().create_page()
+    assert isinstance(page, FormContainer)


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description
https://github.com/cityofaustin/techstack/issues/4260

Here's a good example of all we need to import a new page_type.

You can test that it works by importing a form_container page.

https://joplin-pr-4260-import-form.herokuapp.com/

<!--- include a summary of the change and what it fixes. -->

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->

<!--- If there is a relevant Janis PR, link it here -->
<!--- [Janis Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
