### PR TITLE
4275 step with location

### DIFF
--- a/joplin/importer/create_from_importer.py
+++ b/joplin/importer/create_from_importer.py
@@ -371,8 +371,6 @@ def create_page_from_importer(page_type, page_dictionaries, revision_id=None):
     # Handle 'steps_with_locations' in services
     if page_type is 'services':
         if 'steps' in combined_dictionary:
-            # Only import step with location if we have that location already.
-            removed_locations = False
             '''
             Important note!
             We are iterating through copies of each list.
@@ -383,7 +381,9 @@ def create_page_from_importer(page_type, page_dictionaries, revision_id=None):
             you're iterating through.
             '''
             for i, step in enumerate(combined_dictionary["steps"][:]):
+                # Only import step with location if we have that location already.
                 if step['type'] == 'step_with_locations':
+                    removed_locations = False
                     for j, location in enumerate(step["value"]["locations"][:]):
                         # Add location_page data only if location was already imported.
                         # Right now, a "step_with_location" does not provide enough location_page

--- a/joplin/pages/home_page/models.py
+++ b/joplin/pages/home_page/models.py
@@ -67,4 +67,4 @@ class HomePage(Page):
         if settings.IS_STAGING or settings.IS_PRODUCTION:
             return settings.JANIS_URL
         else:
-            return getattr(self, publish_janis_branch_for_pr)
+            return getattr(self, "publish_janis_branch_for_pr")

--- a/joplin/pages/location_page/fixtures/__init__.py
+++ b/joplin/pages/location_page/fixtures/__init__.py
@@ -1,7 +1,11 @@
 from .test_cases.title import title
+from .test_cases.live_library import live_library
+from .test_cases.live_city_hall import live_city_hall
 
 
 # You can import any test_case fixture individually
 # Or you can load them all with this function
 def load_all():
     title()
+    live_library()
+    live_city_hall()

--- a/joplin/pages/location_page/fixtures/test_cases/live_city_hall.py
+++ b/joplin/pages/location_page/fixtures/test_cases/live_city_hall.py
@@ -1,0 +1,21 @@
+import os
+from pages.location_page.fixtures.helpers.create_fixture import create_fixture
+import pages.location_page.fixtures.helpers.components as components
+
+
+# A Live location page sample
+def live_city_hall():
+    page_data = {
+        "imported_revision_id": None,
+        "live": True,
+        "parent": components.home(),
+        "coa_global": False,
+        "title": "City Hall",
+        "slug": "city-hall",
+        "physical_street": "124 West 8th St.",
+        "physical_zip": 78701,
+        "physical_city": "Austin",
+        "physical_state": "TX",
+    }
+
+    return create_fixture(page_data, os.path.basename(__file__))

--- a/joplin/pages/location_page/fixtures/test_cases/live_library.py
+++ b/joplin/pages/location_page/fixtures/test_cases/live_library.py
@@ -1,0 +1,21 @@
+import os
+from pages.location_page.fixtures.helpers.create_fixture import create_fixture
+import pages.location_page.fixtures.helpers.components as components
+
+
+# A Live location page sample
+def live_library():
+    page_data = {
+        "imported_revision_id": None,
+        "live": True,
+        "parent": components.home(),
+        "coa_global": False,
+        "title": "Faulk Library",
+        "slug": "faulk-library",
+        "physical_street": "800 Guadalupe St.",
+        "physical_zip": 78701,
+        "physical_city": "Austin",
+        "physical_state": "TX",
+    }
+
+    return create_fixture(page_data, os.path.basename(__file__))

--- a/joplin/pages/service_page/factories.py
+++ b/joplin/pages/service_page/factories.py
@@ -1,52 +1,20 @@
 import json
 from pages.service_page.models import ServicePage
 from pages.topic_page.factories import JanisBasePageWithTopicsFactory
+from pages.base_page.fixtures.helpers.streamfieldify import streamfieldify
 
 
 class ServicePageFactory(JanisBasePageWithTopicsFactory):
     @classmethod
     def create(cls, *args, **kwargs):
-        # if we have dynamic content
         if 'dynamic_content' in kwargs:
