### PR TITLE
4288 internal links

### DIFF
--- a/.circleci/vars/branch_overrides.py
+++ b/.circleci/vars/branch_overrides.py
@@ -32,5 +32,9 @@ branch_overrides = {
     "api-page-type-and-description": {
         "LOAD_DATA": "fixtures",
         "V3_WIP": True,
+    },
+    "4288-internal-links": {
+        "LOAD_DATA": "fixtures",
+        "V3_WIP": True,
     }
 }

--- a/joplin/importer/page_importer.py
+++ b/joplin/importer/page_importer.py
@@ -44,9 +44,11 @@ def change_keys(obj, convert):
                 # see if we have a page with that slug
                 try:
                     blarg = JanisBasePage.objects.get(slug=slug)
+                    # todo: make the link internal
                 except:
                     # todo: figure out what we want to to with links to unimported internal pages
-                    x = 3
+                    # for now we're just not changing it
+                    pass
         else:
             return obj
     if isinstance(obj, dict):

--- a/joplin/importer/page_importer.py
+++ b/joplin/importer/page_importer.py
@@ -15,7 +15,6 @@ from pages.base_page.models import JanisBasePage
 ENDPOINTS = {
     'janis.austintexas.io': 'https://joplin-staging.herokuapp.com/api/graphql',
     'janis-pytest.netlify.com': 'https://joplin-pr-pytest.herokuapp.com/api/graphql',
-
 }
 
 
@@ -51,7 +50,7 @@ def change_keys(obj, convert):
                     link['linktype'] = 'page'
                 except:
                     # todo: figure out what we want to to with links to unimported internal pages
-                    # for now we're just not changing it
+                    # for now we're letting it stay an external link to a janis url
                     pass
 
             # return our cleaned soup
@@ -80,7 +79,6 @@ class PageImporter:
         # Undo some of the changes caused by decamelize
         # time2 and bus2 needs to be bus_2 and time_2
         def fix_nums(k): return k.translate(str.maketrans({'1': '_1', '2': '_2', '3': '_3'}))
-
         cleaned_page_dictionary = change_keys(cleaned_page_dictionary, fix_nums)
 
         return cleaned_page_dictionary

--- a/joplin/importer/page_importer.py
+++ b/joplin/importer/page_importer.py
@@ -41,14 +41,21 @@ def change_keys(obj, convert):
                 # we're dealing with an internal link, let's get the slug
                 slug = Path(parse_result.path).parts[-1]
 
-                # see if we have a page with that slug
                 try:
-                    blarg = JanisBasePage.objects.get(slug=slug)
-                    # todo: make the link internal
+                    # get the page with that slug
+                    page = JanisBasePage.objects.get(slug=slug)
+
+                    # the wagtail editor looks for page ids and linktypes when parsing rich text html for internal links
+                    del link['href']
+                    link['id'] = page.id
+                    link['linktype'] = 'page'
                 except:
                     # todo: figure out what we want to to with links to unimported internal pages
                     # for now we're just not changing it
                     pass
+
+            # return our cleaned soup
+            return str(soup)
         else:
             return obj
     if isinstance(obj, dict):
@@ -73,6 +80,7 @@ class PageImporter:
         # Undo some of the changes caused by decamelize
         # time2 and bus2 needs to be bus_2 and time_2
         def fix_nums(k): return k.translate(str.maketrans({'1': '_1', '2': '_2', '3': '_3'}))
+
         cleaned_page_dictionary = change_keys(cleaned_page_dictionary, fix_nums)
 
         return cleaned_page_dictionary
@@ -105,7 +113,6 @@ class PageImporter:
 
         # return ourselves for method chaining
         return self
-
 
     def __init__(self, url, jwt_token):
         # get a urllib.parse result to play with

--- a/joplin/importer/page_importer.py
+++ b/joplin/importer/page_importer.py
@@ -49,19 +49,16 @@ def change_keys(obj, convert):
                     page = None
 
                 # if we didn't get a page, use a placeholder
