### PR TITLE
Steps with options

### DIFF
--- a/joplin/pages/service_page/factories.py
+++ b/joplin/pages/service_page/factories.py
@@ -16,15 +16,14 @@ class ServicePageFactory(JanisBasePageWithTopicsFactory):
                 step_to_format = {'type': step['type']}
                 if step['type'] == 'step_with_options_accordian':
                     step_to_format['value'] = json.dumps({
-                        u'options_description': u'{0}'.format(step['value']['options_description']),
-                        u'options': u'{0}'.format(step['value'])
-                        'options': json.dumps([
+                        u'options': u'{0}'.format(json.dumps([
                             {
-                                u'option_name': u'{0}'.format(option['option_name']),
-                                u'option_description': u'{0}'.format(option['option_description'])
+                                u'option_description': u'{0}'.format(option['option_description']),
+                                u'option_name': u'{0}'.format(option['option_name'])
                             }
                             for option in step['value']['options']
-                        ])
+                        ])),
+                        u'options_description': u'{0}'.format(step['value']['options_description']),
                     })
                     # step_to_format['value'] = step['value']
                 else:

--- a/joplin/pages/service_page/factories.py
+++ b/joplin/pages/service_page/factories.py
@@ -10,12 +10,35 @@ class ServicePageFactory(JanisBasePageWithTopicsFactory):
         step_keywords = ['steps', 'steps_es']
         for step_keyword in step_keywords:
             steps = kwargs.pop(step_keyword, [])
+
+            steps_to_format = []
+            for step in steps:
+                step_to_format = {'type': step['type']}
+                if step['type'] == 'step_with_options_accordian':
+                    blarg = step['value']['options']
+
+                    blargacious = json.dumps([
+                        {
+                            u'option_name': u'{0}'.format(option['option_name']),
+                            u'option_description': u'{0}'.format(option['option_description'])
+                        }
+                        for option in blarg
+                    ])
+
+                    step_to_format['value'] = {
+                        'options_description': step['value']['options_description'],
+                        'options': blargacious
+                    }
+                else:
+                    step_to_format['value'] = step['value']
+                steps_to_format.append(step_to_format)
+
             formatted_steps = json.dumps([
                 {
                     u'type': u'{0}'.format(step['type']),
                     u'value': u'{0}'.format(step['value'])
                 }
-                for step in steps
+                for step in steps_to_format
             ])
             kwargs[step_keyword] = formatted_steps
         return super(ServicePageFactory, cls).create(*args, **kwargs)

--- a/joplin/pages/service_page/factories.py
+++ b/joplin/pages/service_page/factories.py
@@ -15,7 +15,7 @@ class ServicePageFactory(JanisBasePageWithTopicsFactory):
             for step in steps:
                 step_to_format = {'type': step['type']}
                 if step['type'] == 'step_with_options_accordian':
-                    step_to_format['value'] = {
+                    step_to_format['value'] = json.dumps([{
                         'options_description': step['value']['options_description'],
                         'options': json.dumps([
                             {
@@ -24,7 +24,8 @@ class ServicePageFactory(JanisBasePageWithTopicsFactory):
                             }
                             for option in step['value']['options']
                         ])
-                    }
+                    }])
+                    # step_to_format['value'] = step['value']
                 else:
                     step_to_format['value'] = step['value']
                 steps_to_format.append(step_to_format)

--- a/joplin/pages/service_page/factories.py
+++ b/joplin/pages/service_page/factories.py
@@ -15,19 +15,15 @@ class ServicePageFactory(JanisBasePageWithTopicsFactory):
             for step in steps:
                 step_to_format = {'type': step['type']}
                 if step['type'] == 'step_with_options_accordian':
-                    blarg = step['value']['options']
-
-                    blargacious = json.dumps([
-                        {
-                            u'option_name': u'{0}'.format(option['option_name']),
-                            u'option_description': u'{0}'.format(option['option_description'])
-                        }
-                        for option in blarg
-                    ])
-
                     step_to_format['value'] = {
                         'options_description': step['value']['options_description'],
-                        'options': blargacious
+                        'options': json.dumps([
+                            {
+                                u'option_name': u'{0}'.format(option['option_name']),
+                                u'option_description': u'{0}'.format(option['option_description'])
+                            }
+                            for option in step['value']['options']
+                        ])
                     }
                 else:
                     step_to_format['value'] = step['value']

