### PR TITLE
Add live and latest to page revision query

### DIFF
--- a/joplin/api/schema.py
+++ b/joplin/api/schema.py
@@ -763,6 +763,7 @@ class PageRevisionNode(DjangoObjectType):
     as_location_page = graphene.NonNull(LocationPageNode)
     as_event_page = graphene.NonNull(EventPageNode)
     is_latest = graphene.Boolean()
+    is_live = graphene.Boolean()
 
     def resolve_as_service_page(self, resolve_info, *args, **kwargs):
         return self.as_page_object()
@@ -796,6 +797,9 @@ class PageRevisionNode(DjangoObjectType):
 
     def resolve_is_latest(self, resolve_info, *args, **kwargs):
         return self.created_at == self.page.latest_revision_created_at
+
+    def resolve_is_live(self, resolve_info, *args, **kwargs):
+        return self == self.page.live_revision
 
     class Meta:
         model = PageRevision

--- a/joplin/api/schema.py
+++ b/joplin/api/schema.py
@@ -762,6 +762,7 @@ class PageRevisionNode(DjangoObjectType):
     as_form_container = graphene.NonNull(FormContainerNode)
     as_location_page = graphene.NonNull(LocationPageNode)
     as_event_page = graphene.NonNull(EventPageNode)
+    is_latest = graphene.Boolean()
 
     def resolve_as_service_page(self, resolve_info, *args, **kwargs):
         return self.as_page_object()
@@ -792,6 +793,9 @@ class PageRevisionNode(DjangoObjectType):
 
     def resolve_as_event_page(self, resolve_info, *args, **kwargs):
         return self.as_page_object()
+
+    def resolve_is_latest(self, resolve_info, *args, **kwargs):
+        return self.created_at == self.page.latest_revision_created_at
 
     class Meta:
         model = PageRevision

--- a/joplin/api/schema.py
+++ b/joplin/api/schema.py
@@ -764,6 +764,7 @@ class PageRevisionNode(DjangoObjectType):
     as_event_page = graphene.NonNull(EventPageNode)
     is_latest = graphene.Boolean()
     is_live = graphene.Boolean()
+    page_type = graphene.String()
 
     def resolve_as_service_page(self, resolve_info, *args, **kwargs):
         return self.as_page_object()
@@ -800,6 +801,9 @@ class PageRevisionNode(DjangoObjectType):
 
     def resolve_is_live(self, resolve_info, *args, **kwargs):
         return self == self.page.live_revision
+
+    def resolve_page_type(self, resolve_info, *args, **kwargs):
+        return self.page.content_type.name
 
     class Meta:
         model = PageRevision


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description
Add a few quick resolvers in the schema to help us get info we need to do a full import.

<!--- include a summary of the change and what it fixes. -->

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->

<!--- If there is a relevant Janis PR, link it here -->
<!--- [Janis Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 
This [graphql query](http://joplin-pr-latest-revision.herokuapp.com/api/graphiql#query=%7B%0A%09allPageRevisions(last%3A20)%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20isLatest%0A%20%20%20%20%20%20%20%20isLive%0A%20%20%20%20%20%20%20%20pageType%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D) shows off the benefits quite well


# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