-            # convert it into a StreamField-parseable json dump
-            formatted_dynamic_content = json.dumps([
-                {
-                    u'type': u'{0}'.format(dynamic_content_block['type']),
-                    u'value': u'{0}'.format(dynamic_content_block['value'])
-                }
-                for dynamic_content_block in kwargs['dynamic_content']
-            ])
-            kwargs['dynamic_content'] = formatted_dynamic_content
+            kwargs['dynamic_content'] = streamfieldify(kwargs['dynamic_content'])
 
-        # Convert steps into StreamField-parseable json dump
         step_keywords = ['steps', 'steps_es']
         for step_keyword in step_keywords:
-            steps = kwargs.pop(step_keyword, [])
+            if step_keyword in kwargs:
+                kwargs[step_keyword] = streamfieldify(kwargs[step_keyword])
 
-            formatted_steps = []
-            for step in steps:
-                # todo: don't skip these
-                if step['type'] == 'step_with_locations':
-                    continue
-
-                formatted_step = {'type': u'{0}'.format(step['type'])}
-                if step['type'] == 'step_with_options_accordian':
-                    formatted_step['value'] = {
-                        'options': [
-                            {
-                                u'option_description': u'{0}'.format(option['option_description']),
-                                u'option_name': u'{0}'.format(option['option_name'])
-                            }
-                            for option in step['value']['options']
-                        ],
-                        u'options_description': u'{0}'.format(step['value']['options_description']),
-                    }
-                else:
-                    formatted_step['value'] = u'{0}'.format(step['value'])
-                formatted_steps.append(formatted_step)
-
-            json_steps = json.dumps(formatted_steps)
-            kwargs[step_keyword] = json_steps
         return super(ServicePageFactory, cls).create(*args, **kwargs)
 
 

--- a/joplin/pages/service_page/fixtures/__init__.py
+++ b/joplin/pages/service_page/fixtures/__init__.py
@@ -5,7 +5,8 @@ from .test_cases.step_with_options import step_with_options
 from .test_cases.new_contact import new_contact
 from .test_cases.kitchen_sink import kitchen_sink
 from .test_cases.dynamic_content_list import dynamic_content_list
-from .test_cases.steps_with_location import steps_with_location
+from .test_cases.step_with_1_location import step_with_1_location
+from .test_cases.step_with_2_locations import step_with_2_locations
 
 
 # You can import any test_case fixture individually
@@ -18,4 +19,5 @@ def load_all():
     new_contact()
     kitchen_sink()
     dynamic_content_list()
-    steps_with_location()
+    step_with_1_location()
+    step_with_2_locations()