--- a/joplin/pages/service_page/factories.py
+++ b/joplin/pages/service_page/factories.py
@@ -15,8 +15,9 @@ class ServicePageFactory(JanisBasePageWithTopicsFactory):
             for step in steps:
                 step_to_format = {'type': step['type']}
                 if step['type'] == 'step_with_options_accordian':
-                    step_to_format['value'] = json.dumps([{
-                        'options_description': step['value']['options_description'],
+                    step_to_format['value'] = json.dumps({
+                        u'options_description': u'{0}'.format(step['value']['options_description']),
+                        u'options': u'{0}'.format(step['value'])
                         'options': json.dumps([
                             {
                                 u'option_name': u'{0}'.format(option['option_name']),
@@ -24,7 +25,7 @@ class ServicePageFactory(JanisBasePageWithTopicsFactory):
                             }
                             for option in step['value']['options']
                         ])
-                    }])
+                    })
                     # step_to_format['value'] = step['value']
                 else:
                     step_to_format['value'] = step['value']

--- a/joplin/pages/service_page/factories.py
+++ b/joplin/pages/service_page/factories.py
@@ -11,33 +11,26 @@ class ServicePageFactory(JanisBasePageWithTopicsFactory):
         for step_keyword in step_keywords:
             steps = kwargs.pop(step_keyword, [])
 
-            steps_to_format = []
+            formatted_steps = []
             for step in steps:
-                step_to_format = {'type': step['type']}
+                formatted_step = {'type': u'{0}'.format(step['type'])}
                 if step['type'] == 'step_with_options_accordian':
-                    step_to_format['value'] = json.dumps({
-                        u'options': u'{0}'.format(json.dumps([
+                    formatted_step['value'] = {
+                        'options': [
                             {
                                 u'option_description': u'{0}'.format(option['option_description']),
                                 u'option_name': u'{0}'.format(option['option_name'])
                             }
                             for option in step['value']['options']
-                        ])),
+                        ],
                         u'options_description': u'{0}'.format(step['value']['options_description']),
-                    })
-                    # step_to_format['value'] = step['value']
+                    }
                 else:
-                    step_to_format['value'] = step['value']
-                steps_to_format.append(step_to_format)
+                    formatted_step['value'] = u'{0}'.format(step['value'])
+                formatted_steps.append(formatted_step)
 
-            formatted_steps = json.dumps([
-                {
-                    u'type': u'{0}'.format(step['type']),
-                    u'value': u'{0}'.format(step['value'])
-                }
-                for step in steps_to_format
-            ])
-            kwargs[step_keyword] = formatted_steps
+            json_steps = json.dumps(formatted_steps)
+            kwargs[step_keyword] = json_steps
         return super(ServicePageFactory, cls).create(*args, **kwargs)
 
 

--- a/joplin/pages/service_page/fixtures/__init__.py
+++ b/joplin/pages/service_page/fixtures/__init__.py
@@ -1,6 +1,7 @@
 from .test_cases.title import title
 from .test_cases.steps_2 import steps_2
 from .test_cases.steps_with_appblocks import steps_with_appblocks
+from .test_cases.step_with_options import step_with_options
 from .test_cases.new_contact import new_contact
 from .test_cases.kitchen_sink import kitchen_sink
 
@@ -11,5 +12,6 @@ def load_all():
     title()
     steps_2()
     steps_with_appblocks()
+    step_with_options()
     new_contact()
     kitchen_sink()

