### PR TITLE
fix inconsistent revision publish statuses

### DIFF
--- a/joplin/base/views/publish_succeeded.py
+++ b/joplin/base/views/publish_succeeded.py
@@ -35,15 +35,19 @@ def publish_succeeded(request):
             id = page_data["id"]
             try:
                 page = get_object_or_404(Page, id=id).specific
-                # "published" and "unpublished" are the only possible actions for a page that triggered_build
-                if page_data["action"] == "published":
-                    page.published = True
-                elif page_data["action"] == "unpublished":
-                    page.published = False
-                page.publish_request_pk = None
-                page.publish_request_sk = None
-                page.publish_request_enqueued = False
-                page.save()
+                update_page_after_publish_success(page, page_data["action"])
             except Http404:
                 logger.error(f"Couldn't find a page with id={id}")
     return Response(200)
+
+
+def update_page_after_publish_success(page, action):
+    # "published" and "unpublished" are the only possible actions for a page that triggered_build
+    if action == "published":
+        page.published = True
+    elif action == "unpublished":
+        page.published = False
+    page.publish_request_pk = None
+    page.publish_request_sk = None
+    page.publish_request_enqueued = False
+    page.save()

--- a/joplin/pages/base_page/models.py
+++ b/joplin/pages/base_page/models.py
@@ -230,6 +230,18 @@ class JanisBasePage(Page):
 
         return edit_handler.bind_to(model=cls)
 
+    def with_content_json(self, content_json):
+        obj = super().with_content_json(content_json)
+        # Ensure other values that are meaningful for the page as a whole (rather than
+        # to a specific revision) are preserved
+        obj.publish_request_pk = self.publish_request_pk
+        obj.publish_request_sk = self.publish_request_sk
+        obj.publish_request_enqueued = self.publish_request_enqueued
+        obj.published = self.published
+
+        return obj
+
+
     class Meta:
         # https://docs.djangoproject.com/en/2.2/topics/auth/customizing/#custom-permissions
         permissions = [


### PR DESCRIPTION
https://github.com/cityofaustin/techstack/issues/4559

# Description

Ok, there was this crazy thing where page_statuses weren't synced up correctly. Like, on the Content List View, it'd say "oh yeah your page is definitely 'Unpublishing' no worries." But then when you clicked on it, it'd be all like "No, your page is in 'draft' status." And I'd be like "But aren't you still working on 'Unpublishing' it? That's what the Content List View says." And the edit page is still all like "Nah bro don't know what you're talking about."

![Screen Shot 2020-06-26 at 3 30 07 PM](https://user-images.githubusercontent.com/14187277/85898514-f712d880-b7c1-11ea-992c-82a64f923dd6.png)
![Screen Shot 2020-06-26 at 3 29 49 PM](https://user-images.githubusercontent.com/14187277/85898521-f9753280-b7c1-11ea-9711-2a795472e584.png)

How could this be?
I'll tell you how.

There are 2 places where information for a page is saved. 
1. The Page itself. `page = Page.objects.get(id=page_id)`
1.5. (But really the stuff we care about is in the specific model for your content_type) `page = page.specific`
2. The revision! `latest_revision = page.save_revision()`

The revision takes the data that's saved on your page model, and turns it into a revision.
In some places, the data from `page` is used, and in other places the data from your `latest_revision` is used. Because Wagtail assumes that they are interchangeable.

So Wagtail will call `get_latest_revision_as_page()`, and generate a page object that uses the revision's content_json values rather than the values for our `publish_*` fields that are saved on the page. Because the revision is saved and published before the page updates its `publish_*` fields in `base/singals/janis_build_triggers.py`.

We can fix this in the same way Wagtail handles this for other fields it doesn't want revisions to change.

`get_latest_revision_as_page()` calls `latest_revision.as_page_object()` which calls `self.page.specific.with_content_json(self.content_json)`

And if we look at `with_content_json()`, we'll see that that's where Wagtail handles special fields it doesn't want revisions to change:
```
        # Ensure other values that are meaningful for the page as a whole (rather than
        # to a specific revision) are preserved
        obj.draft_title = self.draft_title
        obj.live = self.live
```

So on our base_page modal, we wrote our own modified with_content_json() to handle the fields that we don't want revisions to mess with.

```
    def with_content_json(self, content_json):
        obj = super().with_content_json(content_json)
        # Ensure other values that are meaningful for the page as a whole (rather than
        # to a specific revision) are preserved
        obj.publish_request_pk = self.publish_request_pk
        obj.publish_request_sk = self.publish_request_sk
        obj.publish_request_enqueued = self.publish_request_enqueued
        obj.published = self.published

        return obj
```

Fin.

PS: as a bonus, we now created revisions and publish them for our "live" fixtures so that now they're actually live. They reflect what a real "live" page would look like.

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
https://joplin-pr-4559-better-publishi.herokuapp.com/admin/pages/search/

Publish and Unpublish pages at will. The page statuses will be the same (and correct!) on both the edit page and the content list view.

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
