### PR TITLE
until we get localized urls working just send over the english slug

### DIFF
--- a/joplin/api/schema.py
+++ b/joplin/api/schema.py
@@ -117,7 +117,7 @@ def try_get_api_representation(StreamChild):
                     parsed_location = {
                         "locationPage": {
                             "id": to_global_id(lp._meta.name, location_page.id),
-                            "slug": location_page.slug,
+                            "slug": location_page.slug_en,
                             "title": location_page.title,
                             "physicalStreet": location_page.physical_street,
                             "physicalUnit": location_page.physical_unit,
@@ -1020,7 +1020,7 @@ class DepartmentPageTopPageNode(DjangoObjectType):
         return get_page_from_content_type(self).title
 
     def resolve_slug(self, resolve_info, *args, **kwargs):
-        return get_page_from_content_type(self).slug
+        return get_page_from_content_type(self).slug_en
 
     class Meta:
         model = DepartmentPageTopPage
@@ -1039,7 +1039,7 @@ class DepartmentPageRelatedPageNode(DjangoObjectType):
         return get_page_from_content_type(self).title
 
     def resolve_slug(self, resolve_info, *args, **kwargs):
-        return get_page_from_content_type(self).slug
+        return get_page_from_content_type(self).slug_en
 
     class Meta:
         model = DepartmentPageRelatedPage
@@ -1059,7 +1059,7 @@ class TopicPageTopPageNode(DjangoObjectType):
         return get_page_from_content_type(self).title
 
     def resolve_slug(self, resolve_info, *args, **kwargs):
-        return get_page_from_content_type(self).slug
+        return get_page_from_content_type(self).slug_en
 
     def resolve_page_type(self, info):
         return self.page.content_type.name


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description

<!--- include a summary of the change and what it fixes. -->

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->

<!--- If there is a relevant Janis PR, link it here -->
<!--- [Janis Related Pull Request Link]() -->
https://github.com/cityofaustin/techstack/issues/4449

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 
query https://joplin-pr-4449-slug-es.herokuapp.com/api/graphql with this and switch your headers to en/es, see that we get the english slug every time
```
{
  allPages {
    edges {
      node {
        janisbasepagewithtopiccollections {
        topicpage {
            topPages {
              edges {
                node {
                  slug
                }
              }
            }
          }
        }
      }
    }
  }
}
```

# Checklist:
- [x] Request reviewers
- [x] Slack-out message for review
- [x] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