--- a/joplin/pages/service_page/fixtures/helpers/components.py
+++ b/joplin/pages/service_page/fixtures/helpers/components.py
@@ -85,23 +85,43 @@ step_with_options = [
         "value": {
             "options": [
                 {
-                    "option_description": "<p>Required information</p><ul><li>What happened</li></ul><p>Optional information</p><ul><li>Date and time</li><li>Officer(s) involved</li></ul><p></p><p><a href=\"https://forms.austin.gov/police-thank/what-happened\">Start</a></p>",
-                    "option_name": "Online"
+                    "option_description": "<p>option</p>",
+                    "option_name": "option"
                 },
                 {
-                    "option_description": "<p>Call the Office of Police Oversight at (512) 972-2676. We’d be happy to speak with you.</p><p>If you need an interpreter, you can call with a friend to interpret for you or ask for an interpreter. Just tell us the language you prefer.</p><p>Office hours are Monday through Friday, 8 am to 5 pm.</p>",
-                    "option_name": "Over the phone"
+                    "option_description": "<p>option 2</p>",
+                    "option_name": "option 2"
                 },
-                {
-                    "option_description": "<p>You can share thanks in person at the <a href=\"https://janis.austintexas.io/en/location/office-of-police-oversight\">Office of Police Oversight</a> at 1520 Rutherford Lane, Austin, TX 78754. We are in Building 1, on the 2nd floor, Suite 211. Visitor parking is in front of the main entrance.</p><p>Office hours are Monday through Friday, 8 am to 5 pm.</p>",
-                    "option_name": "In person"
-                },
-                {
-                    "option_description": "<p><a href=\"https://forms.austin.gov/files/OPO_thanks-form_print_English.pdf\">Download the thanks form (PDF)</a>. Print and fill out the form, then mail it to:</p><p>Office of Police Oversight</p><p>P.O. Box 1088</p><p>Austin, TX 78767</p>",
-                    "option_name": "By mail"
-                }
             ],
-            "options_description": "<p>Select an option for saying thanks.</p>"
+            "options_description": "<p>options description</p>"
         }
     },
 ]
+
+#
+# step_with_options = [
+#     {
+#         "type": "step_with_options_accordian",
+#         "value": {
+#             "options": [
+#                 {
+#                     "option_description": "<p>Required information</p><ul><li>What happened</li></ul><p>Optional information</p><ul><li>Date and time</li><li>Officer(s) involved</li></ul><p></p><p><a href=\"https://forms.austin.gov/police-thank/what-happened\">Start</a></p>",
+#                     "option_name": "Online"
+#                 },
+#                 {
+#                     "option_description": "<p>Call the Office of Police Oversight at (512) 972-2676. We’d be happy to speak with you.</p><p>If you need an interpreter, you can call with a friend to interpret for you or ask for an interpreter. Just tell us the language you prefer.</p><p>Office hours are Monday through Friday, 8 am to 5 pm.</p>",
+#                     "option_name": "Over the phone"
+#                 },
+#                 {
+#                     "option_description": "<p>You can share thanks in person at the <a href=\"https://janis.austintexas.io/en/location/office-of-police-oversight\">Office of Police Oversight</a> at 1520 Rutherford Lane, Austin, TX 78754. We are in Building 1, on the 2nd floor, Suite 211. Visitor parking is in front of the main entrance.</p><p>Office hours are Monday through Friday, 8 am to 5 pm.</p>",
+#                     "option_name": "In person"
+#                 },
+#                 {
+#                     "option_description": "<p><a href=\"https://forms.austin.gov/files/OPO_thanks-form_print_English.pdf\">Download the thanks form (PDF)</a>. Print and fill out the form, then mail it to:</p><p>Office of Police Oversight</p><p>P.O. Box 1088</p><p>Austin, TX 78767</p>",
+#                     "option_name": "By mail"
+#                 }
+#             ],
+#             "options_description": "<p>Select an option for saying thanks.</p>"
+#         }
+#     },
+# ]

--- a/joplin/pages/service_page/fixtures/helpers/components.py
+++ b/joplin/pages/service_page/fixtures/helpers/components.py
@@ -78,3 +78,30 @@ steps_2 = [
                  'the week.</p>'
     }
 ]
