### PR TITLE
Issue 5052: site_search view

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ coverage = "==5.1"
 django-coverage-plugin = "==1.8.0"
 pytest-cov = "==2.9.0"
 snapshottest = "==0.5.1"
+pytest = "==6.0.2"
 
 [packages]
 wagtail = "==2.9.3"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -938,11 +938,11 @@
                 "secure"
             ],
             "hashes": [
-                "sha256:91056c15fa70756691db97756772bb1eb9678fa585d9184f24534b100dc60f4a",
-                "sha256:e7983572181f5e1522d9c98453462384ee92a0be7fac5f1413a1e35c56cc0461"
+                "sha256:8d7eaa5a82a1cac232164990f04874c594c9453ec55eef02eab885aa02fc17a2",
+                "sha256:f5321fbe4bf3fefa0efd0bfe7fb14e90909eb62a48ccda331726b4319897dd5e"
             ],
             "markers": "python_version >= '3.4'",
-            "version": "==1.25.10"
+            "version": "==1.25.11"
         },
         "wagtail": {
             "hashes": [
@@ -1520,11 +1520,11 @@
                 "secure"
             ],
             "hashes": [
-                "sha256:91056c15fa70756691db97756772bb1eb9678fa585d9184f24534b100dc60f4a",
-                "sha256:e7983572181f5e1522d9c98453462384ee92a0be7fac5f1413a1e35c56cc0461"
+                "sha256:8d7eaa5a82a1cac232164990f04874c594c9453ec55eef02eab885aa02fc17a2",
+                "sha256:f5321fbe4bf3fefa0efd0bfe7fb14e90909eb62a48ccda331726b4319897dd5e"
             ],
             "markers": "python_version >= '3.4'",
-            "version": "==1.25.10"
+            "version": "==1.25.11"
         },
         "wasmer": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ee94022ee3cdfda9b184e2d00700c913d2b14fe068e5a3182ad786704d672301"
