### PR TITLE
4503 no spanish slugs for now

### DIFF
--- a/joplin/api/schema.py
+++ b/joplin/api/schema.py
@@ -117,7 +117,7 @@ def try_get_api_representation(StreamChild):
                     parsed_location = {
                         "locationPage": {
                             "id": to_global_id(lp._meta.name, location_page.id),
-                            "slug": location_page.slug_en,
+                            "slug": location_page.slug,
                             "title": location_page.title,
                             "physicalStreet": location_page.physical_street,
                             "physicalUnit": location_page.physical_unit,
@@ -1010,7 +1010,6 @@ def get_global_id_from_content_type(self):
 
 class DepartmentPageTopPageNode(DjangoObjectType):
     title = graphene.String()
-    slug = graphene.String()
     page_id = graphene.ID()
 
     def resolve_page_id(self, info):
@@ -1018,9 +1017,6 @@ class DepartmentPageTopPageNode(DjangoObjectType):
 
     def resolve_title(self, resolve_info, *args, **kwargs):
         return get_page_from_content_type(self).title
-
-    def resolve_slug(self, resolve_info, *args, **kwargs):
-        return get_page_from_content_type(self).slug_en
 
     class Meta:
         model = DepartmentPageTopPage
@@ -1039,7 +1035,7 @@ class DepartmentPageRelatedPageNode(DjangoObjectType):
         return get_page_from_content_type(self).title
 
     def resolve_slug(self, resolve_info, *args, **kwargs):
-        return get_page_from_content_type(self).slug_en
+        return get_page_from_content_type(self).slug
 
     class Meta:
         model = DepartmentPageRelatedPage
@@ -1059,7 +1055,7 @@ class TopicPageTopPageNode(DjangoObjectType):
         return get_page_from_content_type(self).title
 
     def resolve_slug(self, resolve_info, *args, **kwargs):
-        return get_page_from_content_type(self).slug_en
+        return get_page_from_content_type(self).slug
 
     def resolve_page_type(self, info):
         return self.page.content_type.name

--- a/joplin/api/schema.py
+++ b/joplin/api/schema.py
@@ -1010,6 +1010,7 @@ def get_global_id_from_content_type(self):
 
 class DepartmentPageTopPageNode(DjangoObjectType):
     title = graphene.String()
+    slug = graphene.String()
     page_id = graphene.ID()
 
     def resolve_page_id(self, info):
@@ -1017,6 +1018,9 @@ class DepartmentPageTopPageNode(DjangoObjectType):
 
     def resolve_title(self, resolve_info, *args, **kwargs):
         return get_page_from_content_type(self).title
+
+    def resolve_slug(self, resolve_info, *args, **kwargs):
+        return get_page_from_content_type(self).slug
 
     class Meta:
         model = DepartmentPageTopPage

--- a/joplin/pages/base_page/models.py
+++ b/joplin/pages/base_page/models.py
@@ -73,7 +73,7 @@ class JanisBasePage(Page):
         # If we're under departments
         departments = self.departments()
         if len(departments) > 0:
-            return [f'/{department.slug_en}/{self.slug_en}/'
+            return [f'/{department.slug}/{self.slug}/'
                     for department in departments
                     ]
 
@@ -95,7 +95,7 @@ class JanisBasePage(Page):
         departments = self.departments()
         if len(departments) > 0:
             return [
-                {'url': f'/{department.slug_en}/{self.slug_en}/',
+                {'url': f'/{department.slug}/{self.slug}/',
                  'parent': department,
                  'grandparent': None}
                 for department in departments

--- a/joplin/pages/department_page/models.py
+++ b/joplin/pages/department_page/models.py
@@ -94,7 +94,7 @@ class DepartmentPage(JanisBasePage):
         # check the one to one relationship of pages to department groups
         # it's the only time we should have a url for a department page
         if hasattr(self, 'department'):
-            return [f'/{self.slug_en}/']
+            return [f'/{self.slug}/']
 
         return []
 
@@ -107,7 +107,7 @@ class DepartmentPage(JanisBasePage):
         # check the one to one relationship of pages to department groups
         # it's the only time we should have a url for a department page
         if hasattr(self, 'department'):
-            return [{'url': f'/{self.slug_en}/', 'parent': None, 'grandparent': None}]
+            return [{'url': f'/{self.slug}/', 'parent': None, 'grandparent': None}]
 
         return []
 

--- a/joplin/pages/event_page/models.py
+++ b/joplin/pages/event_page/models.py
@@ -149,7 +149,7 @@ class EventPage(JanisBasePage):
         # Should publish at event/<fullYear>/<month>/<day>/<slug>"
         # Example: event/2020/4/10/event-1
         if self.slug and self.date and self.date.year and self.date.month and self.date.day:
-            return [f'/{self.janis_url_page_type}/{self.date.year}/{self.date.month}/{self.date.day}/{self.slug_en}']
+            return [f'/{self.janis_url_page_type}/{self.date.year}/{self.date.month}/{self.date.day}/{self.slug}']
         return []
 
 

--- a/joplin/pages/location_page/models.py
+++ b/joplin/pages/location_page/models.py
@@ -172,7 +172,7 @@ class LocationPage(JanisBasePage):
         # Should publish at location/<location-page-slug>/"
         # Example: location/the-place-to-be
         if self.slug:
-            return [f'/{self.janis_url_page_type}/{self.slug_en}']
+            return [f'/{self.janis_url_page_type}/{self.slug}']
         return []
 
 

--- a/joplin/pages/news_page/models.py
+++ b/joplin/pages/news_page/models.py
@@ -67,13 +67,13 @@ class NewsPage(JanisBasePage):
             by_department = self.departments()[0]
 
             return [
-                {'url': f'/{self.written_for_department.slug_en}/{self.slug_en}/',
+                {'url': f'/{self.written_for_department.slug}/{self.slug}/',
                  'parent': self.written_for_department, 'grandparent': None,
                  'from_department': self.written_for_department,
                  'by_department': by_department}]
 
         # If we don't have a written_for department, publish under the default departments
-        return [{'url': f'/{department.slug_en}/{self.slug_en}/',
+        return [{'url': f'/{department.slug}/{self.slug}/',
                  'parent': department,
                  'grandparent': None,
                  'from_department': department,

--- a/joplin/pages/service_page/tests.py
+++ b/joplin/pages/service_page/tests.py
@@ -228,8 +228,7 @@ def test_do_not_import_english_as_spanish(remote_staging_preview_url, test_api_u
     assert page.title_es is None
     assert page.short_description_en == 'a description of this service'
     assert page.short_description_es is None
-    assert page.slug_en == 'service-page-in-english-only'
-    assert page.slug_es is None
+    assert page.slug == 'service-page-in-english-only'
 
 
 @pytest.mark.django_db

--- a/joplin/pages/topic_collection_page/models.py
+++ b/joplin/pages/topic_collection_page/models.py
@@ -47,7 +47,7 @@ class TopicCollectionPage(JanisBasePage):
     def janis_urls(self):
         # should publish at /theme_slug/topic_collection_slug/
         if self.theme and self.theme.slug:
-            return [f'/{self.theme.slug}/{self.slug_en}/']
+            return [f'/{self.theme.slug}/{self.slug}/']
 
         return []
 
@@ -57,7 +57,7 @@ class TopicCollectionPage(JanisBasePage):
         """
         # should publish at /theme_slug/topic_collection_slug/
         if self.theme and self.theme.slug:
-            return [{'url': f'/{self.theme.slug}/{self.slug_en}/', 'parent': None, 'grandparent': None}]
+            return [{'url': f'/{self.theme.slug}/{self.slug}/', 'parent': None, 'grandparent': None}]
 
         return []
 
@@ -70,7 +70,7 @@ class JanisBasePageWithTopicCollections(JanisBasePage):
 
         for base_page_topic_collection in self.topic_collections.all():
             for topic_collection_url in base_page_topic_collection.topic_collection.janis_urls():
-                urls.append(f'{topic_collection_url}{self.slug_en}/')
+                urls.append(f'{topic_collection_url}{self.slug}/')
 
         return urls
 
@@ -82,7 +82,7 @@ class JanisBasePageWithTopicCollections(JanisBasePage):
         for base_page_topic_collection in self.topic_collections.all():
             for topic_collection_url in base_page_topic_collection.topic_collection.janis_instances():
                 instances.append({
-                    'url': f'{topic_collection_url["url"]}{self.slug_en}/',
+                    'url': f'{topic_collection_url["url"]}{self.slug}/',
                     'parent': base_page_topic_collection.topic_collection,
                     'grandparent': None,
                 })

--- a/joplin/pages/topic_page/models.py
+++ b/joplin/pages/topic_page/models.py
@@ -69,7 +69,7 @@ class JanisBasePageWithTopics(JanisBasePage):
             return urls
 
         for base_page_topic in self.topics.all():
-            urls.extend(['{topic_page_url}{page_slug}/'.format(topic_page_url=topic_page_url, page_slug=self.slug_en) for
+            urls.extend(['{topic_page_url}{page_slug}/'.format(topic_page_url=topic_page_url, page_slug=self.slug) for
                          topic_page_url in base_page_topic.topic.janis_urls()])
 
         return urls
@@ -86,7 +86,7 @@ class JanisBasePageWithTopics(JanisBasePage):
         for base_page_topic in self.topics.all():
             for topic_page_url in base_page_topic.topic.janis_instances():
                 instances.extend([{
-                    'url': "{topic_page_url}{page_slug}".format(topic_page_url=topic_page_url['url'], page_slug=self.slug_en),
+                    'url': "{topic_page_url}{page_slug}".format(topic_page_url=topic_page_url['url'], page_slug=self.slug),
                     'parent': base_page_topic.topic,
                     'grandparent': topic_page_url['parent']}])
         return instances

--- a/joplin/settings.py
+++ b/joplin/settings.py
@@ -218,7 +218,7 @@ TIME_ZONE = 'UTC'
 USE_TZ = True
 
 MODELTRANSLATION_DEFAULT_LANGUAGE = 'en'
-
+WAGTAILMODELTRANSLATION_TRANSLATE_SLUGS = False
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.11/howto/static-files/


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description
Until we have a good way to get localized janis urls, we shouldn't have spanish slugs causing 404s

<!--- include a summary of the change and what it fixes. -->

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->
https://github.com/cityofaustin/techstack/issues/4503
<!--- If there is a relevant Janis PR, link it here -->
<!--- [Janis Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 
Go to the SEO tab on any page and see that there's only one slug available

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
