### PR TITLE
Allow importing from prod, fix importing pages with topics with no live revision

### DIFF
--- a/joplin/importer/create_from_importer.py
+++ b/joplin/importer/create_from_importer.py
@@ -182,7 +182,11 @@ def create_page_from_importer(page_type, page_dictionaries, revision_id=None):
                 'en': page_dictionaries['en']['topics']['edges'][index]['node']['topic'],
                 'es': page_dictionaries['es']['topics']['edges'][index]['node']['topic'],
             }
-            revision_id = page_dictionaries['en']['topics']['edges'][index]['node']['topic']['live_revision']['id']
+
+            live_revision = page_dictionaries['en']['topics']['edges'][index]['node']['topic']['live_revision']
+            if live_revision:
+                revision_id = live_revision['id']
+
             topic_page = create_page_from_importer(
                 'topics',
                 topic_page_dictionaries,

--- a/joplin/importer/page_importer.py
+++ b/joplin/importer/page_importer.py
@@ -15,7 +15,7 @@ from pages.service_page.factories import ServicePageFactory
 
 # TODO: this could be retrieved programmatically from the netlify API for PR apps
 ENDPOINTS = {
-    'janis.austintexas.io': 'https://joplin-staging.herokuapp.com/api/graphql',
+    'alpha.austin.gov': 'https://joplin.herokuapp.com/api/graphql',
     'janis-pytest.netlify.com': 'https://joplin-pr-pytest.herokuapp.com/api/graphql',
 }
 


### PR DESCRIPTION


<!--- Remember to connect this PR to a relevant issue on Zenhub! -->
https://github.com/cityofaustin/techstack/issues/4312

# Description
* Importing from prod preview urls works now
* Importing pages that have topics that don't have a live revision (https://alpha.austin.gov/en/preview/services/UGFnZVJldmlzaW9uTm9kZToyNjYz) works now

<!--- include a summary of the change and what it fixes. -->

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->

<!--- If there is a relevant Janis PR, link it here -->
<!--- [Janis Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
