### PR TITLE
4274 are we live? (import live/draft with importer)

### DIFF
--- a/.circleci/vars/branch_overrides.py
+++ b/.circleci/vars/branch_overrides.py
@@ -24,5 +24,9 @@ branch_overrides = {
     "4266-guide": {
         "LOAD_DATA": "fixtures",
         "V3_WIP": True,
+    },
+    "4274-are-we-live": {
+        "LOAD_DATA": "fixtures",
+        "V3_WIP": True,
     }
 }

--- a/joplin/importer/queries.py
+++ b/joplin/importer/queries.py
@@ -65,6 +65,7 @@ fragments['department'] = GraphqlParser('''
     liveRevision {
         id
     }
+    live
 ''').substitute(
     contact=fragments["contact"],
     owner=fragments["owner"],
@@ -82,6 +83,7 @@ fragments["topiccollection"] = '''
         text
         description
       }
+      live
 '''
 
 fragments["topic"] = GraphqlParser('''
@@ -100,6 +102,7 @@ fragments["topic"] = GraphqlParser('''
         }
       }
     }
+    live
 ''').substitute(
     topiccollection=fragments["topiccollection"]
 )
@@ -132,6 +135,7 @@ fragments["information"] = GraphqlParser('''
     departments {
         $$$department
     }
+    live
 ''').substitute(
     topic=fragments["topic"],
     contact=fragments["contact"],
@@ -169,6 +173,7 @@ fragments["services"] = GraphqlParser('''
     departments {
         $$$department
     }
+    live
 ''').substitute(
     topic=fragments["topic"],
     contact=fragments["contact"],
@@ -240,6 +245,7 @@ fragments["official_document"] = GraphqlParser('''
     departments {
         $$$department
     }
+    live
 ''').substitute(
     department=fragments["department"],
     topic=fragments["topic"],
@@ -285,6 +291,7 @@ fragments["location"] = GraphqlParser('''
     departments {
         $$$department
     }
+    live
 ''').substitute(
     hours=fragments["hours"],
     owner=fragments["owner"],
@@ -310,6 +317,7 @@ fragments['form'] = GraphqlParser('''
     departments {
         $$$department
     }
+    live
 ''').substitute(
     topic=fragments["topic"],
     owner=fragments["owner"],

--- a/joplin/importer/tests.py
+++ b/joplin/importer/tests.py
@@ -133,7 +133,8 @@ def test_get_dummy_topic_page_from_revision(remote_staging_preview_url, test_api
                     },
                     'live_revision': {
                         'id': 'UGFnZVJldmlzaW9uTm9kZToz'
-                    }
+                    },
+                    'live': True
                 }
             }
         }]
@@ -173,14 +174,16 @@ def test_get_dummy_information_page_from_revision(remote_staging_preview_url, te
                                     },
                                     'live_revision': {
                                         'id': 'UGFnZVJldmlzaW9uTm9kZToz'
-                                    }
+                                    },
+                                    'live': True
                                 }
                             }
                         }]
                     },
                     'live_revision': {
                         'id': 'UGFnZVJldmlzaW9uTm9kZToxMg=='
-                    }
+                    },
+                    'live': True
                 }
             }
         }]

--- a/joplin/pages/information_page/tests.py
+++ b/joplin/pages/information_page/tests.py
@@ -168,7 +168,7 @@ def test_get_live_page_from_api(remote_staging_preview_url, test_api_url, test_a
     assert isinstance(page, InformationPage)
     assert page.title == 'Live page'
     assert page.description == 'this page is live'
-    assert False
+    assert page.live
 
 
 @pytest.mark.django_db
@@ -177,7 +177,7 @@ def test_get_draft_page_from_api(remote_staging_preview_url, test_api_url, test_
     page = PageImporter(url, test_api_jwt_token).fetch_page_data().create_page()
     assert isinstance(page, InformationPage)
     assert page.title == 'Draft page'
-    assert False
+    assert not page.live
 
 
 @pytest.mark.django_db

--- a/joplin/pages/information_page/tests.py
+++ b/joplin/pages/information_page/tests.py
@@ -162,6 +162,25 @@ def test_create_information_page_with_contact_from_api(remote_staging_preview_ur
 
 
 @pytest.mark.django_db
+def test_get_live_page_from_api(remote_staging_preview_url, test_api_url, test_api_jwt_token):
+    url = f'{remote_staging_preview_url}/information/UGFnZVJldmlzaW9uTm9kZTo0Mg==?CMS_API={test_api_url}'
+    page = PageImporter(url, test_api_jwt_token).fetch_page_data().create_page()
+    assert isinstance(page, InformationPage)
+    assert page.title == 'Live page'
+    assert page.description == 'this page is live'
+    assert False
+
+
+@pytest.mark.django_db
+def test_get_draft_page_from_api(remote_staging_preview_url, test_api_url, test_api_jwt_token):
+    url = f'{remote_staging_preview_url}/information/UGFnZVJldmlzaW9uTm9kZTo0MA==?CMS_API={test_api_url}'
+    page = PageImporter(url, test_api_jwt_token).fetch_page_data().create_page()
+    assert isinstance(page, InformationPage)
+    assert page.title == 'Draft page'
+    assert False
+
+
+@pytest.mark.django_db
 def test_create_information_page_with_new_contact():
     page = fixtures.new_contact()
     assert isinstance(page, InformationPage)


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description
When importing pages, we now query for live and pass it along to the factories.

<!--- include a summary of the change and what it fixes. -->

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->
https://github.com/cityofaustin/techstack/issues/4274

<!--- If there is a relevant Janis PR, link it here -->
<!--- [Janis Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 
* go here https://joplin-pr-4274-are-we-live.herokuapp.com/
* Try importing a page that's live and a page that's a draft
* See that the live page is imported as live and the draft is imported as a draft

# Checklist:
- [x] Request reviewers
- [x] Slack-out message for review
- [x] Link this PR in the issue
- [x] Moved card to *review* in zenhub