--- a/joplin/pages/service_page/fixtures/helpers/components.py
+++ b/joplin/pages/service_page/fixtures/helpers/components.py
@@ -3,6 +3,7 @@
     interchangeably with multiple fixtures
 '''
 from pages.home_page.models import HomePage
+import pages.location_page.fixtures as location_page_fixtures
 
 
 def home():
@@ -115,17 +116,27 @@ step_with_options = [
     },
 ]
 
-steps_with_location = [{'type': 'basic_step',
-                        'value': '<p>Use this tool to find out what items are accepted. Residents can drop off up to 30-gallons of hazardous waste for free each year.</p><p><code>APPBLOCK: What do I do with</code></p>',
-                        'id': 'a69f4e15-3613-4d69-9c3f-0575db4ac1fc'}, {'type': 'basic_step',
-                                                                        'value': '<p>Review the household hazardous waste do&#x27;s and don’ts below.</p>',
-                                                                        'id': '893cb981-9258-4cad-a597-5e5ec3d09613'},
-                       {'type': 'step_with_locations', 'value': {
-                           'locations_description': '<p>Drop off your items at the Recycle and ReUse Center.</p>',
-                           'locations': [{'location_page': {'id': 'TG9jYXRpb25QYWdlTm9kZTozMjc=',
-                                                            'slug': 'recycle-reuse-drop-off-center',
-                                                            'title': 'Recycle & Reuse Drop-off Center',
-                                                            'physical_street': '2514 Business Center Drive',
-                                                            'physical_unit': '', 'physical_city': 'Austin',
-                                                            'physical_state': 'TX', 'physical_zip': '78744'}}]},
-                        'id': '71210fba-4714-4e68-b131-cc9251bc992f'}]
+def step_with_1_location():
+    library_location = location_page_fixtures.live_library()
+    return [
+        {
+            "type": "step_with_locations",
+            "value": {
+                "locations_description": "<p>You should go here.</p>",
+                "locations": [library_location.pk]
+            }
+        }
+    ]
+
+def step_with_2_locations():
+    library_location = location_page_fixtures.live_library()
+    city_hall_location = location_page_fixtures.live_city_hall()
+    return [
+        {
+            "type": "step_with_locations",
+            "value": {
+                "locations_description": "<p>Go to one of these two places.</p>",
+                "locations": [library_location.pk, city_hall_location.pk]
+            }
+        }
+    ]

--- a/joplin/pages/service_page/fixtures/test_cases/kitchen_sink.py
+++ b/joplin/pages/service_page/fixtures/test_cases/kitchen_sink.py
@@ -11,7 +11,7 @@ def kitchen_sink():
     steps = components.steps_with_appblocks
     steps.extend(components.steps_2)
     steps.extend(components.step_with_options)
-    steps.extend(components.steps_with_location)
+    steps.extend(components.step_with_1_location())
     department = kitchen_sink_department.kitchen_sink()
 
     page_data = {

--- a/joplin/pages/service_page/fixtures/test_cases/step_with_1_location.py
+++ b/joplin/pages/service_page/fixtures/test_cases/step_with_1_location.py
@@ -1,0 +1,23 @@
+import os
+from pages.service_page.fixtures.helpers.create_fixture import create_fixture
+import pages.service_page.fixtures.helpers.components as components
+
+
+# A Service Page that has a step with a location
+def step_with_1_location():
+    page_data = {
+        "imported_revision_id": None,
+        "live": False,
+        "parent": components.home(),
+        "coa_global": False,
+        "title": "Service Page with 1 location step",
+        "slug": "service-page-with-1-location-step",
+        "add_topics": {
+            "topics": []
+        },
+        "short_description": "This is a very short description",
+        "additional_content": components.additional_content,
+        "steps": components.step_with_1_location(),
+    }
+
+    return create_fixture(page_data, os.path.basename(__file__))

--- a/joplin/pages/service_page/fixtures/test_cases/step_with_1_location.py
+++ b/joplin/pages/service_page/fixtures/test_cases/step_with_1_location.py
@@ -5,10 +5,12 @@ import pages.service_page.fixtures.helpers.components as components
 
 # A Service Page that has a step with a location
 def step_with_1_location():
+    steps = components.step_with_1_location()
+    home = components.home()
     page_data = {
         "imported_revision_id": None,
         "live": False,
-        "parent": components.home(),
+        "parent": home,
         "coa_global": False,
         "title": "Service Page with 1 location step",
         "slug": "service-page-with-1-location-step",
@@ -17,7 +19,7 @@ def step_with_1_location():
         },
         "short_description": "This is a very short description",
         "additional_content": components.additional_content,
-        "steps": components.step_with_1_location(),
+        "steps": steps,
     }
 
     return create_fixture(page_data, os.path.basename(__file__))

--- a/joplin/pages/service_page/fixtures/test_cases/step_with_2_locations.py
+++ b/joplin/pages/service_page/fixtures/test_cases/step_with_2_locations.py
@@ -5,10 +5,12 @@ import pages.service_page.fixtures.helpers.components as components
 
 # A Service Page that has a step with a location
 def step_with_2_locations():
+    steps = components.step_with_2_locations()
+    home = components.home()
     page_data = {
         "imported_revision_id": None,
         "live": False,
-        "parent": components.home(),
+        "parent": home,
         "coa_global": False,
         "title": "Service Page with 2 locations step",
         "slug": "service-page-with-2-locations-step",
@@ -17,7 +19,7 @@ def step_with_2_locations():
         },
         "short_description": "This is a very short description",
         "additional_content": components.additional_content,
-        "steps": components.step_with_2_locations(),
+        "steps": steps,
     }
 
     return create_fixture(page_data, os.path.basename(__file__))

--- a/joplin/pages/service_page/fixtures/test_cases/step_with_2_locations.py
+++ b/joplin/pages/service_page/fixtures/test_cases/step_with_2_locations.py
@@ -4,20 +4,20 @@ import pages.service_page.fixtures.helpers.components as components
 
 
 # A Service Page that has a step with a location
-def steps_with_location():
+def step_with_2_locations():
     page_data = {
         "imported_revision_id": None,
         "live": False,
         "parent": components.home(),
         "coa_global": False,
-        "title": "Service Page with location step",
-        "slug": "service-page-with-location-step",
+        "title": "Service Page with 2 locations step",
+        "slug": "service-page-with-2-locations-step",
         "add_topics": {
             "topics": []
         },
         "short_description": "This is a very short description",
         "additional_content": components.additional_content,
-        "steps": components.steps_with_location,
+        "steps": components.step_with_2_locations(),
     }
 
     return create_fixture(page_data, os.path.basename(__file__))

--- a/joplin/pages/service_page/management/commands/load_test_service_pages.py
+++ b/joplin/pages/service_page/management/commands/load_test_service_pages.py
@@ -11,4 +11,4 @@ class Command(BaseCommand):
     help = "Loads test data for manual exploration of test service_pages"
 
     def handle(self, *args, **options):
-        service_page_fixtures.step_with_1_location()
+        service_page_fixtures.load_all()

--- a/joplin/pages/service_page/management/commands/load_test_service_pages.py
+++ b/joplin/pages/service_page/management/commands/load_test_service_pages.py
@@ -11,4 +11,4 @@ class Command(BaseCommand):
     help = "Loads test data for manual exploration of test service_pages"
 
     def handle(self, *args, **options):
-        service_page_fixtures.load_all()
+        service_page_fixtures.step_with_1_location()

--- a/joplin/pages/service_page/tests.py
+++ b/joplin/pages/service_page/tests.py
@@ -169,6 +169,7 @@ def test_import_step_with_1_already_existing_location_1_new_location(remote_stag
     page = PageImporter(url, test_api_jwt_token).fetch_page_data().create_page()
     assert isinstance(page, ServicePage)
     assert not page.live
+    # The importer should delete one of the two locations because it hasn't been imported yet.
     assert len(page.steps.stream_data[0]["value"]["locations"]) == 1
     assert page.steps.stream_data[0]["value"]["locations"][0] == location_page.pk
 


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description
https://github.com/cityofaustin/techstack/issues/4275

Alright, here's the deal with importing steps with location pages.

Take a look at the test fixtures I made. That's how our ServicePage model's streamfield wants to get a step with a location_page. All it wants is the primary key of your location page. It's a lot like adding a location_page onto an event_page

So that works great if we just want to make a fixture ourselves. But its tricky when we want to import a service page. Our API for steps does not return enough data to fully create/import a new location_page. There is a path to making this work. This guy laid some good groundwork that we could use to make resolvers for streamfields that could connect to LocationPageNodes instead of being a generic Scalar. https://github.com/graphql-python/graphene-django/issues/369#issuecomment-385245415

However, that's a lot of effort. And I don't want to hold up v3 to figure out something that is non-essential. So here's the compromise I made in the importer. If we are importing a "step_with_locations":

1. Check if we've already imported that location (or a location with that slug).
2. If so, great, add that location's pk to our streamfield value. This is an ideal import.
3. If we have not already imported that location, don't even try to import it. Delete that location from your "step_with_locations."
4. If your "step_with_locations" has no locations, then delete that step.
5. If we deleted any locations, then make sure live=False, otherwise we could be publishing a service_page that does not meet publish requirements. And we'd want manual human intervention to add the right "step_with_locations" before publishing anyway.

We've got automated tests to check all those edgecases.

# Implications
For an ideal full site import, just make sure we import all location_pages before importing all service_pages. That should ensure that our service_pages with "steps_with_locations" will be matched to a location instead of deleted. If not, we can still manually add them.

MVP! MVP!

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
