### PR TITLE
Issue 4371: fix bugs with editing your own user

### DIFF
--- a/joplin/users/forms.py
+++ b/joplin/users/forms.py
@@ -10,19 +10,37 @@ from groups.models import Department
 '''
     Overwrite clean() method for Users.
     Ensure that non-admins choose both a Role and a Department.
-    Set user-selected "Roles" and "Department" into "Groups".
+    Consolidate user-selected "Roles" and "Department" into "Groups".
 '''
 def custom_user_clean(self, cleaned_data):
-    # Consolidate "roles" and "department" into "groups"
+    '''
+        Why do we have this weird is_superuser fallback?
+        Because if a user is editing their own information, they cannot toggle their own superuser status.
+        "is_superuser" is determined by the "Administrator" checkbox on the edit user page.
+        However, the "Administrator" Checkbox won't show up for you when you're editing your own user.
+        A user can neither make themselves an admin nor make themselves not an admin.
+        cleaned_data only passes data submitted from the frontend form.
+        So cleaned_data will not contain "is_superuser" if you're editing your own user.
+
+        So then how can we tell if you are a superuser or not?
+        There is a property called "self.initial" that contains the previous state of user data.
+        So if cleaned_data doesn't have "is_superuser", then we can assume that it's because a user is editing themselves.
+        And their is_superuser status will be in their prior data.
+        Note: we only want to check self.initial if cleaned_data.get("is_superuser") is None and does not exist, not if its False.
+    '''
+    is_superuser = cleaned_data.get("is_superuser")
+    if is_superuser is None:
+        is_superuser = self.initial.get("is_superuser")
+
     group_pks = []
     if cleaned_data["department"]:
         group_pks.append(cleaned_data["department"].pk)
-    elif not cleaned_data["is_superuser"]:
+    elif not is_superuser:
         self.add_error("department", ValidationError("Non-Administrators must belong to one Department."))
     if cleaned_data["roles"]:
         for role in cleaned_data["roles"]:
             group_pks.append(role.pk)
-    elif not cleaned_data["is_superuser"]:
+    elif not is_superuser:
         self.add_error("roles", ValidationError("Non-Administrators must have at least one Role."))
     if group_pks:
         cleaned_data["groups"] = Group.objects.filter(pk__in=group_pks)


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->
https://github.com/cityofaustin/techstack/issues/4371

# Description

Alright. There was a bug with editing anything related to your own user. I made a custom user form handler. And I didn't realize that is_superuser won't be part of cleaned_data if you're editing your own user. I wrote more in the code comments. It might be excessive, but I didn't want there to be mystery logic in our code.

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 
https://joplin-pr-4371-user-bugs.herokuapp.com/

Make a user on the PR deployment. Then try to edit that user while you're logged in as that same issue. You should have no problem changing your password, name, or department.

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