+
+step_with_options = [
+    {
+        "type": "step_with_options_accordian",
+        "value": {
+            "options": [
+                {
+                    "option_description": "<p>Required information</p><ul><li>What happened</li></ul><p>Optional information</p><ul><li>Date and time</li><li>Officer(s) involved</li></ul><p></p><p><a href=\"https://forms.austin.gov/police-thank/what-happened\">Start</a></p>",
+                    "option_name": "Online"
+                },
+                {
+                    "option_description": "<p>Call the Office of Police Oversight at (512) 972-2676. We’d be happy to speak with you.</p><p>If you need an interpreter, you can call with a friend to interpret for you or ask for an interpreter. Just tell us the language you prefer.</p><p>Office hours are Monday through Friday, 8 am to 5 pm.</p>",
+                    "option_name": "Over the phone"
+                },
+                {
+                    "option_description": "<p>You can share thanks in person at the <a href=\"https://janis.austintexas.io/en/location/office-of-police-oversight\">Office of Police Oversight</a> at 1520 Rutherford Lane, Austin, TX 78754. We are in Building 1, on the 2nd floor, Suite 211. Visitor parking is in front of the main entrance.</p><p>Office hours are Monday through Friday, 8 am to 5 pm.</p>",
+                    "option_name": "In person"
+                },
+                {
+                    "option_description": "<p><a href=\"https://forms.austin.gov/files/OPO_thanks-form_print_English.pdf\">Download the thanks form (PDF)</a>. Print and fill out the form, then mail it to:</p><p>Office of Police Oversight</p><p>P.O. Box 1088</p><p>Austin, TX 78767</p>",
+                    "option_name": "By mail"
+                }
+            ],
+            "options_description": "<p>Select an option for saying thanks.</p>"
+        }
+    },
+]

--- a/joplin/pages/service_page/fixtures/helpers/components.py
+++ b/joplin/pages/service_page/fixtures/helpers/components.py
@@ -85,43 +85,23 @@ step_with_options = [
         "value": {
             "options": [
                 {
-                    "option_description": "<p>option</p>",
-                    "option_name": "option"
+                    "option_description": "<p>Required information</p><ul><li>What happened</li></ul><p>Optional information</p><ul><li>Date and time</li><li>Officer(s) involved</li></ul><p></p><p><a href=\"https://forms.austin.gov/police-thank/what-happened\">Start</a></p>",
+                    "option_name": "Online"
                 },
                 {
-                    "option_description": "<p>option 2</p>",
-                    "option_name": "option 2"
+                    "option_description": "<p>Call the Office of Police Oversight at (512) 972-2676. We’d be happy to speak with you.</p><p>If you need an interpreter, you can call with a friend to interpret for you or ask for an interpreter. Just tell us the language you prefer.</p><p>Office hours are Monday through Friday, 8 am to 5 pm.</p>",
+                    "option_name": "Over the phone"
                 },
+                {
+                    "option_description": "<p>You can share thanks in person at the <a href=\"https://janis.austintexas.io/en/location/office-of-police-oversight\">Office of Police Oversight</a> at 1520 Rutherford Lane, Austin, TX 78754. We are in Building 1, on the 2nd floor, Suite 211. Visitor parking is in front of the main entrance.</p><p>Office hours are Monday through Friday, 8 am to 5 pm.</p>",
+                    "option_name": "In person"
+                },
+                {
+                    "option_description": "<p><a href=\"https://forms.austin.gov/files/OPO_thanks-form_print_English.pdf\">Download the thanks form (PDF)</a>. Print and fill out the form, then mail it to:</p><p>Office of Police Oversight</p><p>P.O. Box 1088</p><p>Austin, TX 78767</p>",
+                    "option_name": "By mail"
+                }
             ],
-            "options_description": "<p>options description</p>"
+            "options_description": "<p>Select an option for saying thanks.</p>"
         }
     },
 ]
-
-#
-# step_with_options = [
-#     {
-#         "type": "step_with_options_accordian",
-#         "value": {
-#             "options": [
-#                 {
-#                     "option_description": "<p>Required information</p><ul><li>What happened</li></ul><p>Optional information</p><ul><li>Date and time</li><li>Officer(s) involved</li></ul><p></p><p><a href=\"https://forms.austin.gov/police-thank/what-happened\">Start</a></p>",
-#                     "option_name": "Online"
-#                 },
-#                 {
-#                     "option_description": "<p>Call the Office of Police Oversight at (512) 972-2676. We’d be happy to speak with you.</p><p>If you need an interpreter, you can call with a friend to interpret for you or ask for an interpreter. Just tell us the language you prefer.</p><p>Office hours are Monday through Friday, 8 am to 5 pm.</p>",
-#                     "option_name": "Over the phone"
-#                 },
-#                 {
-#                     "option_description": "<p>You can share thanks in person at the <a href=\"https://janis.austintexas.io/en/location/office-of-police-oversight\">Office of Police Oversight</a> at 1520 Rutherford Lane, Austin, TX 78754. We are in Building 1, on the 2nd floor, Suite 211. Visitor parking is in front of the main entrance.</p><p>Office hours are Monday through Friday, 8 am to 5 pm.</p>",
-#                     "option_name": "In person"
-#                 },
-#                 {
-#                     "option_description": "<p><a href=\"https://forms.austin.gov/files/OPO_thanks-form_print_English.pdf\">Download the thanks form (PDF)</a>. Print and fill out the form, then mail it to:</p><p>Office of Police Oversight</p><p>P.O. Box 1088</p><p>Austin, TX 78767</p>",
-#                     "option_name": "By mail"
-#                 }
-#             ],
-#             "options_description": "<p>Select an option for saying thanks.</p>"
-#         }
-#     },
-# ]

