### PR TITLE
Api page type and description

### DIFF
--- a/.circleci/vars/branch_overrides.py
+++ b/.circleci/vars/branch_overrides.py
@@ -28,5 +28,9 @@ branch_overrides = {
     "4274-are-we-live": {
         "LOAD_DATA": "fixtures",
         "V3_WIP": True,
+    },
+    "api-page-type-and-description": {
+        "LOAD_DATA": "fixtures",
+        "V3_WIP": True,
     }
 }

--- a/joplin/api/schema.py
+++ b/joplin/api/schema.py
@@ -180,6 +180,8 @@ class ContextualNavData(graphene.ObjectType):
 class JanisBasePageNode(DjangoObjectType):
     janis_urls = graphene.List(graphene.String)
     janis_instances = graphene.List(ContextualNavData)
+    page_type = graphene.String()
+    description = graphene.String()
 
     class Meta:
         model = JanisBasePage
@@ -188,6 +190,15 @@ class JanisBasePageNode(DjangoObjectType):
 
     def resolve_janis_urls(self, info):
         return self.specific.janis_urls()
+
+    def resolve_page_type(self, info):
+        return self.content_type
+
+    def resolve_description(self, info):
+        if hasattr(self.specific, "short_description"):
+            return self.specific.short_description
+        elif hasattr(self.specific, "mission"):
+            return self.specific.mission
 
     def resolve_janis_instances(self, info):
         instances = []

--- a/joplin/api/schema.py
+++ b/joplin/api/schema.py
@@ -181,7 +181,7 @@ class JanisBasePageNode(DjangoObjectType):
     janis_urls = graphene.List(graphene.String)
     janis_instances = graphene.List(ContextualNavData)
     page_type = graphene.String()
-    description = graphene.String()
+    summery = graphene.String()
 
     class Meta:
         model = JanisBasePage
@@ -194,7 +194,7 @@ class JanisBasePageNode(DjangoObjectType):
     def resolve_page_type(self, info):
         return self.content_type
 
-    def resolve_description(self, info):
+    def resolve_summery(self, info):
         if hasattr(self.specific, "short_description"):
             return self.specific.short_description
         elif hasattr(self.specific, "mission"):


### PR DESCRIPTION
This changes our  allPages API to include page types and descriptions for page indexes. 

Example graphql query used to build search  indexes.

- I modified the basepage a bit to allow for `page types` and `short descriptions` and filtered out non-`live` pages. 

```
{
  allPages(live: true) {
    edges {
      node {
        id
        title
        janisUrls
        pageType
        summery
      }
    }
  }
}
```

To Test: 
- See API queries include all current page data deployed branch's  in Joplin.

Deployed: http://joplin-pr-api-pagetype-descrip.herokuapp.com

URL query:  http://joplin-pr-api-pagetype-descrip.herokuapp.com/api/graphql/?query={%20allPages(live:%20true)%20{%20edges%20{%20node%20{%20id%20title%20janisUrls%20pageType%20summery%20}%20}%20}%20}

Graphiql: http://joplin-pr-api-pagetype-descrip.herokuapp.com/api/graphiql/#query=%7B%0A%20%20allPages(live%3A%20true)%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20id%0A%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20janisUrls%0A%20%20%20%20%20%20%20%20pageType%0A%20%20%20%20%20%20%20%20summery%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D