### PR TITLE
4317 until we support importing images don't try to import them

### DIFF
--- a/joplin/importer/create_from_importer.py
+++ b/joplin/importer/create_from_importer.py
@@ -284,6 +284,10 @@ def create_page_from_importer(page_type, page_dictionaries, revision_id=None):
             combined_dictionary['add_related_services'].append(location_page_related_service_to_add)
         del combined_dictionary['related_services']
 
+    # remove physical location photo from location pages until we support importing images
+    if 'physical_location_photo' in combined_dictionary:
+        del combined_dictionary['physical_location_photo']
+
     # associate/create documents
     # Only applies to OfficialDocumentPages
     if 'official_documents' in combined_dictionary:


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description
We were trying to pass `physical_location_photo` data to the location page factory without doing anything to it. This caused location pages with images to fail to import.

This allows the page to import without the image instead of failing to import entirely.

<!--- include a summary of the change and what it fixes. -->

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->
https://github.com/cityofaustin/techstack/issues/4317

<!--- If there is a relevant Janis PR, link it here -->
<!--- [Janis Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 
I already merged this into import-everything. The location page from the original error is here now https://joplin-pr-import-everything.herokuapp.com/admin/pages/191/edit/#tab-content

# Checklist:
- [x] Request reviewers
- [x] Slack-out message for review
- [x] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