--- a/joplin/pages/service_page/fixtures/test_cases/kitchen_sink.py
+++ b/joplin/pages/service_page/fixtures/test_cases/kitchen_sink.py
@@ -7,6 +7,7 @@ from pages.topic_page.fixtures.test_cases import kitchen_sink as kitchen_sink_to
 # A "kitchen sink" service page
 def kitchen_sink():
     topic = kitchen_sink_topic.kitchen_sink()
+    steps = components.steps_with_appblocks.extend(components.steps_2).extend(components.step_with_options)
 
     page_data = {
         "imported_revision_id": None,
@@ -21,7 +22,7 @@ def kitchen_sink():
         },
         "short_description": "Kitchen sink service page short description [en]",
         "dynamic_content": components.dynamic_content,
-        "steps": components.steps_2,
+        "steps": steps,
     }
 
     return create_fixture(page_data, os.path.basename(__file__))

--- a/joplin/pages/service_page/fixtures/test_cases/kitchen_sink.py
+++ b/joplin/pages/service_page/fixtures/test_cases/kitchen_sink.py
@@ -7,7 +7,9 @@ from pages.topic_page.fixtures.test_cases import kitchen_sink as kitchen_sink_to
 # A "kitchen sink" service page
 def kitchen_sink():
     topic = kitchen_sink_topic.kitchen_sink()
