### PR TITLE
4621 preview

### DIFF
--- a/.circleci/vars/branch_overrides.py
+++ b/.circleci/vars/branch_overrides.py
@@ -29,14 +29,7 @@ branch_overrides = {
         "LOAD_DATA": "fixtures",
         "V3_WIP": True,
     },
-    "4356-queue": {
-        "LOAD_DATA": "fixtures",
-        "CI_COA_PUBLISHER_V2_URL_PR": "https://oar72z1wgf.execute-api.us-east-1.amazonaws.com/4356-queue/publish-request",
-        "COA_PUBLISHER_V2_API_KEY_PR": "changeme",
-    },
-    "4356-queue-banner": {
-        "LOAD_DATA": "fixtures",
-        "CI_COA_PUBLISHER_V2_URL_PR": "https://oar72z1wgf.execute-api.us-east-1.amazonaws.com/4356-queue/publish-request",
-        "COA_PUBLISHER_V2_API_KEY_PR": "changeme",
+    "4621-preview": {
+        "LOAD_DATA": "",
     }
 }

--- a/joplin/api/schema.py
+++ b/joplin/api/schema.py
@@ -759,6 +759,7 @@ class OfficialDocumentCollectionDocumentFilter(FilterSet):
 class DocumentNodeDocument(graphene.ObjectType):
     filename = graphene.String()
     fileSize = graphene.String()
+    url = graphene.String()
 
 
 class OfficialDocumentPageNode(DjangoObjectType):
@@ -776,12 +777,14 @@ class OfficialDocumentPageNode(DjangoObjectType):
             english_doc = DocumentNodeDocument(
                 filename=self.document.filename,
                 fileSize=self.document.file_size,
+                url=self.document.url,
             )
             if django.utils.translation.get_language() == 'es':
                 if self.document_es:
                     return DocumentNodeDocument(
                         filename=self.document_es.filename,
                         fileSize=self.document_es.file_size,
+                        url=self.document_es.url,
                     )
                 else:
                     return english_doc

--- a/joplin/base/management/commands/make_translation_report.py
+++ b/joplin/base/management/commands/make_translation_report.py
@@ -20,10 +20,10 @@ class Command(BaseCommand):
     help = "Sends a report to alert translators about pages requiring translation."
 
     def handle(self, *args, **options):
+        CT = timezone('US/Central')
         def make_date(datetime_instance):
             return datetime(datetime_instance.year, datetime_instance.month, datetime_instance.day, 0, 0, 0, 0, CT)
 
-        CT = timezone('US/Central')
         now = datetime.now(CT)
         weekday = now.weekday()
         upper_bound = make_date(now)

--- a/joplin/settings.py
+++ b/joplin/settings.py
@@ -399,7 +399,7 @@ if(IS_PRODUCTION or IS_STAGING or IS_REVIEW):
     }
 
     # Specifying the location of files
-    # The Janis CMS_MEDIA = AWS_STORAGE_BUCKET_NAME + AWS_LOCATION
+    # The Janis CMS_MEDIA = 'https://' + AWS_S3_CUSTOM_DOMAIN + '/' + AWS_LOCATION
     if IS_PRODUCTION:
         AWS_LOCATION = 'production/static'
         AWS_IS_GZIPPED = True