-                try:
-                    page = JanisBasePage.objects.get(slug='placeholder_service_page_for_internal_links')
-                except JanisBasePage.DoesNotExist:
-                    page = None
-
-                # If we didn't get a placeholder page, make it
                 if not page:
-                    placeholder_page_dictionary = {
-                        'parent': HomePage.objects.first(),
-                        'title': 'placeholder service page for internal links',
-                        'slug': 'placeholder_service_page_for_internal_links'
-                    }
-                    page = ServicePageFactory.create(**placeholder_page_dictionary)
+                    try:
+                        page = JanisBasePage.objects.get(slug='placeholder_service_page_for_internal_links')
+                    except JanisBasePage.DoesNotExist:
+                        placeholder_page_dictionary = {
+                            'parent': HomePage.objects.first(),
+                            'title': 'Placeholder service page for internal links',
+                            'slug': 'placeholder_service_page_for_internal_links'
+                        }
+                        page = ServicePageFactory.create(**placeholder_page_dictionary)
 
                 # the wagtail editor looks for page ids and linktypes when parsing rich text html for internal links
                 del link['href']

--- a/joplin/pages/service_page/fixtures/__init__.py
+++ b/joplin/pages/service_page/fixtures/__init__.py
@@ -8,6 +8,7 @@ from .test_cases.dynamic_content_list import dynamic_content_list
 from .test_cases.step_with_1_location import step_with_1_location
 from .test_cases.step_with_2_locations import step_with_2_locations
 from .test_cases.step_with_internal_links import step_with_internal_links
+from .test_cases.placeholder_for_internal_links import placeholder_for_internal_links
 
 
 # You can import any test_case fixture individually
@@ -23,3 +24,4 @@ def load_all():
     step_with_1_location()
     step_with_2_locations()
     step_with_internal_links()
+    placeholder_for_internal_links()

--- a/joplin/pages/service_page/fixtures/__init__.py
+++ b/joplin/pages/service_page/fixtures/__init__.py
@@ -7,6 +7,7 @@ from .test_cases.kitchen_sink import kitchen_sink
 from .test_cases.dynamic_content_list import dynamic_content_list
 from .test_cases.step_with_1_location import step_with_1_location
 from .test_cases.step_with_2_locations import step_with_2_locations
+from .test_cases.step_with_internal_links import step_with_internal_links
 
 
 # You can import any test_case fixture individually
@@ -21,3 +22,4 @@ def load_all():
     dynamic_content_list()
     step_with_1_location()
     step_with_2_locations()
+    step_with_internal_links()

--- a/joplin/pages/service_page/fixtures/helpers/components.py
+++ b/joplin/pages/service_page/fixtures/helpers/components.py
@@ -143,7 +143,7 @@ def step_with_2_locations():
         }
     ]
 
-def step_with_internal_links():
+def step_with_one_imported_and_some_unimported_internal_links():
     linked_topic_page = topic_page_fixtures.title()
     placeholder_service_page = service_page_fixtures.placeholder_for_internal_links()
 

--- a/joplin/pages/service_page/fixtures/helpers/components.py
+++ b/joplin/pages/service_page/fixtures/helpers/components.py
@@ -143,6 +143,6 @@ def step_with_2_locations():
 
 step_with_internal_links = [{
     'type': 'basic_step',
-    'value': '<p><a href="http://janis-austin-gov-staging.s3-website-us-east-1.amazonaws.com/en/theme-slug-en/topic-collection-title-en/topic-title-en">topic title [en]</a> <a href="http://janis-austin-gov-staging.s3-website-us-east-1.amazonaws.com/en/theme-slug-en/topic-collection-title-en/topic-title-en/service-page-with-contact">Service page with contact</a> <a href="http://janis-austin-gov-staging.s3-website-us-east-1.amazonaws.com/en/pytest-department">Pytest department</a></p>',
+    'value': '<p><a href="http://janis-pytest.netlify.com/en/theme-slug-en/topic-collection-title-en/topic-title-en">topic title [en]</a> <a href="http://janis-pytest.netlify.com/en/theme-slug-en/topic-collection-title-en/topic-title-en/service-page-with-contact">Service page with contact</a> <a href="http://janis-pytest.netlify.com/en/pytest-department">Pytest department</a></p>',
     'id': '4f8605e3-39d1-4ab9-b5c5-b494569061e3'
 }]