+            "sha256": "0970a6d685456cb7ab77ab39de727e3cdfeb7891d19a4df015d2e1966017b922"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -25,11 +25,11 @@
         },
         "asgiref": {
             "hashes": [
-                "sha256:7e51911ee147dd685c3c8b805c0ad0cb58d360987b56953878f8c06d2d1c6f1a",
-                "sha256:9fc6fb5d39b8af147ba40765234fa822b39818b12cc80b35ad9b0cef3a476aed"
+                "sha256:a5098bc870b80e7b872bff60bb363c7f2c2c89078759f6c47b53ff8c525a152e",
+                "sha256:cd88907ecaec59d78e4ac00ea665b03e571cb37e3a0e37b3702af1a9e86c365a"
             ],
             "markers": "python_version >= '3.5'",
-            "version": "==3.2.10"
+            "version": "==3.3.0"
         },
         "autopep8": {
             "hashes": [
@@ -367,11 +367,11 @@
         },
         "faker": {
             "hashes": [
-                "sha256:075a95ac4c95765370919d787dcd958acfaea635005ad5af4d926cb0973800db",
-                "sha256:80bab8d46035a7393de827210c5d39c17109d3346d131946bde622137120c496"
+                "sha256:30afa8f564350770373f299d2d267bff42aaba699a7ae0a3b6f378b2a8170569",
+                "sha256:a7a36c3c657f06bd1e3e3821b9480f2a92017d8a26e150e464ab6b97743cbc92"
             ],
             "markers": "python_version >= '3.5'",
-            "version": "==4.1.3"
+            "version": "==4.14.0"
         },
         "future": {
             "hashes": [
@@ -862,49 +862,55 @@
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:072766c3bd09294d716b2d114d46ffc5ccf8ea0b714a4e1c48253014b771c6bb",
-                "sha256:107d4af989831d7b091e382d192955679ec07a9209996bf8090f1f539ffc5804",
-                "sha256:15c0bcd3c14f4086701c33a9e87e2c7ceb3bcb4a246cd88ec54a49cf2a5bd1a6",
-                "sha256:26c5ca9d09f0e21b8671a32f7d83caad5be1f6ff45eef5ec2f6fd0db85fc5dc0",
-                "sha256:276936d41111a501cf4a1a0543e25449108d87e9f8c94714f7660eaea89ae5fe",
-                "sha256:3292a28344922415f939ee7f4fc0c186f3d5a0bf02192ceabd4f1129d71b08de",
-                "sha256:33d29ae8f1dc7c75b191bb6833f55a19c932514b9b5ce8c3ab9bc3047da5db36",
-                "sha256:3bba2e9fbedb0511769780fe1d63007081008c5c2d7d715e91858c94dbaa260e",
-                "sha256:465c999ef30b1c7525f81330184121521418a67189053bcf585824d833c05b66",
-                "sha256:51064ee7938526bab92acd049d41a1dc797422256086b39c08bafeffb9d304c6",
-                "sha256:5a49e8473b1ab1228302ed27365ea0fadd4bf44bc0f9e73fe38e10fdd3d6b4fc",
-                "sha256:618db68745682f64cedc96ca93707805d1f3a031747b5a0d8e150cfd5055ae4d",
-                "sha256:6547b27698b5b3bbfc5210233bd9523de849b2bb8a0329cd754c9308fc8a05ce",
-                "sha256:6557af9e0d23f46b8cd56f8af08eaac72d2e3c632ac8d5cf4e20215a8dca7cea",
-                "sha256:73a40d4fcd35fdedce07b5885905753d5d4edf413fbe53544dd871f27d48bd4f",
-                "sha256:8280f9dae4adb5889ce0bb3ec6a541bf05434db5f9ab7673078c00713d148365",
-                "sha256:83469ad15262402b0e0974e612546bc0b05f379b5aa9072ebf66d0f8fef16bea",
-                "sha256:860d0fe234922fd5552b7f807fbb039e3e7ca58c18c8d38aa0d0a95ddf4f6c23",
-                "sha256:883c9fb62cebd1e7126dd683222b3b919657590c3e2db33bdc50ebbad53e0338",
-                "sha256:8afcb6f4064d234a43fea108859942d9795c4060ed0fbd9082b0f280181a15c1",
-                "sha256:96f51489ac187f4bab588cf51f9ff2d40b6d170ac9a4270ffaed535c8404256b",
-                "sha256:9e865835e36dfbb1873b65e722ea627c096c11b05f796831e3a9b542926e979e",
-                "sha256:aa0554495fe06172b550098909be8db79b5accdf6ffb59611900bea345df5eba",
-                "sha256:b595e71c51657f9ee3235db8b53d0b57c09eee74dfb5b77edff0e46d2218dc02",
-                "sha256:b6ff91356354b7ff3bd208adcf875056d3d886ed7cef90c571aef2ab8a554b12",
-                "sha256:b70bad2f1a5bd3460746c3fb3ab69e4e0eb5f59d977a23f9b66e5bdc74d97b86",
-                "sha256:c7adb1f69a80573698c2def5ead584138ca00fff4ad9785a4b0b2bf927ba308d",
-                "sha256:c898b3ebcc9eae7b36bd0b4bbbafce2d8076680f6868bcbacee2d39a7a9726a7",
-                "sha256:e49947d583fe4d29af528677e4f0aa21f5e535ca2ae69c48270ebebd0d8843c0",
-                "sha256:eb1d71643e4154398b02e88a42fc8b29db8c44ce4134cf0f4474bfc5cb5d4dac",
-                "sha256:f2e8a9c0c8813a468aa659a01af6592f71cd30237ec27c4cc0683f089f90dcfc",
-                "sha256:fe7fe11019fc3e6600819775a7d55abc5446dda07e9795f5954fdbf8a49e1c37"
+                "sha256:009e8388d4d551a2107632921320886650b46332f61dc935e70c8bcf37d8e0d6",
+                "sha256:0157c269701d88f5faf1fa0e4560e4d814f210c01a5b55df3cab95e9346a8bcc",
+                "sha256:0a92745bb1ebbcb3985ed7bda379b94627f0edbc6c82e9e4bac4fb5647ae609a",
+                "sha256:0cca1844ba870e81c03633a99aa3dc62256fb96323431a5dec7d4e503c26372d",
+                "sha256:166917a729b9226decff29416f212c516227c2eb8a9c9f920d69ced24e30109f",
+                "sha256:1f5f369202912be72fdf9a8f25067a5ece31a2b38507bb869306f173336348da",
+                "sha256:2909dffe5c9a615b7e6c92d1ac2d31e3026dc436440a4f750f4749d114d88ceb",
+                "sha256:2b5dafed97f778e9901b79cc01b88d39c605e0545b4541f2551a2fd785adc15b",
+                "sha256:2e9bd5b23bba8ae8ce4219c9333974ff5e103c857d9ff0e4b73dc4cb244c7d86",
+                "sha256:3aa6d45e149a16aa1f0c46816397e12313d5e37f22205c26e06975e150ffcf2a",
+                "sha256:4bdbdb8ca577c6c366d15791747c1de6ab14529115a2eb52774240c412a7b403",
+                "sha256:53fd857c6c8ffc0aa6a5a3a2619f6a74247e42ec9e46b836a8ffa4abe7aab327",
+                "sha256:5cdfe54c1e37279dc70d92815464b77cd8ee30725adc9350f06074f91dbfeed2",
+                "sha256:5d92c18458a4aa27497a986038d5d797b5279268a2de303cd00910658e8d149c",
+                "sha256:632b32183c0cb0053194a4085c304bc2320e5299f77e3024556fa2aa395c2a8b",
+                "sha256:7c735c7a6db8ee9554a3935e741cf288f7dcbe8706320251eb38c412e6a4281d",
+                "sha256:7cd40cb4bc50d9e87b3540b23df6e6b24821ba7e1f305c1492b0806c33dbdbec",
+                "sha256:84f0ac4a09971536b38cc5d515d6add7926a7e13baa25135a1dbb6afa351a376",
+                "sha256:8dcbf377529a9af167cbfc5b8acec0fadd7c2357fc282a1494c222d3abfc9629",
+                "sha256:950f0e17ffba7a7ceb0dd056567bc5ade22a11a75920b0e8298865dc28c0eff6",
+                "sha256:9e379674728f43a0cd95c423ac0e95262500f9bfd81d33b999daa8ea1756d162",
+                "sha256:b15002b9788ffe84e42baffc334739d3b68008a973d65fad0a410ca5d0531980",
+                "sha256:b6f036ecc017ec2e2cc2a40615b41850dc7aaaea6a932628c0afc73ab98ba3fb",
+                "sha256:bad73f9888d30f9e1d57ac8829f8a12091bdee4949b91db279569774a866a18e",
+                "sha256:bbc58fca72ce45a64bb02b87f73df58e29848b693869e58bd890b2ddbb42d83b",
+                "sha256:bca4d367a725694dae3dfdc86cf1d1622b9f414e70bd19651f5ac4fb3aa96d61",
+                "sha256:be41d5de7a8e241864189b7530ca4aaf56a5204332caa70555c2d96379e18079",
+                "sha256:bf53d8dddfc3e53a5bda65f7f4aa40fae306843641e3e8e701c18a5609471edf",
+                "sha256:c092fe282de83d48e64d306b4bce03114859cdbfe19bf8a978a78a0d44ddadb1",
+                "sha256:c3ab23ee9674336654bf9cac30eb75ac6acb9150dc4b1391bec533a7a4126471",
+                "sha256:ce64a44c867d128ab8e675f587aae7f61bd2db836a3c4ba522d884cd7c298a77",
+                "sha256:d05cef4a164b44ffda58200efcb22355350979e000828479971ebca49b82ddb1",
+                "sha256:d2f25c7f410338d31666d7ddedfa67570900e248b940d186b48461bd4e5569a1",
+                "sha256:d3b709d64b5cf064972b3763b47139e4a0dc4ae28a36437757f7663f67b99710",
+                "sha256:e32e3455db14602b6117f0f422f46bc297a3853ae2c322ecd1e2c4c04daf6ed5",
+                "sha256:ed53209b5f0f383acb49a927179fa51a6e2259878e164273ebc6815f3a752465",
+                "sha256:f605f348f4e6a2ba00acb3399c71d213b92f27f2383fc4abebf7a37368c12142",
+                "sha256:fcdb3755a7c355bc29df1b5e6fb8226d5c8b90551d202d69d0076a8a5649d68b"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.3.19"
+            "version": "==1.3.20"
         },
         "sqlparse": {
             "hashes": [
-                "sha256:022fb9c87b524d1f7862b3037e541f68597a730a8843245c349fc93e1643dc4e",
-                "sha256:e162203737712307dfe78860cc56c8da8a852ab2ee33750e33aeadf38d12c548"
+                "sha256:017cde379adbd6a1f15a61873f43e8274179378e95ef3fede90b5aa64d304ed0",
+                "sha256:0f91fd2e829c44362cbcfab3e9ae12e22badaa8a29ad5ff599f9ec109f0454e8"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==0.3.1"
+            "markers": "python_version >= '3.5'",
+            "version": "==0.4.1"
         },
         "text-unidecode": {
             "hashes": [
@@ -984,18 +990,18 @@
         },
         "xlsxwriter": {
             "hashes": [
-                "sha256:99b665203d737db31378ec729c9990a004c1abae53a6fa211c104f8c2e36cffd",
-                "sha256:b89002dea57bb3d4c8207f3e28ef8244bfd9e936b85d74e7dd1f97e11bb70313"
+                "sha256:9b1ade2d1ba5d9b40a6d1de1d55ded4394ab8002718092ae80a08532c2add2e6",
+                "sha256:b807c2d3e379bf6a925f472955beef3e07495c1bac708640696876e68675b49b"
             ],
-            "version": "==1.3.6"
+            "version": "==1.3.7"
         },
         "zipp": {
             "hashes": [
-                "sha256:43f4fa8d8bb313e65d8323a3952ef8756bf40f9a5c3ea7334be23ee4ec8278b6",
-                "sha256:b52f22895f4cfce194bc8172f3819ee8de7540aa6d873535a8668b730b8b411f"
+                "sha256:16522f69653f0d67be90e8baa4a46d66389145b734345d68a257da53df670903",
+                "sha256:c1532a8030c32fd52ff6a288d855fe7adef5823ba1d26a29a68fd6314aa72baa"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==3.2.0"
+            "version": "==3.3.1"
         },
         "zope.event": {
             "hashes": [
@@ -1006,49 +1012,49 @@
         },
         "zope.interface": {
             "hashes": [
-                "sha256:0103cba5ed09f27d2e3de7e48bb320338592e2fabc5ce1432cf33808eb2dfd8b",
-                "sha256:14415d6979356629f1c386c8c4249b4d0082f2ea7f75871ebad2e29584bd16c5",
-                "sha256:1ae4693ccee94c6e0c88a4568fb3b34af8871c60f5ba30cf9f94977ed0e53ddd",
-                "sha256:1b87ed2dc05cb835138f6a6e3595593fea3564d712cb2eb2de963a41fd35758c",
-                "sha256:269b27f60bcf45438e8683269f8ecd1235fa13e5411de93dae3b9ee4fe7f7bc7",
-                "sha256:27d287e61639d692563d9dab76bafe071fbeb26818dd6a32a0022f3f7ca884b5",
-                "sha256:39106649c3082972106f930766ae23d1464a73b7d30b3698c986f74bf1256a34",
-                "sha256:40e4c42bd27ed3c11b2c983fecfb03356fae1209de10686d03c02c8696a1d90e",
-                "sha256:461d4339b3b8f3335d7e2c90ce335eb275488c587b61aca4b305196dde2ff086",
-                "sha256:4f98f70328bc788c86a6a1a8a14b0ea979f81ae6015dd6c72978f1feff70ecda",
-                "sha256:558a20a0845d1a5dc6ff87cd0f63d7dac982d7c3be05d2ffb6322a87c17fa286",
-                "sha256:562dccd37acec149458c1791da459f130c6cf8902c94c93b8d47c6337b9fb826",
-                "sha256:5e86c66a6dea8ab6152e83b0facc856dc4d435fe0f872f01d66ce0a2131b7f1d",
-                "sha256:60a207efcd8c11d6bbeb7862e33418fba4e4ad79846d88d160d7231fcb42a5ee",
-                "sha256:645a7092b77fdbc3f68d3cc98f9d3e71510e419f54019d6e282328c0dd140dcd",
-                "sha256:6874367586c020705a44eecdad5d6b587c64b892e34305bb6ed87c9bbe22a5e9",
-                "sha256:74bf0a4f9091131de09286f9a605db449840e313753949fe07c8d0fe7659ad1e",
-                "sha256:7b726194f938791a6691c7592c8b9e805fc6d1b9632a833b9c0640828cd49cbc",
-                "sha256:8149ded7f90154fdc1a40e0c8975df58041a6f693b8f7edcd9348484e9dc17fe",
-                "sha256:8cccf7057c7d19064a9e27660f5aec4e5c4001ffcf653a47531bde19b5aa2a8a",
-                "sha256:911714b08b63d155f9c948da2b5534b223a1a4fc50bb67139ab68b277c938578",
-                "sha256:a5f8f85986197d1dd6444763c4a15c991bfed86d835a1f6f7d476f7198d5f56a",
-                "sha256:a744132d0abaa854d1aad50ba9bc64e79c6f835b3e92521db4235a1991176813",
-                "sha256:af2c14efc0bb0e91af63d00080ccc067866fb8cbbaca2b0438ab4105f5e0f08d",
-                "sha256:b054eb0a8aa712c8e9030065a59b5e6a5cf0746ecdb5f087cca5ec7685690c19",
-                "sha256:b0becb75418f8a130e9d465e718316cd17c7a8acce6fe8fe07adc72762bee425",
-                "sha256:b1d2ed1cbda2ae107283befd9284e650d840f8f7568cb9060b5466d25dc48975",
-                "sha256:ba4261c8ad00b49d48bbb3b5af388bb7576edfc0ca50a49c11dcb77caa1d897e",
-                "sha256:d1fe9d7d09bb07228650903d6a9dc48ea649e3b8c69b1d263419cc722b3938e8",
-                "sha256:d7804f6a71fc2dda888ef2de266727ec2f3915373d5a785ed4ddc603bbc91e08",
-                "sha256:da2844fba024dd58eaa712561da47dcd1e7ad544a257482392472eae1c86d5e5",
-                "sha256:dcefc97d1daf8d55199420e9162ab584ed0893a109f45e438b9794ced44c9fd0",
-                "sha256:dd98c436a1fc56f48c70882cc243df89ad036210d871c7427dc164b31500dc11",
-                "sha256:e74671e43ed4569fbd7989e5eecc7d06dc134b571872ab1d5a88f4a123814e9f",
-                "sha256:eb9b92f456ff3ec746cd4935b73c1117538d6124b8617bc0fe6fda0b3816e345",
-                "sha256:ebb4e637a1fb861c34e48a00d03cffa9234f42bef923aec44e5625ffb9a8e8f9",
-                "sha256:ef739fe89e7f43fb6494a43b1878a36273e5924869ba1d866f752c5812ae8d58",
-                "sha256:f40db0e02a8157d2b90857c24d89b6310f9b6c3642369852cdc3b5ac49b92afc",
-                "sha256:f68bf937f113b88c866d090fea0bc52a098695173fc613b055a17ff0cf9683b6",
-                "sha256:fb55c182a3f7b84c1a2d6de5fa7b1a05d4660d866b91dbf8d74549c57a1499e8"
+                "sha256:040f833694496065147e76581c0bf32b229a8b8c5eda120a0293afb008222387",
+                "sha256:11198b44e4a3d8c7a80cc20bbdd65522258a4d82fe467cd310c9fcce8ffe2ed2",
+                "sha256:121a9dccfe0c34be9c33b2c28225f0284f9b8e090580ffdff26c38fa16c7ffe1",
+                "sha256:15f3082575e7e19581a80b866664f843719b647a7f7189c811ba7f9ab3309f83",
+                "sha256:1d73d8986f948525536956ddd902e8a587a6846ebf4492117db16daba2865ddf",
+                "sha256:208e82f73b242275b8566ac07a25158e7b21fa2f14e642a7881048430612d1a6",
+                "sha256:2557833df892558123d791d6ff80ac4a2a0351f69c7421c7d5f0c07db72c8865",
+                "sha256:25ea6906f9987d42546329d06f9750e69f0ee62307a2e7092955ed0758e64f09",
+                "sha256:2c867914f7608674a555ac8daf20265644ac7be709e1da7d818089eebdfe544e",
+                "sha256:2eadac20711a795d3bb7a2bfc87c04091cb5274d9c3281b43088a1227099b662",
+                "sha256:37999d5ebd5d7bcd32438b725ca3470df05a7de8b1e9c0395bef24296b31ca99",
+                "sha256:3ae8946d51789779f76e4fa326fd6676d8c19c1c3b4c4c5e9342807185264875",
+                "sha256:5636cd7e60583b1608044ae4405e91575399430e66a5e1812f4bf30bcc55864e",
+                "sha256:570e637cb6509998555f7e4af13006d89fad6c09cfc5c4795855385391063e4b",
+                "sha256:590a40447ff3803c44050ce3c17c3958f11ca028dae3eacdd7b96775184394fa",
+                "sha256:5aab51b9c1af1b8a84f40aa49ffe1684d41810b18d6c3e94aa50194e0a563f01",
+                "sha256:5ffe4e0753393bcbcfc9a58133ed3d3a584634cc7cc2e667f8e3e6fbcbb2155d",
+                "sha256:663982381bd428a275a841009e52983cc69c471a4979ce01344fadbf72cf353d",
+                "sha256:6d06bf8e24dd6c473c4fbd8e16a83bd2e6d74add6ba25169043deb46d497b211",
+                "sha256:6e5b9a4bf133cf1887b4a04c21c10ca9f548114f19c83957b2820d5c84254940",
+                "sha256:70a2aed9615645bbe9d82c0f52bc7e676d2c0f8a63933d68418e0cb307f30536",
+                "sha256:7750746421c4395e3d2cc3d805919f4f57bb9f2a9a0ccd955566a9341050a1b4",
+                "sha256:7fc8708bc996e50fc7a9a2ad394e1f015348e389da26789fa6916630237143d7",
+                "sha256:91abd2f080065a7c007540f6bbd93ef7bdbbffa6df4a4cfab3892d8623b83c98",
+                "sha256:988f8b2281f3d95c66c01bdb141cefef1cc97db0d473c25c3fe2927ef00293b9",
+                "sha256:9f56121d8a676802044584e6cc41250bbcde069d8adf725b9b817a6b0fd87f09",
+                "sha256:a0f51536ce6e817a7aa25b0dca8b62feb210d4dc22cabfe8d1a92d47979372cd",
+                "sha256:a1cdd7390d7f66ddcebf545203ca3728c4890d605f9f2697bc8e31437906e8e7",
+                "sha256:b10eb4d0a77609679bf5f23708e20b1cd461a1643bd8ea42b1ca4149b1a5406c",
+                "sha256:b274ac8e511b55ffb62e8292316bd2baa80c10e9fe811b1aa5ce81da6b6697d8",
+                "sha256:c75b502af2c83fcfa2ee9c2257c1ba5806634a91a50db6129ff70e67c42c7e7b",
+                "sha256:c9c8e53a5472b77f6a391b515c771105011f4b40740ce53af8428d1c8ca20004",
+                "sha256:d867998a56c5133b9d31992beb699892e33b72150a8bf40f86cb52b8c606c83f",
+                "sha256:eb566cab630ec176b2d6115ed08b2cf4d921b47caa7f02cca1b4a9525223ee94",
+                "sha256:f61e6b95b414431ffe9dc460928fe9f351095fde074e2c2f5c6dda7b67a2192d",
+                "sha256:f718675fd071bcce4f7cbf9250cbaaf64e2e91ef1b0b32a1af596e7412647556",
+                "sha256:f9d4bfbd015e4b80dbad11c97049975f94592a6a0440e903ee647309f6252a1f",
+                "sha256:fae50fc12a5e8541f6f1cc4ed744ca8f76a9543876cf63f618fb0e6aca8f8375",
+                "sha256:fcf9c8edda7f7b2fd78069e97f4197815df5e871ec47b0f22580d330c6dec561",
+                "sha256:fdedce3bc5360bd29d4bb90396e8d4d3c09af49bc0383909fe84c7233c5ee675"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==5.1.0"
+            "version": "==5.1.2"
         }
     },
     "develop": {
@@ -1136,11 +1142,11 @@
         },
         "faker": {
             "hashes": [
-                "sha256:075a95ac4c95765370919d787dcd958acfaea635005ad5af4d926cb0973800db",
-                "sha256:80bab8d46035a7393de827210c5d39c17109d3346d131946bde622137120c496"
+                "sha256:30afa8f564350770373f299d2d267bff42aaba699a7ae0a3b6f378b2a8170569",
+                "sha256:a7a36c3c657f06bd1e3e3821b9480f2a92017d8a26e150e464ab6b97743cbc92"
             ],
             "markers": "python_version >= '3.5'",
-            "version": "==4.1.3"
+            "version": "==4.14.0"
         },
         "fastdiff": {
             "hashes": [
@@ -1267,10 +1273,10 @@
         },
         "iniconfig": {
             "hashes": [
-                "sha256:80cf40c597eb564e86346103f609d74efce0f6b4d4f30ec8ce9e2c26411ba437",
-                "sha256:e5f92f89355a67de0595932a6c6c02ab4afddc6fcdc0bfc5becd0d60884d3f69"
+                "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3",
+                "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"
             ],
-            "version": "==1.0.1"
+            "version": "==1.1.1"
         },
         "itsdangerous": {
             "hashes": [
@@ -1386,7 +1392,7 @@
                 "sha256:0e37f61339c4578776e090c3b8f6b16ce4db333889d65d0efb305243ec544b40",
                 "sha256:c8f57c2a30983f469bf03e68cdfa74dc474ce56b8f280ddcb080dfd91df01043"
             ],
-            "markers": "python_version >= '3.5'",
+            "index": "pypi",
             "version": "==6.0.2"
         },
         "pytest-cov": {
@@ -1434,6 +1440,7 @@
                 "sha256:046b92e860914e39612e84fa760fc3f16054d268c11e0e25dcb011fb1bc6a075",
                 "sha256:09d24a80ccb8cbda1af6ed8eb26b005b6743e58e9290566d2a6841f4e31fa8e0",
                 "sha256:0a422fc290d03958899743db091f8154958410fc76ce7ee0ceb66150f72c2c97",
+                "sha256:18189fc59ff5bf46b7ccf5a65c1963326dbfc85a2bc73e9f4a90a40322b992c8",
                 "sha256:276ad604bffd70992a386a84bea34883e696a6b22e7378053e5d3227321d9702",
                 "sha256:296540a065c8c21b26d63e3cea2d1d57902373b16e4256afe46422691903a438",
                 "sha256:29d51279060d0a70f551663bc592418bcad7f4be4eea7b324f6dd81de05cb4c1",
@@ -1447,13 +1454,16 @@
                 "sha256:73483a2caaa0264ac717af33d6fb3f143d8379e60a422730ee8d010526ce1913",
                 "sha256:8a6ada5a3f719bf46a04ba38595073df8d6b067316c011180102ba2a1925f5b5",
                 "sha256:8b66b94fe6243d2d1d89bca336b2424399aac57932858b9a30309803ffc28112",
+                "sha256:949a219493a861c263b75a16588eadeeeab08f372e25ff4a15a00f73dfe341f4",
                 "sha256:99cc0e339a731c6a34109e5c4072aaa06d8e32c0b93dc2c2d90345dd45fa196c",
                 "sha256:a7e7f930039ee0c4c26e4dfee015f20bd6919cd8b97c9cd7afbde2923a5167b6",
                 "sha256:ab0d01148d13854de716786ca73701012e07dff4dfbbd68c4e06d8888743526e",
+                "sha256:b1dd4cf4c5e09cbeef0aee83f3b8af1e9986c086a8927b261c042655607571e8",
                 "sha256:c1a31cd42905b405530e92bdb70a8a56f048c8a371728b8acf9d746ecd4482c0",
                 "sha256:c20dd60b9428f532bc59f2ef6d3b1029a28fc790d408af82f871a7db03e722ff",
                 "sha256:c36ffe1e5aa35a1af6a96640d723d0d211c5f48841735c2aa8d034204e87eb87",
                 "sha256:c40fbb2b9933369e994b837ee72193d6a4c35dfb9a7c573257ef7ff28961272c",
+                "sha256:c6d653bab76b3925c65d4ac2ddbdffe09710f3f41cc7f177299e8c4498adb04a",
                 "sha256:d46fb17f5693244de83e434648b3dbb4f4b0fec88415d6cbab1c1452b6f2ae17",
                 "sha256:e36f12f503511d72d9bdfae11cadbadca22ff632ff67c1b5459f69756a029c19",
                 "sha256:f1a25a61495b6f7bb986accc5b597a3541d9bd3ef0016f50be16dbb32025b302",
@@ -1538,11 +1548,11 @@
         },
         "zipp": {
             "hashes": [
-                "sha256:43f4fa8d8bb313e65d8323a3952ef8756bf40f9a5c3ea7334be23ee4ec8278b6",
-                "sha256:b52f22895f4cfce194bc8172f3819ee8de7540aa6d873535a8668b730b8b411f"
+                "sha256:16522f69653f0d67be90e8baa4a46d66389145b734345d68a257da53df670903",
+                "sha256:c1532a8030c32fd52ff6a288d855fe7adef5823ba1d26a29a68fd6314aa72baa"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==3.2.0"
+            "version": "==3.3.1"
         }
     }
 }

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -28,6 +28,10 @@ case "${DEPLOYMENT_MODE}" in
     python ./joplin/manage.py load_joplin_data
   ;;
 esac
+
+# Update our search index in case newly loaded data or existing data has not been indexed yet.
+python ./joplin/manage.py update_index
+
 case "${DEPLOYMENT_MODE}" in
   REVIEW|STAGING|PRODUCTION)
     echo "Collecting static files"

--- a/joplin/api/schema.py
+++ b/joplin/api/schema.py
@@ -729,6 +729,14 @@ class OfficialDocumentCollectionOfficialDocumentPageNode(DjangoObjectType):
 
 
 class OfficialDocumentCollectionNode(JanisBasePageNode):
+    documents_count = graphene.Int()
+
+    def resolve_documents_count(self, info):
+        return OfficialDocumentPage.objects.filter(
+            live=True,
+            official_document_collection__official_document_collection__id__in=[self.id]
+        ).count()
+
     class Meta:
         model = OfficialDocumentCollection
         filter_fields = ['id', 'slug', 'live', 'coa_global']

--- a/joplin/api/schema.py
+++ b/joplin/api/schema.py
@@ -707,26 +707,17 @@ class OfficialDocumentPageNode(JanisBasePageNode):
         interfaces = [graphene.Node, DepartmentResolver]
 
     def resolve_document(self, info):
+        document = self.get_document
         # although documents are required for publishing, one can save a page without a document
         # and since the filtering on live pages is done on Janis, it could cause an error
-        if self.document:
-            english_doc = DocumentNodeDocument(
-                filename=self.document.filename,
-                fileSize=self.document.file_size,
-                url=self.document.url,
+        if document:
+            return DocumentNodeDocument(
+                filename=document.filename,
+                fileSize=document.file_size,
+                url=document.url,
             )
-            if django.utils.translation.get_language() == 'es':
-                if self.document_es:
-                    return DocumentNodeDocument(
-                        filename=self.document_es.filename,
-                        fileSize=self.document_es.file_size,
-                        url=self.document_es.url,
-                    )
-                else:
-                    return english_doc
-            else:
-                return english_doc
-        return None
+        else:
+            return None
 
 
 class OfficialDocumentCollectionOfficialDocumentPageNode(DjangoObjectType):

--- a/joplin/base/views/site_search.py
+++ b/joplin/base/views/site_search.py
@@ -1,48 +1,49 @@
+import sys
 from rest_framework.decorators import api_view
 from django.http import HttpResponse
-import json
+from django.utils import translation
 
 from pages.base_page.models import JanisBasePage
 from pages.official_documents_page.models import OfficialDocumentPage
 
 @api_view(['GET'])
 def site_search(request):
+    try:
+        params = request.query_params
+        q = (params.get("q") or "")[:100] # only allow 100 characters max
+        page = int(params.get("page") or 1)
+        limit = int(params.get("limit") or 10)
+        lang = params.get("lang") or "en"
+        official_document_collection_id = params.get("official_document_collection_id")
+        result = None
 
-    print("hi")
-    # body = json.loads(request.body)
-    # query = body["q"]
-    #
-    params = request.query_params
-    q = params.get("q")
-    page = int(params.get("page") or 1)
-    limit = int(params.get("limit") or 10)
-    official_document_collection_id = params.get("official_document_collection_id")
-    result = None
+        # A query for an official_document_collection will only need to return the pages that are part of it.
+        if (official_document_collection_id):
+            '''
+            We can't run on .search() on a .filter() that filters by a foreign key. This is a limitation in Wagtail https://docs.wagtail.io/en/v2.10.2/topics/search/indexing.html#index-relatedfields
+            But there's a workaround. You can run one query that just gets all the ids you want.
+            Then run a search on that QuerySet.
+            This is the workaround recommended by Wagtail "as long as you don't have 1000s of pages" https://groups.google.com/g/wagtail/c/k2-E4h2oLtI/m/uPOzbuwKBgAJ
+            '''
+            doc_ids_for_collection = OfficialDocumentPage.objects.filter(
+                published=True, live=True,
+                official_document_collection__official_document_collection__id__in=[official_document_collection_id]
+            ).values_list('id', flat=True)
 
-    # A query for an official_document_collection will only need to return the pages that are part of it.
-    if (official_document_collection_id):
-        '''
-        We can't run on .search() on a .filter() that filters by a foreign key. This is a limitation in Wagtail https://docs.wagtail.io/en/v2.10.2/topics/search/indexing.html#index-relatedfields
-        But there's a workaround. You can run one query that just gets all the ids you want.
-        Then run a search on that QuerySet.
-        This is the workaround recommended by Wagtail "as long as you don't have 1000s of pages" https://groups.google.com/g/wagtail/c/k2-E4h2oLtI/m/uPOzbuwKBgAJ
-        '''
-        doc_ids_for_collection = OfficialDocumentPage.objects.filter(
-            published=True, live=True,
-            official_document_collection__official_document_collection__id__in=[official_document_collection_id]
-        ).values_list('id', flat=True)
+            result = OfficialDocumentPage.objects.filter(
+                id__in=doc_ids_for_collection
+            ).order_by("-date").search(q)
+        # If a query doesn't have an official_document_collection_id, then assume that it's for the global SearchPage
+        else:
+            result = JanisBasePage.objects.filter(published=True, live=True).search(q)
 
-        result = OfficialDocumentPage.objects.filter(
-            id__in=doc_ids_for_collection
-        ).order_by("-date").search(q)
-    # If a query doesn't have an official_document_collection_id, then assume that it's for the global SearchPage
-    else:
-        result = JanisBasePage.objects.filter(published=True, live=True).search(q)
+        offset = ((page-1) * limit)
+        result = result[offset:(offset + limit)]
 
-    offset = ((page-1) * limit)
-    result = result[offset:(offset + limit)]
-    if (result):
-        print("count:", result.count())
-        return HttpResponse([r.to_json() for r in result], content_type='application/json')
-    else:
-        return HttpResponse(200)
+        # Set the set language for return values
+        translation.activate(lang)
+        # return HttpResponse([r.to_json() for r in result], content_type='application/json')
+        return HttpResponse([r.specific.search_output for r in result], content_type="application/json")
+    except Exception as err:
+        print(f"Error on site_search", sys.exc_info()[0])
+        return HttpResponse(500)

--- a/joplin/base/views/site_search.py
+++ b/joplin/base/views/site_search.py
@@ -1,0 +1,48 @@
+from rest_framework.decorators import api_view
+from django.http import HttpResponse
+import json
+
+from pages.base_page.models import JanisBasePage
+from pages.official_documents_page.models import OfficialDocumentPage
+
+@api_view(['GET'])
+def site_search(request):
+
+    print("hi")
+    # body = json.loads(request.body)
+    # query = body["q"]
+    #
+    params = request.query_params
+    q = params.get("q")
+    page = int(params.get("page") or 1)
+    limit = int(params.get("limit") or 10)
+    official_document_collection_id = params.get("official_document_collection_id")
+    result = None
+
+    # A query for an official_document_collection will only need to return the pages that are part of it.
+    if (official_document_collection_id):
+        '''
+        We can't run on .search() on a .filter() that filters by a foreign key. This is a limitation in Wagtail https://docs.wagtail.io/en/v2.10.2/topics/search/indexing.html#index-relatedfields
+        But there's a workaround. You can run one query that just gets all the ids you want.
+        Then run a search on that QuerySet.
+        This is the workaround recommended by Wagtail "as long as you don't have 1000s of pages" https://groups.google.com/g/wagtail/c/k2-E4h2oLtI/m/uPOzbuwKBgAJ
+        '''
+        doc_ids_for_collection = OfficialDocumentPage.objects.filter(
+            published=True, live=True,
+            official_document_collection__official_document_collection__id__in=[official_document_collection_id]
+        ).values_list('id', flat=True)
+
+        result = OfficialDocumentPage.objects.filter(
+            id__in=doc_ids_for_collection
+        ).order_by("-date").search(q)
+    # If a query doesn't have an official_document_collection_id, then assume that it's for the global SearchPage
+    else:
+        result = JanisBasePage.objects.filter(published=True, live=True).search(q)
+
+    offset = ((page-1) * limit)
+    result = result[offset:(offset + limit)]
+    if (result):
+        print("count:", result.count())
+        return HttpResponse([r.to_json() for r in result], content_type='application/json')
+    else:
+        return HttpResponse(200)

--- a/joplin/pages/base_page/models.py
+++ b/joplin/pages/base_page/models.py
@@ -32,6 +32,15 @@ class JanisBasePage(Page):
         index.FilterField('published'),
     ]
 
+    @property
+    def search_output(self):
+        return {
+            "title": self.title,
+            "searchSummary": self.specific.search_summary,
+            "url": self.specific.janis_urls() and self.specific.janis_urls()[0],
+            "pageType": self.content_type.name,
+        }
+
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 

--- a/joplin/pages/base_page/models.py
+++ b/joplin/pages/base_page/models.py
@@ -36,6 +36,7 @@ class JanisBasePage(Page):
     def search_output(self):
         return {
             "title": self.title,
+            "id": self.id,
             "searchSummary": self.specific.search_summary,
             "url": self.specific.janis_urls() and self.specific.janis_urls()[0],
             "pageType": self.content_type.name,

--- a/joplin/pages/base_page/models.py
+++ b/joplin/pages/base_page/models.py
@@ -27,7 +27,9 @@ class JanisBasePage(Page):
         index.RelatedFields('owner', [
             index.SearchField('last_name', partial_match=True),
             index.FilterField('last_name'),
-        ])
+        ]),
+        index.FilterField('live'),
+        index.FilterField('published'),
     ]
 
     created_at = models.DateTimeField(auto_now_add=True)

--- a/joplin/pages/location_page/models.py
+++ b/joplin/pages/location_page/models.py
@@ -104,6 +104,19 @@ class LocationPage(JanisBasePage):
 
     base_form_class = LocationPageForm
 
+    @property
+    def search_output(self):
+        output = {}
+        output.update(super().search_output)
+        output.update({
+            "physicalStreet": self.physical_street,
+            "physicalUnit": self.physical_unit,
+            "physicalCity": self.physical_city,
+            "physicalState": self.physical_state,
+            "physicalZip": self.physical_zip,
+        })
+        return output
+
     publish_requirements = (
         FieldPublishRequirement("physical_street", message="Street address is required."),
         FieldPublishRequirement("physical_zip", message="ZIP Code is required."),

--- a/joplin/pages/official_documents_page/models.py
+++ b/joplin/pages/official_documents_page/models.py
@@ -1,17 +1,14 @@
 from django.db import models
-
 from modelcluster.fields import ParentalKey
 from modelcluster.models import ClusterableModel
-
-from base.forms import OfficialDocumentPageForm
-
+from wagtail.search import index
 from wagtail.admin.edit_handlers import FieldPanel, InlinePanel, PageChooserPanel
 from wagtail.documents.models import Document
 from wagtail.documents.edit_handlers import DocumentChooserPanel
 from wagtail.core.fields import RichTextField
 
 from pages.base_page.models import JanisBasePage
-
+from base.forms import OfficialDocumentPageForm
 from base.models.constants import DEFAULT_MAX_LENGTH
 from base.models.widgets import countMe, AUTHOR_LIMITS
 from publish_preflight.requirements import FieldPublishRequirement, RelationPublishRequirement
@@ -67,6 +64,15 @@ class OfficialDocumentPage(JanisBasePage):
         DocumentChooserPanel('document'),
         DocumentChooserPanel('document_es'),
         InlinePanel('official_document_collection', label="Official document collections this document belongs to"),
+    ]
+
+    search_fields = JanisBasePage.search_fields + [
+        index.SearchField('body'),
+        index.SearchField('summary'),
+        index.FilterField('date'),
+        index.RelatedFields('official_document_collection', [
+            index.FilterField('id'),
+        ])
     ]
 
     class Meta:

--- a/joplin/pages/official_documents_page/models.py
+++ b/joplin/pages/official_documents_page/models.py
@@ -63,10 +63,15 @@ class OfficialDocumentPage(JanisBasePage):
         })
         document = self.get_document
         if document:
+            output["filename"] = document.filename
             output["link"] = document.url
-            # There's nothing stopping us from including the size of any document, I'm just following our prior acceptance criteria
+            # There's nothing stopping us from including the size of any type of document, I'm just following our prior acceptance criteria
             if document.file_extension == 'pdf':
                 output["pdfSize"] = document.file_size
+        output["officialDocumentCollections"] = [{
+            "title": c.official_document_collection.title,
+            "url": c.official_document_collection.janis_urls() and c.official_document_collection.janis_urls()[0],
+        } for c in self.specific.official_document_collection.all()]
         return output
 
 

--- a/joplin/pages/topic_page/models.py
+++ b/joplin/pages/topic_page/models.py
@@ -104,9 +104,10 @@ class JanisBasePageWithTopics(JanisBasePage):
     def search_output(self):
         output = {}
         output.update(super().search_output)
-        output.update({
-            "topics": [t.topic.title for t in self.specific.topics.all()]
-        })
+        output["topics"] = [{
+            "title": t.topic.title,
+            "url": t.topic.janis_urls() and t.topic.janis_urls()[0],
+        } for t in self.specific.topics.all()]
         return output
 
 

--- a/joplin/pages/topic_page/models.py
+++ b/joplin/pages/topic_page/models.py
@@ -100,6 +100,15 @@ class JanisBasePageWithTopics(JanisBasePage):
 
         return departments
 
+    @property
+    def search_output(self):
+        output = {}
+        output.update(super().search_output)
+        output.update({
+            "topics": [t.topic.title for t in self.specific.topics.all()]
+        })
+        return output
+
 
 class JanisBasePageTopic(ClusterableModel):
     page = ParentalKey(JanisBasePageWithTopics, related_name='topics')

--- a/joplin/settings.py
+++ b/joplin/settings.py
@@ -106,6 +106,7 @@ INSTALLED_APPS = [
     'pages.news_page',
     'snippets.contact',
     'snippets.theme',
+    'wagtail.contrib.postgres_search',
 ]
 
 MIDDLEWARE = [
@@ -533,3 +534,10 @@ else:
     # Redirect to HTTPS
     SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
     SECURE_SSL_REDIRECT = True
+
+# Search
+WAGTAILSEARCH_BACKENDS = {
+    'default': {
+        'BACKEND': 'wagtail.contrib.postgres_search.backend',
+    }
+}

--- a/joplin/settings.py
+++ b/joplin/settings.py
@@ -539,5 +539,6 @@ else:
 WAGTAILSEARCH_BACKENDS = {
     'default': {
         'BACKEND': 'wagtail.contrib.postgres_search.backend',
+        'AUTO_UPDATE': True,
     }
 }

--- a/joplin/urls.py
+++ b/joplin/urls.py
@@ -11,7 +11,8 @@ from wagtail.documents import urls as wagtaildocs_urls
 from base.views import \
     new_page_from_modal, \
     joplin_search_views, \
-    publish_succeeded
+    publish_succeeded, \
+    site_search
 from users.urls import users as user_urls
 from snippets import urls as snippet_urls
 from django.urls import reverse
@@ -62,6 +63,7 @@ urlpatterns = [
     url(r'session_security/', include('session_security.urls')),
     url(r'^performance/', include('silk.urls', namespace='silk')),
     url('publish_succeeded', publish_succeeded.publish_succeeded),
+    url('site_search', site_search.site_search),
 
 
     # For anything not caught by a more specific rule above, hand over to


### PR DESCRIPTION
Issue: https://github.com/cityofaustin/techstack/issues/5052
Janis PR: https://github.com/cityofaustin/janis/pull/887

# Description

Now we have live keyword filtering. Both on the SearchPage and the OfficialDocumentCollectionPage. You enter a word. It'll query a new route called site_search on your CMS_API. It'll search through any field that you want to query (title, summary, body, etc.). And it'll return the exact page of results that you want. How cool!

I wrote notes for potential improvements to make from here in our Search v2 epic: https://github.com/cityofaustin/techstack/issues/4762

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
Check it out! 
- [ ] https://janis-v3-5052-search.netlify.app/en/health-safety/policing-in-austin/police-feedback-and-records/official-complaint-and-discipline-documents/
- [ ] https://janis-v3-5052-search.netlify.app/en/search/

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