--- a/scripts/sync_data.sh
+++ b/scripts/sync_data.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -o errexit
+
+# Usage:
+# bash scripts/sync_data.sh APP_SOURCE APP_DEST
+# APP_SOURCE is the joplin app you want to extract data from.
+# APP_DEST is the joplin app you want to send that data to.
+# Use optional -d flag to sync documents too (skip if you aren't testing documents on your PR).
+# bash scripts/sync_data.sh APP_SOURCE APP_DEST -d
+
+APP_SOURCE=$1
+APP_DEST=$2
+GET_DOCUMENTS=$3
+
+if [ "$APP_DEST" == "joplin" ]; then
+  echo "No. Don't overwrite the production database."
+  exit 1
+fi
+
+heroku pg:copy $APP_SOURCE::DATABASE_URL DATABASE_URL -a $APP_DEST
+
+if [ "$GET_DOCUMENTS" == "-d" ]; then
+  echo "Copying documents over."
+  if [ "$APP_SOURCE" == "joplin" ]; then
+    # Get Production documents location
+    DOC_SOURCE="joplin3-austin-gov-static/production/media/documents"
+  elif [ "$APP_SOURCE" == "joplin-staging" ]; then
+    # Get Staging documents location
+    DOC_SOURCE="joplin3-austin-gov-static/staging/media/documents"
+  else
+    # Get Review App documents location
+    BRANCH=$(heroku config:get CIRCLE_BRANCH -a $APP_SOURCE)
+    DOC_SOURCE="joplin3-austin-gov-static/review/$BRANCH/media/documents"
+  fi
+
+  if [ "$APP_DEST" == "joplin-staging" ]; then
+    # Get Staging documents location
+    DOC_DEST="joplin3-austin-gov-static/staging/media/documents"
+  else
+    # Get Review App documents location
+    BRANCH=$(heroku config:get CIRCLE_BRANCH -a $APP_SOURCE)
+    DOC_DEST="joplin3-austin-gov-static/review/$BRANCH/media/documents"
+  fi
+
+  aws s3 sync s3://$DOC_SOURCE s3://$DOC_DEST --only-show-errors --delete
+fi

--- a/scripts/sync_data.sh
+++ b/scripts/sync_data.sh
@@ -29,8 +29,12 @@ if [ "$GET_DOCUMENTS" == "-d" ]; then
     DOC_SOURCE="joplin3-austin-gov-static/staging/media/documents"
   else
     # Get Review App documents location
-    BRANCH=$(heroku config:get CIRCLE_BRANCH -a $APP_SOURCE)
-    DOC_SOURCE="joplin3-austin-gov-static/review/$BRANCH/media/documents"
+    SOURCE_BRANCH=$(heroku config:get CIRCLE_BRANCH -a $APP_SOURCE)
+    if [ -z "$SOURCE_BRANCH" ]; then
+      echo "No CIRCLE_BRANCH found for $APP_SOURCE"
+      exit 1
+    fi
+    DOC_SOURCE="joplin3-austin-gov-static/review/$SOURCE_BRANCH/media/documents"
   fi
 
   if [ "$APP_DEST" == "joplin-staging" ]; then
@@ -38,8 +42,12 @@ if [ "$GET_DOCUMENTS" == "-d" ]; then
     DOC_DEST="joplin3-austin-gov-static/staging/media/documents"
   else
     # Get Review App documents location
-    BRANCH=$(heroku config:get CIRCLE_BRANCH -a $APP_SOURCE)
-    DOC_DEST="joplin3-austin-gov-static/review/$BRANCH/media/documents"
+    DEST_BRANCH=$(heroku config:get CIRCLE_BRANCH -a $APP_DEST)
+    if [ -z "$DEST_BRANCH" ]; then
+      echo "No CIRCLE_BRANCH found for $APP_DEST"
+      exit 1
+    fi
+    DOC_DEST="joplin3-austin-gov-static/review/$DEST_BRANCH/media/documents"
   fi
 
   aws s3 sync s3://$DOC_SOURCE s3://$DOC_DEST --only-show-errors --delete


### PR DESCRIPTION
https://github.com/cityofaustin/techstack/issues/4621

# Description

Previews for Official Document Collections should now display their child documents within Preview. We changed the api.schema to return the document url within DocumentNodeDocument.

Bonus thing that got added! There's now an a script to copy data between Joplin environments, including documents.

Janis PR: https://github.com/cityofaustin/janis/pull/817

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
https://joplin-pr-4621-preview.herokuapp.com/admin/pages/319/edit/?next=/admin/pages/319/edit/#tab-content

We should be able to see child official documents in the mobile preview.

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
