### PR TITLE
4400 Prevent editors/authors from creating topics and topic collections

### DIFF
--- a/joplin/base/templatetags/joplin_tags.py
+++ b/joplin/base/templatetags/joplin_tags.py
@@ -89,6 +89,6 @@ def joplin_page_listing_buttons(context, page, page_perms, is_parent=False):
 @register.simple_tag(takes_context=True)
 def can_create_topics(context):
     if context.request.user.is_superuser or context.request.user.groups.filter(id=1):
-        return {"topics": True}
+        return True
 
-    return {"topics": False}
+    return False

--- a/joplin/base/templatetags/joplin_tags.py
+++ b/joplin/base/templatetags/joplin_tags.py
@@ -84,3 +84,11 @@ def joplin_page_listing_buttons(context, page, page_perms, is_parent=False):
         hook(buttons, page, page_perms, is_parent, context)
 
     return {'page': page, 'buttons': buttons}
+
+
+@register.simple_tag(takes_context=True)
+def is_editor(context):
+    if context.request.user.groups.filter(id=2):
+        return "true"
+
+    return "false"

--- a/joplin/base/templatetags/joplin_tags.py
+++ b/joplin/base/templatetags/joplin_tags.py
@@ -87,8 +87,8 @@ def joplin_page_listing_buttons(context, page, page_perms, is_parent=False):
 
 
 @register.simple_tag(takes_context=True)
-def is_editor(context):
-    if context.request.user.groups.filter(id=2):
-        return "true"
+def can_create_topics(context):
+    if context.request.user.is_superuser or context.request.user.groups.filter(id=1):
+        return {"topics": True}
 
-    return "false"
+    return {"topics": False}

--- a/joplin/conftest.py
+++ b/joplin/conftest.py
@@ -70,7 +70,7 @@ def test_api_jwt_token(request, test_api_url):
         headers={
             'Accept-Language': 'en',
         },