--- a/joplin/pages/service_page/fixtures/helpers/components.py
+++ b/joplin/pages/service_page/fixtures/helpers/components.py
@@ -150,5 +150,11 @@ def step_with_one_imported_and_some_unimported_internal_links():
     return [{
         'type': 'basic_step',
         'value': f'<p><a id="{linked_topic_page.id}" linktype="page">topic title [en]</a> <a id="{placeholder_service_page.id}" linktype="page">Service page with contact</a> <a id="{placeholder_service_page.id}" linktype="page">Pytest department</a></p>',
-        'id': '4f8605e3-39d1-4ab9-b5c5-b494569061e3'
+    }]
+
+def step_with_one_imported_internal_link():
+    linked_topic_page = topic_page_fixtures.title()
+    return [{
+        'type': 'basic_step',
+        'value': f'<p><a id="{linked_topic_page.id}" linktype="page">topic title [en]</a></p>',
     }]

--- a/joplin/pages/service_page/fixtures/helpers/components.py
+++ b/joplin/pages/service_page/fixtures/helpers/components.py
@@ -142,7 +142,7 @@ def step_with_2_locations():
     ]
 
 step_with_internal_links = [{
-    [{'type': 'basic_step',
-      'value': '<p><a href="http://janis-austin-gov-staging.s3-website-us-east-1.amazonaws.com/en/theme-slug-en/topic-collection-title-en/topic-title-en">topic title [en]</a> <a href="http://janis-austin-gov-staging.s3-website-us-east-1.amazonaws.com/en/theme-slug-en/topic-collection-title-en/topic-title-en/service-page-with-contact">Service page with contact</a> <a href="http://janis-austin-gov-staging.s3-website-us-east-1.amazonaws.com/en/pytest-department">Pytest department</a></p>',
-      'id': '4f8605e3-39d1-4ab9-b5c5-b494569061e3'}]
+    'type': 'basic_step',
+    'value': '<p><a href="http://janis-austin-gov-staging.s3-website-us-east-1.amazonaws.com/en/theme-slug-en/topic-collection-title-en/topic-title-en">topic title [en]</a> <a href="http://janis-austin-gov-staging.s3-website-us-east-1.amazonaws.com/en/theme-slug-en/topic-collection-title-en/topic-title-en/service-page-with-contact">Service page with contact</a> <a href="http://janis-austin-gov-staging.s3-website-us-east-1.amazonaws.com/en/pytest-department">Pytest department</a></p>',
+    'id': '4f8605e3-39d1-4ab9-b5c5-b494569061e3'
 }]

