### PR TITLE
Issue 4561: fix unpublishing UX bugs

### DIFF
--- a/joplin/templates/joplin_UI/messages/unpublishing.html
+++ b/joplin/templates/joplin_UI/messages/unpublishing.html
@@ -3,5 +3,5 @@
         Your page has been unpublished, but will take 4-6 minutes to be removed from the live site.
         <a class="coa-message__link coa-page-status__open-modal-unpublishing">How will I know when it's removed?</a>
     </div>
-    <span class="material-icons coa-message__close-button" id="coa-message__publishing-close">close</span>
+    <span class="material-icons coa-message__close-button" id="coa-message__unpublishing-close">close</span>
 </div>

--- a/joplin/templates/wagtailadmin/pages/confirm_unpublish.html
+++ b/joplin/templates/wagtailadmin/pages/confirm_unpublish.html
@@ -1,0 +1,38 @@
+{% extends "wagtailadmin/base.html" %}
+{% load i18n %}
+{% block titletag %}{% blocktrans with title=page.get_admin_display_title %}Unpublish {{ title }}{% endblocktrans %}{% endblock %}
+{% block content %}
+    {% trans "Unpublish" as unpublish_str %}
+    {% include "wagtailadmin/shared/header.html" with title=unpublish_str subtitle=page.get_admin_display_title icon="doc-empty-inverse" %}
+
+    <div class="nice-padding">
+        <p>{% trans "Are you sure you want to unpublish this page?" %}</p>
+        <form action="{% url 'wagtailadmin_pages:unpublish' page.id %}" method="POST">
+            {% csrf_token %}
+            <!-- Added custom value for "next". We redirect back to the same edit page after unpublishing. -->
+            <input type="hidden" name="next" value="{% url 'wagtailadmin_pages:edit' page.id %}">
+            <ul class="fields">
+                {% if live_descendant_count > 0 %}
+                <li>
+                    <div class="field boolean_field checkbox_input">
+                        <div class="field-content">
+                            <div class="input">
+                                <input id="id_include_descendants" name="include_descendants" type="checkbox">
+                                <label for="id_include_descendants" class="plain-checkbox-label">{% blocktrans count counter=live_descendant_count %}
+                    This page has one subpage. Unpublish this too
+                {% plural %}
+                    This page has {{ live_descendant_count }} subpages. Unpublish these too
+                {% endblocktrans %}</label>
+                            </div>
+                        </div>
+                    </div>
+                    </li>
+                {% endif %}
+                <li>
+                    <input type="submit" value="{% trans 'Yes, unpublish it' %}" class="button">
+                    <a href="{% if next %}{{ next }}{% else %}{% url 'wagtailadmin_explore' page.get_parent.id %}{% endif %}" class="button button-secondary">{% trans "No, don't unpublish" %}</a>
+                </li>
+            </ul>
+        </form>
+    </div>
+{% endblock %}


### PR DESCRIPTION
https://github.com/cityofaustin/techstack/issues/4541

# Description

Just a couple Joplin UX bugs.
- [ ] Unpublishing doesn't redirect back to same edit page.
- [ ] The "X" on the "unpublishing" banner message does not work.
They work now.

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
https://joplin-pr-4561-queue-bugs.herokuapp.com/admin/pages/search/

Unpublish a live page.
It should redirect back to the edit page.
And it should have an "unpublishing" banner at the top that you can close.

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