-    steps = components.steps_with_appblocks.extend(components.steps_2).extend(components.step_with_options)
+    steps = components.steps_with_appblocks
+    steps.extend(components.steps_2)
+    steps.extend(components.step_with_options)
 
     page_data = {
         "imported_revision_id": None,

--- a/joplin/pages/service_page/fixtures/test_cases/step_with_options.py
+++ b/joplin/pages/service_page/fixtures/test_cases/step_with_options.py
@@ -1,0 +1,23 @@
+import os
+from pages.service_page.fixtures.helpers.create_fixture import create_fixture
+import pages.service_page.fixtures.helpers.components as components
+
+
+# A fixture with a step with options
+def step_with_options():
+    page_data = {
+        "imported_revision_id": None,
+        "live": False,
+        "parent": components.home(),
+        "coa_global": False,
+        "title": "Service Page with a Step with options",
+        "slug": "step-with-yee-or-haw",
+        "add_topics": {
+            "topics": []
+        },
+        "short_description": "This is a very short description",
+        "dynamic_content": components.dynamic_content,
+        "steps": components.step_with_options,
+    }
+
+    return create_fixture(page_data, os.path.basename(__file__))

--- a/joplin/pages/service_page/tests.py
+++ b/joplin/pages/service_page/tests.py
@@ -57,13 +57,17 @@ def test_create_service_page_with_appblock_steps():
 @pytest.mark.django_db
 def test_create_service_page_with_step_with_options():
     page = fixtures.step_with_options()
-    expected_steps = components.step_with_options
+
     assert isinstance(page, ServicePage)
     assert page.title == "Service Page with a Step with options"
     assert page.slug == "step-with-yee-or-haw"
-    for i, step in enumerate(page.steps.stream_data):
-        assert step["type"] == expected_steps[i]["type"]
-        assert step["value"] == expected_steps[i]["value"]
+    step_with_options = page.steps.stream_data[0]['value']
+    assert False
+    for i, option in step_with_options['options']:
+        # todo test the options
+        assert False
+        # assert step["type"] == expected_steps[i]["type"]
+        # assert step["value"] == expected_steps[i]["value"]
 
 
 @pytest.mark.django_db

--- a/joplin/pages/service_page/tests.py
+++ b/joplin/pages/service_page/tests.py
@@ -62,16 +62,9 @@ def test_create_service_page_with_step_with_options():
     assert isinstance(page, ServicePage)
     assert page.title == "Service Page with a Step with options"
     assert page.slug == "step-with-yee-or-haw"
-    # for i, step in enumerate(page.steps.stream_data):
-    #     assert step["type"] == expected_steps[i]["type"]
-    #     assert step["value"] == expected_steps[i]["value"]
-
-    step_with_options = page.steps.stream_data[0]['value']
-    for i, option in step_with_options['options']:
-        # todo test the options
-        assert False
-        # assert step["type"] == expected_steps[i]["type"]
-        # assert step["value"] == expected_steps[i]["value"]
+    for i, step in enumerate(page.steps.stream_data):
+        assert step["type"] == expected_steps[i]["type"]
+        assert step["value"] == expected_steps[i]["value"]
 
 
 @pytest.mark.django_db

--- a/joplin/pages/service_page/tests.py
+++ b/joplin/pages/service_page/tests.py
@@ -57,12 +57,16 @@ def test_create_service_page_with_appblock_steps():
 @pytest.mark.django_db
 def test_create_service_page_with_step_with_options():
     page = fixtures.step_with_options()
+    expected_steps = components.step_with_options
 
     assert isinstance(page, ServicePage)
     assert page.title == "Service Page with a Step with options"
     assert page.slug == "step-with-yee-or-haw"
+    for i, step in enumerate(page.steps.stream_data):
+        assert step["type"] == expected_steps[i]["type"]
+        assert step["value"] == expected_steps[i]["value"]
+
     step_with_options = page.steps.stream_data[0]['value']
-    assert False
     for i, option in step_with_options['options']:
         # todo test the options
         assert False

--- a/joplin/pages/service_page/tests.py
+++ b/joplin/pages/service_page/tests.py
@@ -55,6 +55,18 @@ def test_create_service_page_with_appblock_steps():
 
 
 @pytest.mark.django_db
+def test_create_service_page_with_step_with_options():
+    page = fixtures.step_with_options()
+    expected_steps = components.step_with_options
+    assert isinstance(page, ServicePage)
+    assert page.title == "Service Page with a Step with options"
+    assert page.slug == "step-with-yee-or-haw"
+    for i, step in enumerate(page.steps.stream_data):
+        assert step["type"] == expected_steps[i]["type"]
+        assert step["value"] == expected_steps[i]["value"]
+
+
+@pytest.mark.django_db
 def test_create_service_page_with_new_contact():
     page = fixtures.new_contact()
     assert isinstance(page, ServicePage)

--- a/joplin/pages/service_page/tests.py
+++ b/joplin/pages/service_page/tests.py
@@ -62,9 +62,9 @@ def test_create_service_page_with_step_with_options():
     assert isinstance(page, ServicePage)
     assert page.title == "Service Page with a Step with options"
     assert page.slug == "step-with-yee-or-haw"
-    for i, step in enumerate(page.steps.stream_data):
-        assert step["type"] == expected_steps[i]["type"]
-        assert step["value"] == expected_steps[i]["value"]
+    # for i, step in enumerate(page.steps.stream_data):
+    #     assert step["type"] == expected_steps[i]["type"]
+    #     assert step["value"] == expected_steps[i]["value"]
 
     step_with_options = page.steps.stream_data[0]['value']
     for i, option in step_with_options['options']:


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description
When trying to import https://janis.austintexas.io/en/preview/services/UGFnZVJldmlzaW9uTm9kZTozMjM1 in an effort to test out associated department importing, I found that importing steps with options was broken. This address that by:
* adding fixture data for step with options
* adding a test for steps with options
* making that test pass by updating the Service Page factory

<!--- include a summary of the change and what it fixes. -->

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->

<!--- If there is a relevant Janis PR, link it here -->
<!--- [Janis Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 

# Checklist:
- [x] Request reviewers
- [x] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
