### PR TITLE
allow local full site builds; redirect to https

### DIFF
--- a/joplin/settings.py
+++ b/joplin/settings.py
@@ -107,6 +107,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -115,7 +116,6 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'django.middleware.security.SecurityMiddleware',
     'wagtail.core.middleware.SiteMiddleware',
     'wagtail.contrib.redirects.middleware.RedirectMiddleware',
     'session_security.middleware.SessionSecurityMiddleware',
@@ -260,7 +260,7 @@ MONITOR_PERFORMANCE = bool(strtobool(os.environ.get('MONITOR_PERFORMANCE', str(F
 WAGTAILEMBEDS_RESPONSIVE_HTML = True
 
 if MONITOR_PERFORMANCE:
-    MIDDLEWARE = ['silk.middleware.SilkyMiddleware'] + MIDDLEWARE
+    MIDDLEWARE.insert(1, 'silk.middleware.SilkyMiddleware')
 
     SILKY_PYTHON_PROFILER = False
     SILKY_PYTHON_PROFILER_BINARY = False
@@ -284,9 +284,7 @@ if DEBUG_TOOLBAR:
         'pympler'
     ]
 
-    MIDDLEWARE = [
-        'debug_toolbar.middleware.DebugToolbarMiddleware'
-    ] + MIDDLEWARE
+    MIDDLEWARE.insert(1, 'debug_toolbar.middleware.DebugToolbarMiddleware')
 
     DEBUG_TOOLBAR_PANELS = [
         'debug_toolbar.panels.profiling.ProfilingPanel',
@@ -516,4 +514,5 @@ if IS_LOCAL:
     SERVER_PROTOCOL = 'HTTP/0.9'
 else:
     # Redirect to HTTPS
+    SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
     SECURE_SSL_REDIRECT = True

--- a/joplin/settings.py
+++ b/joplin/settings.py
@@ -509,3 +509,11 @@ V3_WIP = bool(strtobool(os.environ.get('V3_WIP', str(False))))
 AUTH_USER_MODEL = 'users.User'
 WAGTAIL_USER_EDIT_FORM = 'users.forms.CustomUserEditForm'
 WAGTAIL_USER_CREATION_FORM = 'users.forms.CustomUserCreationForm'
+
+if IS_LOCAL:
+    # Allow non HTTPS requests when running a local Janis build from localhost.
+    SECURE_SSL_REDIRECT = False
+    SERVER_PROTOCOL = 'HTTP/0.9'
+else:
+    # Redirect to HTTPS
+    SECURE_SSL_REDIRECT = True


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description
Janis PR: https://github.com/cityofaustin/janis/pull/738

I guess full site builds weren't working locally, so I fixed it.

Doing that led to redirecting http to https. That seems like a good security thing. I followed these directions: https://help.heroku.com/J2R1S4T8/can-heroku-force-an-application-to-use-ssl-tls

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them -->

Click here:
http://joplin-pr-4309-topics.herokuapp.com/admin/pages/search/ 

It'll redirect you here:
https://joplin-pr-4309-topics.herokuapp.com/admin/pages/search/

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
