### PR TITLE
Issue 4092: use publish_v3 for staging and production

### DIFF
--- a/joplin/base/signals/janis_build_triggers.py
+++ b/joplin/base/signals/janis_build_triggers.py
@@ -28,7 +28,8 @@ def trigger_build(sender, pages_ids, action='saved', instance=None):
     """
     trigger_object = instance
     logger.info(f'{trigger_object} {action}, triggering build')
-    publish_v3(pages_ids)
+    if settings.IS_STAGING or settings.IS_PRODUCTION or settings.IS_REVIEW:
+        publish_v3(pages_ids)
 
 def collect_pages(instance):
     # does this work on page deletion? pages arent deleted right, just unpublished?

--- a/joplin/base/signals/janis_build_triggers.py
+++ b/joplin/base/signals/janis_build_triggers.py
@@ -28,11 +28,7 @@ def trigger_build(sender, pages_ids, action='saved', instance=None):
     """
     trigger_object = instance
     logger.info(f'{trigger_object} {action}, triggering build')
-    if settings.IS_STAGING or settings.IS_PRODUCTION:
-        create_build_aws(sender, instance, request=get_http_request())
-    elif settings.IS_REVIEW:
-        publish_v3(pages_ids)
-
+    publish_v3(pages_ids)
 
 def collect_pages(instance):
     # does this work on page deletion? pages arent deleted right, just unpublished?

--- a/joplin/base/signals/publish_v3.py
+++ b/joplin/base/signals/publish_v3.py
@@ -25,7 +25,7 @@ def publish_v3(page_ids=[]):
         "page_ids": page_ids,
         "joplin_appname": settings.APPNAME,
         "env_vars": {
-            "REACT_STATIC_PREFETCH_RATE": "5",
+            "REACT_STATIC_PREFETCH_RATE": "0",
         },
         "build_type": "all_pages",
     }


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description
Issue: https://github.com/cityofaustin/publisher/pull/8
- Remove the old aws_publish invocation, use new Publisher for staging and production

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
