### PR TITLE
4281 don't import english into spanish fields

### DIFF
--- a/.circleci/vars/branch_overrides.py
+++ b/.circleci/vars/branch_overrides.py
@@ -33,7 +33,7 @@ branch_overrides = {
         "LOAD_DATA": "fixtures",
         "V3_WIP": True,
     },
-    "4288-internal-links": {
+    "4281-spanish": {
         "LOAD_DATA": "fixtures",
         "V3_WIP": True,
     }

--- a/joplin/importer/create_from_importer.py
+++ b/joplin/importer/create_from_importer.py
@@ -413,7 +413,10 @@ def create_page_from_importer(page_type, page_dictionaries, revision_id=None):
     for field in factory._meta.model._meta.fields:
         if field.column.endswith("_es"):
             if field.column[:-3] in page_dictionaries['es']:
-                combined_dictionary[field.column] = page_dictionaries['es'][field.column[:-3]]
+                # make sure we aren't just getting the english fallback value
+                # https://wagtail-modeltranslation-docs.readthedocs.io/en/latest/Advanced%20Settings.html#fallback-languages
+                if page_dictionaries['es'][field.column[:-3]] != page_dictionaries['en'][field.column[:-3]]:
+                    combined_dictionary[field.column] = page_dictionaries['es'][field.column[:-3]]
 
     # set the owner of the page
     if 'owner' in combined_dictionary:

--- a/joplin/pages/service_page/tests.py
+++ b/joplin/pages/service_page/tests.py
@@ -224,9 +224,9 @@ def test_do_not_import_english_as_spanish(remote_staging_preview_url, test_api_u
     url = f'{remote_staging_preview_url}/services/UGFnZVJldmlzaW9uTm9kZTo3MA==?CMS_API={test_api_url}'
     page = PageImporter(url, test_api_jwt_token).fetch_page_data().create_page()
     assert isinstance(page, ServicePage)
-    assert page['title_en'] == 'Service page in english only'
-    assert page['title_es'] is None
-    assert page['short_description_en'] == 'a description of this service'
-    assert page['short_description_es'] is None
-    assert page['slug_en'] == 'service-page-in-english-only'
-    assert page['slug_es'] is None
+    assert page.title_en == 'Service page in english only'
+    assert page.title_es is None
+    assert page.short_description_en == 'a description of this service'
+    assert page.short_description_es is None
+    assert page.slug_en == 'service-page-in-english-only'
+    assert page.slug_es is None

--- a/joplin/pages/service_page/tests.py
+++ b/joplin/pages/service_page/tests.py
@@ -217,3 +217,16 @@ def test_import_step_with_1_imported_internal_link(remote_staging_preview_url, t
     for i, step in enumerate(page.steps.stream_data):
         assert step["type"] == expected_steps[i]["type"]
         assert step["value"] == expected_steps[i]["value"]
+
+
+@pytest.mark.django_db
+def test_do_not_import_english_as_spanish(remote_staging_preview_url, test_api_url, test_api_jwt_token):
+    url = f'{remote_staging_preview_url}/services/UGFnZVJldmlzaW9uTm9kZTo3MA==?CMS_API={test_api_url}'
+    page = PageImporter(url, test_api_jwt_token).fetch_page_data().create_page()
+    assert isinstance(page, ServicePage)
+    assert page['title_en'] == 'Service page in english only'
+    assert page['title_es'] is None
+    assert page['short_description_en'] == 'a description of this service'
+    assert page['short_description_es'] is None
+    assert page['slug_en'] == 'service-page-in-english-only'
+    assert page['slug_es'] is None


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description
When importing, we get english fallback values from the API when there isn't a localized value. This is great for Janis, but not the best for importer. This PR addresses that by checking to make sure the english and spanish values aren't equal when combining dictionaries.

<!--- include a summary of the change and what it fixes. -->

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->
https://github.com/cityofaustin/techstack/issues/4281
<!--- If there is a relevant Janis PR, link it here -->
<!--- [Janis Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 
* go here https://joplin-pr-4281-spanish.herokuapp.com/admin/login/
* import a page
* see that it doesn't fill the spanish fields with english content

# Checklist:
- [x] Request reviewers
- [x] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