--- a/joplin/pages/service_page/fixtures/helpers/components.py
+++ b/joplin/pages/service_page/fixtures/helpers/components.py
@@ -4,6 +4,7 @@
 '''
 from pages.home_page.models import HomePage
 import pages.location_page.fixtures as location_page_fixtures
+import pages.topic_page.fixtures as topic_page_fixtures
 
 
 def home():
@@ -141,8 +142,11 @@ def step_with_2_locations():
         }
     ]
 
-step_with_internal_links = [{
-    'type': 'basic_step',
-    'value': '<p><a href="http://janis-pytest.netlify.com/en/theme-slug-en/topic-collection-title-en/topic-title-en">topic title [en]</a> <a href="http://janis-pytest.netlify.com/en/theme-slug-en/topic-collection-title-en/topic-title-en/service-page-with-contact">Service page with contact</a> <a href="http://janis-pytest.netlify.com/en/pytest-department">Pytest department</a></p>',
-    'id': '4f8605e3-39d1-4ab9-b5c5-b494569061e3'
-}]
+def step_with_internal_links():
+    linked_topic_page = topic_page_fixtures.title()
+
+    return [{
+        'type': 'basic_step',
+        'value': f'<p><a id="{linked_topic_page.id}" linktype="page">topic title [en]</a> <a href="http://janis-pytest.netlify.com/en/theme-slug-en/topic-collection-title-en/topic-title-en/service-page-with-contact">Service page with contact</a> <a href="http://janis-pytest.netlify.com/en/pytest-department">Pytest department</a></p>',
+        'id': '4f8605e3-39d1-4ab9-b5c5-b494569061e3'
+    }]

--- a/joplin/pages/service_page/fixtures/helpers/components.py
+++ b/joplin/pages/service_page/fixtures/helpers/components.py
@@ -5,6 +5,7 @@
 from pages.home_page.models import HomePage
 import pages.location_page.fixtures as location_page_fixtures
 import pages.topic_page.fixtures as topic_page_fixtures
+import pages.service_page.fixtures as service_page_fixtures
 
 
 def home():
@@ -144,9 +145,10 @@ def step_with_2_locations():
 
 def step_with_internal_links():
     linked_topic_page = topic_page_fixtures.title()
+    placeholder_service_page = service_page_fixtures.placeholder_for_internal_links()
 
     return [{
         'type': 'basic_step',
-        'value': f'<p><a id="{linked_topic_page.id}" linktype="page">topic title [en]</a> <a href="http://janis-pytest.netlify.com/en/theme-slug-en/topic-collection-title-en/topic-title-en/service-page-with-contact">Service page with contact</a> <a href="http://janis-pytest.netlify.com/en/pytest-department">Pytest department</a></p>',
+        'value': f'<p><a id="{linked_topic_page.id}" linktype="page">topic title [en]</a> <a id="{placeholder_service_page.id}" linktype="page">Service page with contact</a> <a id="{placeholder_service_page.id}" linktype="page">Pytest department</a></p>',
         'id': '4f8605e3-39d1-4ab9-b5c5-b494569061e3'
     }]

--- a/joplin/pages/service_page/fixtures/helpers/components.py
+++ b/joplin/pages/service_page/fixtures/helpers/components.py
@@ -129,3 +129,9 @@ steps_with_location = [{'type': 'basic_step',
                                                             'physical_unit': '', 'physical_city': 'Austin',
                                                             'physical_state': 'TX', 'physical_zip': '78744'}}]},
                         'id': '71210fba-4714-4e68-b131-cc9251bc992f'}]
+
+step_with_internal_links = [{
+    [{'type': 'basic_step',
+      'value': '<p><a href="http://janis-austin-gov-staging.s3-website-us-east-1.amazonaws.com/en/theme-slug-en/topic-collection-title-en/topic-title-en">topic title [en]</a> <a href="http://janis-austin-gov-staging.s3-website-us-east-1.amazonaws.com/en/theme-slug-en/topic-collection-title-en/topic-title-en/service-page-with-contact">Service page with contact</a> <a href="http://janis-austin-gov-staging.s3-website-us-east-1.amazonaws.com/en/pytest-department">Pytest department</a></p>',
+      'id': '4f8605e3-39d1-4ab9-b5c5-b494569061e3'}]
+}]

--- a/joplin/pages/service_page/fixtures/test_cases/placeholder_for_internal_links.py
+++ b/joplin/pages/service_page/fixtures/test_cases/placeholder_for_internal_links.py
@@ -1,0 +1,17 @@
+import os
+from pages.service_page.fixtures.helpers.create_fixture import create_fixture
+import pages.service_page.fixtures.helpers.components as components
+
+
+# A placeholder service page for internal links
+def placeholder_for_internal_links():
+    page_data = {
+        "imported_revision_id": None,
+        "live": False,
+        "parent": components.home(),
+        "coa_global": False,
+        "title": "Placeholder service page for internal links",
+        "slug": "placeholder_service_page_for_internal_links",
+    }
+
+    return create_fixture(page_data, os.path.basename(__file__))

--- a/joplin/pages/service_page/fixtures/test_cases/step_with_internal_links.py
+++ b/joplin/pages/service_page/fixtures/test_cases/step_with_internal_links.py
@@ -1,0 +1,25 @@
+import os
+from pages.service_page.fixtures.helpers.create_fixture import create_fixture
+import pages.service_page.fixtures.helpers.components as components
+
+
+# A Service Page that has a step with internal links
+def step_with_internal_links():
+    steps = components.step_with_internal_links()
+    home = components.home()
+    page_data = {
+        "imported_revision_id": None,
+        "live": False,
+        "parent": home,
+        "coa_global": False,
+        "title": "Service Page with internal links",
+        "slug": "service-page-with-internal-links",
+        "add_topics": {
+            "topics": []
+        },
+        "short_description": "This is a very short description",
+        "additional_content": components.additional_content,
+        "steps": steps,
+    }
+
+    return create_fixture(page_data, os.path.basename(__file__))

--- a/joplin/pages/service_page/fixtures/test_cases/step_with_internal_links.py
+++ b/joplin/pages/service_page/fixtures/test_cases/step_with_internal_links.py
@@ -5,7 +5,7 @@ import pages.service_page.fixtures.helpers.components as components
 
 # A Service Page that has a step with internal links
 def step_with_internal_links():
-    steps = components.step_with_internal_links()
+    steps = components.step_with_one_imported_and_some_unimported_internal_links()
     home = components.home()
     page_data = {
         "imported_revision_id": None,

--- a/joplin/pages/service_page/tests.py
+++ b/joplin/pages/service_page/tests.py
@@ -37,16 +37,20 @@ def test_create_service_page_with_department_from_api(remote_staging_preview_url
 
 
 @pytest.mark.django_db
-def test_create_service_page_with_internal_links_from_api(remote_staging_preview_url, test_api_url, test_api_jwt_token):
+def test_create_service_page_with_one_imported_and_some_unimported_internal_links_from_api(remote_staging_preview_url, test_api_url, test_api_jwt_token):
+    # this fixture has the same slug as the first link of the page we're importing,
+    # let's create it so the importer can link to it
     topic_page_fixtures.title()
-    expected_steps = components.step_with_internal_links()
+
+    expected_steps = components.step_with_one_imported_and_some_unimported_internal_links()
     url = f'{remote_staging_preview_url}/services/UGFnZVJldmlzaW9uTm9kZTo1MQ==?CMS_API={test_api_url}'
     page = PageImporter(url, test_api_jwt_token).fetch_page_data().create_page()
     assert isinstance(page, ServicePage)
-    assert not page.live
     for i, step in enumerate(page.steps.stream_data):
         assert step["type"] == expected_steps[i]["type"]
         assert step["value"] == expected_steps[i]["value"]
+    # since some of the imported links are using placeholder pages, we shouldn't be live yet
+    assert not page.live
 
 
 @pytest.mark.django_db

--- a/joplin/pages/service_page/tests.py
+++ b/joplin/pages/service_page/tests.py
@@ -5,6 +5,7 @@ from pages.service_page.models import ServicePage
 import pages.service_page.fixtures as fixtures
 import pages.service_page.fixtures.helpers.components as components
 import pages.location_page.fixtures as location_page_fixtures
+import pages.topic_page.fixtures as topic_page_fixtures
 
 
 @pytest.mark.django_db
@@ -37,6 +38,7 @@ def test_create_service_page_with_department_from_api(remote_staging_preview_url
 
 @pytest.mark.django_db
 def test_create_service_page_with_internal_links_from_api(remote_staging_preview_url, test_api_url, test_api_jwt_token):
+    linked_topic_page = topic_page_fixtures.title()
     url = f'{remote_staging_preview_url}/services/UGFnZVJldmlzaW9uTm9kZTo1MQ==?CMS_API={test_api_url}'
     page = PageImporter(url, test_api_jwt_token).fetch_page_data().create_page()
     assert isinstance(page, ServicePage)

--- a/joplin/pages/service_page/tests.py
+++ b/joplin/pages/service_page/tests.py
@@ -37,23 +37,6 @@ def test_create_service_page_with_department_from_api(remote_staging_preview_url
 
 
 @pytest.mark.django_db
-def test_create_service_page_with_one_imported_and_some_unimported_internal_links_from_api(remote_staging_preview_url, test_api_url, test_api_jwt_token):
-    # this fixture has the same slug as the first link of the page we're importing,
-    # let's create it so the importer can link to it
-    topic_page_fixtures.title()
-
-    expected_steps = components.step_with_one_imported_and_some_unimported_internal_links()
-    url = f'{remote_staging_preview_url}/services/UGFnZVJldmlzaW9uTm9kZTo1MQ==?CMS_API={test_api_url}'
-    page = PageImporter(url, test_api_jwt_token).fetch_page_data().create_page()
-    assert isinstance(page, ServicePage)
-    for i, step in enumerate(page.steps.stream_data):
-        assert step["type"] == expected_steps[i]["type"]
-        assert step["value"] == expected_steps[i]["value"]
-    # since some of the imported links are using placeholder pages, we shouldn't be live yet
-    assert not page.live
-
-
-@pytest.mark.django_db
 def test_create_service_page_with_title():
     page = fixtures.title()
     assert isinstance(page, ServicePage)
@@ -201,3 +184,35 @@ def test_import_step_with_2_already_existing_locations(remote_staging_preview_ur
     assert page.live
     assert page.steps.stream_data[0]["value"]["locations"][0] == location_page_1.pk
     assert page.steps.stream_data[0]["value"]["locations"][1] == location_page_2.pk
+
+
+@pytest.mark.django_db
+def test_import_step_with_1_imported_and_some_unimported_internal_links(remote_staging_preview_url, test_api_url, test_api_jwt_token):
+    # this fixture has the same slug as the first link of the page we're importing,
+    # let's create it so the importer can link to it
+    topic_page_fixtures.title()
+
+    expected_steps = components.step_with_one_imported_and_some_unimported_internal_links()
+    url = f'{remote_staging_preview_url}/services/UGFnZVJldmlzaW9uTm9kZTo1MQ==?CMS_API={test_api_url}'
+    page = PageImporter(url, test_api_jwt_token).fetch_page_data().create_page()
+    assert isinstance(page, ServicePage)
+    for i, step in enumerate(page.steps.stream_data):
+        assert step["type"] == expected_steps[i]["type"]
+        assert step["value"] == expected_steps[i]["value"]
+    # since some of the imported links are using placeholder pages, we shouldn't be live yet
+    assert not page.live
+
+
+@pytest.mark.django_db
+def test_import_step_with_1_imported_internal_link(remote_staging_preview_url, test_api_url, test_api_jwt_token):
+    topic_page_fixtures.title()
+    expected_steps = components.step_with_one_imported_internal_link()
+    url = f'{remote_staging_preview_url}/services/UGFnZVJldmlzaW9uTm9kZTo2Ng==?CMS_API={test_api_url}'
+    page = PageImporter(url, test_api_jwt_token).fetch_page_data().create_page()
+    assert isinstance(page, ServicePage)
+
+    # since we didn't need to use a placeholder, we should be live!
+    assert page.live
+    for i, step in enumerate(page.steps.stream_data):
+        assert step["type"] == expected_steps[i]["type"]
+        assert step["value"] == expected_steps[i]["value"]

--- a/joplin/pages/service_page/tests.py
+++ b/joplin/pages/service_page/tests.py
@@ -35,6 +35,14 @@ def test_create_service_page_with_department_from_api(remote_staging_preview_url
 
 
 @pytest.mark.django_db
+def test_create_service_page_with_internal_links_from_api(remote_staging_preview_url, test_api_url, test_api_jwt_token):
+    url = f'{remote_staging_preview_url}/services/UGFnZVJldmlzaW9uTm9kZTo1MQ==?CMS_API={test_api_url}'
+    page = PageImporter(url, test_api_jwt_token).fetch_page_data().create_page()
+    assert isinstance(page, ServicePage)
+    assert False
+
+
+@pytest.mark.django_db
 def test_create_service_page_with_title():
     page = fixtures.title()
     assert isinstance(page, ServicePage)

--- a/joplin/pages/service_page/tests.py
+++ b/joplin/pages/service_page/tests.py
@@ -43,6 +43,7 @@ def test_create_service_page_with_internal_links_from_api(remote_staging_preview
     url = f'{remote_staging_preview_url}/services/UGFnZVJldmlzaW9uTm9kZTo1MQ==?CMS_API={test_api_url}'
     page = PageImporter(url, test_api_jwt_token).fetch_page_data().create_page()
     assert isinstance(page, ServicePage)
+    assert not page.live
     for i, step in enumerate(page.steps.stream_data):
         assert step["type"] == expected_steps[i]["type"]
         assert step["value"] == expected_steps[i]["value"]

--- a/joplin/pages/service_page/tests.py
+++ b/joplin/pages/service_page/tests.py
@@ -38,11 +38,14 @@ def test_create_service_page_with_department_from_api(remote_staging_preview_url
 
 @pytest.mark.django_db
 def test_create_service_page_with_internal_links_from_api(remote_staging_preview_url, test_api_url, test_api_jwt_token):
-    linked_topic_page = topic_page_fixtures.title()
+    topic_page_fixtures.title()
+    expected_steps = components.step_with_internal_links()
     url = f'{remote_staging_preview_url}/services/UGFnZVJldmlzaW9uTm9kZTo1MQ==?CMS_API={test_api_url}'
     page = PageImporter(url, test_api_jwt_token).fetch_page_data().create_page()
     assert isinstance(page, ServicePage)
-    assert False
+    for i, step in enumerate(page.steps.stream_data):
+        assert step["type"] == expected_steps[i]["type"]
+        assert step["value"] == expected_steps[i]["value"]
 
 
 @pytest.mark.django_db

--- a/joplin/pages/topic_page/fixtures/__init__.py
+++ b/joplin/pages/topic_page/fixtures/__init__.py
@@ -1,7 +1,9 @@
 from .test_cases.kitchen_sink import kitchen_sink
+from .test_cases.title import title
 
 
 # You can import any test_case fixture individually
 # Or you can load them all with this function
 def load_all():
     kitchen_sink()
+    title()

--- a/joplin/pages/topic_page/fixtures/test_cases/title.py
+++ b/joplin/pages/topic_page/fixtures/test_cases/title.py
@@ -1,0 +1,23 @@
+import os
+from pages.topic_page.fixtures.helpers.create_fixture import create_fixture
+import pages.topic_page.fixtures.helpers.components as components
+from pages.topic_collection_page.fixtures.test_cases import kitchen_sink as kitchen_sink_topic_collection
+
+
+# A topic page with a title
+def title():
+    topic_collection = kitchen_sink_topic_collection.kitchen_sink()
+
+    page_data = {
+        "imported_revision_id": None,
+        "live": True,
+        "parent": components.home(),
+        "title": "Topic title [en]",
+        "title_es": "Topic title [es]",
+        "slug": "topic-title-en",
+        "add_topic_collections": {
+            "topic_collections": [topic_collection]
+        },
+    }
+
+    return create_fixture(page_data, os.path.basename(__file__))


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description
When importing pages with internal links, we now try to recreate the internal links by matching slugs to previously imported pages. If we don't find a page with a matching slug, the link is set to a placeholder and the imported page is kept in draft state.

<!--- include a summary of the change and what it fixes. -->

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->
https://github.com/cityofaustin/techstack/issues/4288
<!--- If there is a relevant Janis PR, link it here -->
<!--- [Janis Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 
* go here: http://joplin-pr-4288-internal-links.herokuapp.com/admin/pages/search/
* try importing a page with a rich text internal link to a page you've already imported
* see that the link is set as internal and to the correct page

# Checklist:
- [x] Request reviewers
- [x] Slack-out message for review
- [x] Link this PR in the issue
- [x] Moved card to *review* in zenhub
