### PR TITLE
fix bug I introduced - move comment in file

### DIFF
--- a/joplin/templates/wagtailimages/images/index.html
+++ b/joplin/templates/wagtailimages/images/index.html
@@ -1,10 +1,11 @@
-{% comment %}
-    Difference between this template and the original is the removal of image tags from the display.
-{% endcomment %}
 {% extends "wagtailadmin/base.html" %}
 {% load wagtailadmin_tags %}
 {% load wagtailimages_tags %}
 {% load i18n %}
+
+{% comment %}
+    Difference between this template and the original is the removal of image tags from the display.
+{% endcomment %}
 
 {% block titletag %}{% trans "Images" %}{% endblock %}
 {% block extra_js %}


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description

Yesterday before I merged my changes, I decided to add some more documentation. However, I didnt test after I did that, because I erroneously thought that comments wouldn't break anything. 

I was wrong. Templates have to have the `{% extends %}` block at the beginning of the file or else it won't load and does an internal server error. 

So I have learned:
do not assume comments wont change behavior. 
don't change things after QA has approved and expect it to still work
pay more attention during your 9pm code merges
also I learned how to revert pull requests and how to revert command line merges and which one is easier to do. (pull requests)

<!--- include a summary of the change and what it fixes. -->

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->

<!--- If there is a relevant Janis PR, link it here -->
<!--- [Janis Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 

https://joplin-pr-fix-image-bug.herokuapp.com/admin/pages/search/

click images on side bar, it should load and not fail.
admin/x to sign in

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
