### PR TITLE
Resolve Janis Preview Instances

### DIFF
--- a/.circleci/vars/branch_overrides.py
+++ b/.circleci/vars/branch_overrides.py
@@ -9,8 +9,8 @@
     branch_overrides are not required for every branch.
 '''
 branch_overrides = {
-    "4282-homepage": {
-        "LOAD_DATA": "",
+    "4302-janis-preview": {
+        "LOAD_DATA": "fixtures",
         "V3_WIP": True,
     },
     "v3": {

--- a/joplin/api/schema.py
+++ b/joplin/api/schema.py
@@ -916,7 +916,7 @@ class PageRevisionNode(DjangoObjectType):
         return self.page.content_type.name
 
     def resolve_preview_janis_instance(self, resolve_info, *args, **kwargs):
-        preview_instance = None
+        preview_instance = {}
 
         # for now just get the first one
         page = self.as_page_object()


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description

If a page doesn't have janis instances (in draft or no departments yet), the preview query was giving an error `Cannot return null for non-nullable field`. But an empty `{}` is fine. 

<!--- include a summary of the change and what it fixes. -->

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->

<!--- If there is a relevant Janis PR, link it here -->
<!--- [Janis Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 

In conjunction with https://janis-v3-4302-make-janis-preview.netlify.app/, you can preview locations, service pages in draft (ex: 
https://joplin-pr-4302-janis-preview.herokuapp.com/admin/pages/16/edit/#tab-content) etc. 

Note!!
This page did not preview
https://joplin-pr-4302-janis-preview.herokuapp.com/admin/pages/27/edit/#tab-content 
because it did not provide the CMSPreview with an id. 

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