-        verify=True
+        verify=False
     )
     client = Client(
         retries=3,

--- a/joplin/js/CreateContentModal/ChooseTypeStep.js
+++ b/joplin/js/CreateContentModal/ChooseTypeStep.js
@@ -37,6 +37,7 @@ const ChooseTypeStep = ({
   handleTypeSelect,
   handleContentOrTopicSelect,
   content_or_topic,
+  canSetTopics,
 }) => {
   const content = content_or_topic === 'content';
   const topic = content_or_topic === 'topic';
@@ -140,6 +141,7 @@ const ChooseTypeStep = ({
     <div className="CreateContentModal__step">
       <div>
         <h2 className="CreateContentModal__header">Select a content type</h2>
+        {canSetTopics &&
         <div className="CreateContentModal__content_or_topic">
           {/* whichever type is selected, show as text, otherwise a link to select*/}
           {content ? (
@@ -166,6 +168,7 @@ const ChooseTypeStep = ({
             </a>
           )}
         </div>
+        }
         <div className="ChooseTypeStep__options-wrapper">
           {content && (
             <React.Fragment>

--- a/joplin/js/CreateContentModal/index.js
+++ b/joplin/js/CreateContentModal/index.js
@@ -35,6 +35,7 @@ class CreateContentModal extends Component {
       creatingContent: false,
       content_or_topic: 'content',
       missingTitle: false,
+      can_set_topics: (document.getElementById("createNewContentButton").dataset.createTopics === 'true')
     };
   }
 
@@ -190,6 +191,7 @@ class CreateContentModal extends Component {
                           this.handleContentOrTopicSelect
                         }
                         content_or_topic={this.state.content_or_topic}
+                        canSetTopics={this.state.can_set_topics}
                       />
                     )}
                     {this.state.activeStep === stepsEnum.CHOOSE_TITLE && (

--- a/joplin/js/CreateContentModal/index.js
+++ b/joplin/js/CreateContentModal/index.js
@@ -35,7 +35,7 @@ class CreateContentModal extends Component {
       creatingContent: false,
       content_or_topic: 'content',
       missingTitle: false,
-      can_set_topics: (document.getElementById("createNewContentButton").dataset.isEditor === 'false')
+      canSetTopics: JSON.parse(document.getElementById('can-create-topics').textContent).topics,
     };
   }
 
@@ -191,7 +191,7 @@ class CreateContentModal extends Component {
                           this.handleContentOrTopicSelect
                         }
                         content_or_topic={this.state.content_or_topic}
-                        canSetTopics={this.state.can_set_topics}
+                        canSetTopics={this.state.canSetTopics}
                       />
                     )}
                     {this.state.activeStep === stepsEnum.CHOOSE_TITLE && (

--- a/joplin/js/CreateContentModal/index.js
+++ b/joplin/js/CreateContentModal/index.js
@@ -35,7 +35,7 @@ class CreateContentModal extends Component {
       creatingContent: false,
       content_or_topic: 'content',
       missingTitle: false,
-      canSetTopics: JSON.parse(document.getElementById('can-create-topics').textContent).topics,
+      canSetTopics: JSON.parse(document.getElementById('can-create-topics').textContent),
     };
   }
 

--- a/joplin/js/CreateContentModal/index.js
+++ b/joplin/js/CreateContentModal/index.js
@@ -35,7 +35,7 @@ class CreateContentModal extends Component {
       creatingContent: false,
       content_or_topic: 'content',
       missingTitle: false,
-      can_set_topics: (document.getElementById("createNewContentButton").dataset.createTopics === 'true')
+      can_set_topics: (document.getElementById("createNewContentButton").dataset.isEditor === 'false')
     };
   }
 

--- a/joplin/templates/wagtailadmin/pages/search_header.html
+++ b/joplin/templates/wagtailadmin/pages/search_header.html
@@ -22,7 +22,7 @@
     <div class="actions">
       <!-- <div> -->
         <!-- Button trigger modal -->
-        <button type="button" class="button" data-toggle="modal" data-target="#createNewContentModal">
+        <button type="button" class="button" data-toggle="modal" data-target="#createNewContentModal" id="createNewContentButton" data-create-topics=false>
           Create New Content
         </button>
       <!-- </div> -->

--- a/joplin/templates/wagtailadmin/pages/search_header.html
+++ b/joplin/templates/wagtailadmin/pages/search_header.html
@@ -2,6 +2,8 @@
 {% load joplin_tags %}
 
 <div class="header secondary coa-search-header ">
+    {% can_create_topics as topics %}
+    {{topics|json_script:"can-create-topics"}}
 
     <div>
         <h1 class="coa-search-results-h1">
@@ -23,8 +25,7 @@
     <div class="actions">
       <!-- <div> -->
         <!-- Button trigger modal -->
-        {% is_editor as editor%}
-        <button type="button" class="button" data-toggle="modal" data-target="#createNewContentModal" id="createNewContentButton" data-is-editor={{editor}}>
+        <button type="button" class="button" data-toggle="modal" data-target="#createNewContentModal" id="createNewContentButton">
           Create New Content
         </button>
       <!-- </div> -->

--- a/joplin/templates/wagtailadmin/pages/search_header.html
+++ b/joplin/templates/wagtailadmin/pages/search_header.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load joplin_tags %}
 
 <div class="header secondary coa-search-header ">
 
@@ -22,7 +23,8 @@
     <div class="actions">
       <!-- <div> -->
         <!-- Button trigger modal -->
-        <button type="button" class="button" data-toggle="modal" data-target="#createNewContentModal" id="createNewContentButton" data-create-topics=false>
+        {% is_editor as editor%}
+        <button type="button" class="button" data-toggle="modal" data-target="#createNewContentModal" id="createNewContentButton" data-is-editor={{editor}}>
           Create New Content
         </button>
       <!-- </div> -->


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description

Authors should not be able to make topics or topic collections, so that link is hidden from the create content modal. 

I registered an inclusion tag to be able to check if the user is in the editors groups or not. 

<!--- include a summary of the change and what it fixes. -->

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->

<!--- If there is a relevant Janis PR, link it here -->
<!--- [Janis Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 

https://joplin-pr-4400-topic-prevent.herokuapp.com/admin/pages/search/

login as admin. click create content modal, see the option to make a topic or topic collection

login as editor, follow the same steps and you shouldnt be able to see the topic and topic collection

login: editor@austintexas.io
pw: e


# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
