### PR TITLE
Spanish steps with locations

### DIFF
--- a/.circleci/vars/branch_overrides.py
+++ b/.circleci/vars/branch_overrides.py
@@ -33,7 +33,7 @@ branch_overrides = {
         "LOAD_DATA": "fixtures",
         "V3_WIP": True,
     },
-    "4281-spanish": {
+    "4311-stream-block-error": {
         "LOAD_DATA": "fixtures",
         "V3_WIP": True,
     }

--- a/joplin/importer/create_from_importer.py
+++ b/joplin/importer/create_from_importer.py
@@ -379,46 +379,18 @@ def create_page_from_importer(page_type, page_dictionaries, revision_id=None):
 
     # Handle 'steps_with_locations' in services
     if page_type is 'services':
-        
-
-        if 'steps' in combined_dictionary:
-            '''
-            Important note!
-            We are iterating through copies of each list.
-            Note the slice [:] on combined_dictionary["steps"][:].
-            We need to iterate through copies of these lists, because some pieces of logic
-            will require us to delete the indexes that we're iterating on.
-            Make sure that you're modifying/deleting the original list, not the copy[:] that
-            you're iterating through.
-            '''
-            for i, step in enumerate(combined_dictionary["steps"][:]):
-                # Only import step with location if we have that location already.
-                if step['type'] == 'step_with_locations':
-                    removed_locations = False
-                    for j, location in enumerate(step["value"]["locations"][:]):
-                        # Add location_page data only if location was already imported.
-                        # Right now, a "step_with_location" does not provide enough location_page
-                        # data required to import a new location_page.
-                        try:
-                            location_page = LocationPage.objects.get(slug=location["location_page"]['slug'])
-                        except LocationPage.DoesNotExist:
-                            location_page = None
-                        if location_page:
-                            combined_dictionary["steps"][i]["value"]["locations"][j] = location_page.pk
-                        else:
-                            removed_locations = True
-                            del combined_dictionary["steps"][i]["value"]["locations"][j]
-                    if removed_locations:
-                        # If all locations were removed from step, then delete the step
-                        if not len(step["value"]["locations"]):
-                            del combined_dictionary["steps"][i]
-                        # If any locations were removed, then make sure the Service_Page is not published
-                        combined_dictionary["live"] = False
-
-
-            # todo: this but not copypasta
-            if 'steps_es' in combined_dictionary:
-                for i, step in enumerate(combined_dictionary["steps_es"][:]):
+        for lang in ['', '_es']:
+            if f'steps{lang}' in combined_dictionary:
+                '''
+                Important note!
+                We are iterating through copies of each list.
+                Note the slice [:] on combined_dictionary["steps"][:].
+                We need to iterate through copies of these lists, because some pieces of logic
+                will require us to delete the indexes that we're iterating on.
+                Make sure that you're modifying/deleting the original list, not the copy[:] that
+                you're iterating through.
+                '''
+                for i, step in enumerate(combined_dictionary[f'steps{lang}'][:]):
                     # Only import step with location if we have that location already.
                     if step['type'] == 'step_with_locations':
                         removed_locations = False
@@ -431,17 +403,16 @@ def create_page_from_importer(page_type, page_dictionaries, revision_id=None):
                             except LocationPage.DoesNotExist:
                                 location_page = None
                             if location_page:
-                                combined_dictionary["steps_es"][i]["value"]["locations"][j] = location_page.pk
+                                combined_dictionary[f'steps{lang}'][i]["value"]["locations"][j] = location_page.pk
                             else:
                                 removed_locations = True
-                                del combined_dictionary["steps_es"][i]["value"]["locations"][j]
+                                del combined_dictionary[f'steps{lang}'][i]["value"]["locations"][j]
                         if removed_locations:
                             # If all locations were removed from step, then delete the step
                             if not len(step["value"]["locations"]):
-                                del combined_dictionary["steps_es"][i]
+                                del combined_dictionary[f'steps{lang}'][i]
                             # If any locations were removed, then make sure the Service_Page is not published
                             combined_dictionary["live"] = False
-
 
     # remove liveRevision if we have it
     if 'live_revision' in combined_dictionary:

--- a/joplin/importer/create_from_importer.py
+++ b/joplin/importer/create_from_importer.py
@@ -367,9 +367,20 @@ def create_page_from_importer(page_type, page_dictionaries, revision_id=None):
             combined_dictionary['add_fees'] = {'fees': fees}
             del combined_dictionary['fees']
 
+    # set the translated fields
+    # by doing this before thee steps logic, we can make sure to not import english steps into spanish step fields
+    for field in factory._meta.model._meta.fields:
+        if field.column.endswith("_es"):
+            if field.column[:-3] in page_dictionaries['es']:
+                # make sure we aren't just getting the english fallback value
+                # https://wagtail-modeltranslation-docs.readthedocs.io/en/latest/Advanced%20Settings.html#fallback-languages
+                if page_dictionaries['es'][field.column[:-3]] != page_dictionaries['en'][field.column[:-3]]:
+                    combined_dictionary[field.column] = page_dictionaries['es'][field.column[:-3]]
 
     # Handle 'steps_with_locations' in services
     if page_type is 'services':
+        
+
         if 'steps' in combined_dictionary:
             '''
             Important note!
@@ -405,18 +416,36 @@ def create_page_from_importer(page_type, page_dictionaries, revision_id=None):
                         combined_dictionary["live"] = False
 
 
+            # todo: this but not copypasta
+            if 'steps_es' in combined_dictionary:
+                for i, step in enumerate(combined_dictionary["steps_es"][:]):
+                    # Only import step with location if we have that location already.
+                    if step['type'] == 'step_with_locations':
+                        removed_locations = False
+                        for j, location in enumerate(step["value"]["locations"][:]):
+                            # Add location_page data only if location was already imported.
+                            # Right now, a "step_with_location" does not provide enough location_page
+                            # data required to import a new location_page.
+                            try:
+                                location_page = LocationPage.objects.get(slug=location["location_page"]['slug'])
+                            except LocationPage.DoesNotExist:
+                                location_page = None
+                            if location_page:
+                                combined_dictionary["steps_es"][i]["value"]["locations"][j] = location_page.pk
+                            else:
+                                removed_locations = True
+                                del combined_dictionary["steps_es"][i]["value"]["locations"][j]
+                        if removed_locations:
+                            # If all locations were removed from step, then delete the step
+                            if not len(step["value"]["locations"]):
+                                del combined_dictionary["steps_es"][i]
+                            # If any locations were removed, then make sure the Service_Page is not published
+                            combined_dictionary["live"] = False
+
+
     # remove liveRevision if we have it
     if 'live_revision' in combined_dictionary:
         del combined_dictionary['live_revision']
-
-    # set the translated fields
-    for field in factory._meta.model._meta.fields:
-        if field.column.endswith("_es"):
-            if field.column[:-3] in page_dictionaries['es']:
-                # make sure we aren't just getting the english fallback value
-                # https://wagtail-modeltranslation-docs.readthedocs.io/en/latest/Advanced%20Settings.html#fallback-languages
-                if page_dictionaries['es'][field.column[:-3]] != page_dictionaries['en'][field.column[:-3]]:
-                    combined_dictionary[field.column] = page_dictionaries['es'][field.column[:-3]]
 
     # set the owner of the page
     if 'owner' in combined_dictionary:

--- a/joplin/importer/create_from_importer.py
+++ b/joplin/importer/create_from_importer.py
@@ -368,7 +368,7 @@ def create_page_from_importer(page_type, page_dictionaries, revision_id=None):
             del combined_dictionary['fees']
 
     # set the translated fields
-    # by doing this before thee steps logic, we can make sure to not import english steps into spanish step fields
+    # by doing this before the steps logic, we can make sure to not import english steps into spanish step fields
     for field in factory._meta.model._meta.fields:
         if field.column.endswith("_es"):
             if field.column[:-3] in page_dictionaries['es']:

--- a/joplin/pages/service_page/fixtures/__init__.py
+++ b/joplin/pages/service_page/fixtures/__init__.py
@@ -9,6 +9,7 @@ from .test_cases.step_with_1_location import step_with_1_location
 from .test_cases.step_with_2_locations import step_with_2_locations
 from .test_cases.step_with_internal_links import step_with_internal_links
 from .test_cases.placeholder_for_internal_links import placeholder_for_internal_links
+from .test_cases.step_with_location_first_then_basic_step import step_with_location_first_then_basic_step
 
 
 # You can import any test_case fixture individually
@@ -25,3 +26,4 @@ def load_all():
     step_with_2_locations()
     step_with_internal_links()
     placeholder_for_internal_links()
+    step_with_location_first_then_basic_step()

--- a/joplin/pages/service_page/fixtures/helpers/components.py
+++ b/joplin/pages/service_page/fixtures/helpers/components.py
@@ -158,3 +158,11 @@ def step_with_one_imported_internal_link():
         'type': 'basic_step',
         'value': f'<p><a id="{linked_topic_page.id}" linktype="page">topic title [en]</a></p>',
     }]
+
+def step_with_location_first_then_basic_step():
+    steps = step_with_1_location()
+    steps.append({
+        'type': 'basic_step',
+        'value': '<p>just a basic step</p>'
+    })
+    return steps

--- a/joplin/pages/service_page/fixtures/test_cases/step_with_location_first_then_basic_step.py
+++ b/joplin/pages/service_page/fixtures/test_cases/step_with_location_first_then_basic_step.py
@@ -1,0 +1,25 @@
+import os
+from pages.service_page.fixtures.helpers.create_fixture import create_fixture
+import pages.service_page.fixtures.helpers.components as components
+
+
+# A Service Page that has a step with a location first followed by a basic step
+def step_with_location_first_then_basic_step():
+    steps = components.step_with_location_first_then_basic_step()
+    home = components.home()
+    page_data = {
+        "imported_revision_id": None,
+        "live": False,
+        "parent": home,
+        "coa_global": False,
+        "title": "Service Page with location step followed by basic step",
+        "slug": "service-page-with-location-basic-steps",
+        "add_topics": {
+            "topics": []
+        },
+        "short_description": "This is a very short description",
+        "additional_content": components.additional_content,
+        "steps": steps,
+    }
+
+    return create_fixture(page_data, os.path.basename(__file__))

--- a/joplin/pages/service_page/tests.py
+++ b/joplin/pages/service_page/tests.py
@@ -230,3 +230,14 @@ def test_do_not_import_english_as_spanish(remote_staging_preview_url, test_api_u
     assert page.short_description_es is None
     assert page.slug_en == 'service-page-in-english-only'
     assert page.slug_es is None
+
+
+@pytest.mark.django_db
+def test_import_page_with_step_with_location_followed_by_basic_step(remote_staging_preview_url, test_api_url, test_api_jwt_token):
+    url = f'{remote_staging_preview_url}/services/UGFnZVJldmlzaW9uTm9kZTo3Ng==?CMS_API={test_api_url}'
+    page = PageImporter(url, test_api_jwt_token).fetch_page_data().create_page()
+    assert isinstance(page, ServicePage)
+    # we should only have 1 step, as we haven't imported the associated location page
+    assert len(page.steps) == 1
+    # we should not have any spanish steps
+    assert len(page.steps_es) == 0


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description
When importing steps with locations, we ran into an issue with localization. Our logic was leading to `steps_es` making it into our final `combined_dictionary` without having been processed.

This PR fixes that


<!--- include a summary of the change and what it fixes. -->

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->
https://github.com/cityofaustin/techstack/issues/4311

<!--- If there is a relevant Janis PR, link it here -->
<!--- [Janis Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 
* go here https://joplin-pr-4311-stream-block-er.herokuapp.com/admin/pages/search/
* try importing https://janis.austintexas.io/en/preview/services/UGFnZVJldmlzaW9uTm9kZTozNDc4
* watch it work

# Checklist:
- [x] Request reviewers
- [x] Slack-out message for review
- [x] Link this PR in the issue
- [x] Moved card to *review* in zenhub
