### PR TITLE
4591 - add department resolver to official document pages

### DIFF
--- a/joplin/api/schema.py
+++ b/joplin/api/schema.py
@@ -767,7 +767,7 @@ class OfficialDocumentPageNode(DjangoObjectType):
     class Meta:
         model = OfficialDocumentPage
         filter_fields = ['date']
-        interfaces = [graphene.Node, DepartmentResolver]
+        interfaces = [graphene.Node]
 
     def resolve_document(self, info):
         # although documents are required for publishing, one can save a page without a document

--- a/joplin/api/schema.py
+++ b/joplin/api/schema.py
@@ -767,7 +767,7 @@ class OfficialDocumentPageNode(DjangoObjectType):
     class Meta:
         model = OfficialDocumentPage
         filter_fields = ['date']
-        interfaces = [graphene.Node]
+        interfaces = [graphene.Node, DepartmentResolver]
 
     def resolve_document(self, info):
         # although documents are required for publishing, one can save a page without a document

--- a/joplin/api/schema.py
+++ b/joplin/api/schema.py
@@ -930,6 +930,7 @@ class PageRevisionNode(DjangoObjectType):
     as_department_page = graphene.NonNull(DepartmentPageNode)
     as_topic_page = graphene.NonNull(TopicNode)
     as_topic_collection_page = graphene.NonNull(TopicCollectionNode)
+    as_official_document_page = graphene.NonNull(OfficialDocumentPageNode)
     as_official_document_collection = graphene.NonNull(OfficialDocumentCollectionNode)
     as_guide_page = graphene.NonNull(GuidePageNode)
     as_form_container = graphene.NonNull(FormContainerNode)


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description
Adds two very important things: 

- Official Document Pages on Janis need to know what department they are under, I forgot to include that when creating the officialDocumentPageNode 
- Return OfficialDocumentPageNode in the Revision Query in order for previews to work

<!--- include a summary of the change and what it fixes. -->

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->

<!--- If there is a relevant Janis PR, link it here -->
 [Janis Related Pull Request Link](https://github.com/cityofaustin/janis/pull/820) 

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 
https://joplin-pr-4591-janis-docs.herokuapp.com/admin/pages/search/


# Checklist:
- [x] Request reviewers
- [ ] Slack-out message for review
- [x] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
