### PR TITLE
4907 remove importer tests

### DIFF
--- a/.circleci/scripts/check_app_status.py
+++ b/.circleci/scripts/check_app_status.py
@@ -14,15 +14,15 @@ def check_app_status():
                             capture_output=True,
                             text=True
                             )
-    if (output.stdout):
+    if output.stdout:
         print(output.stdout)
-    if (output.stderr):
+    if output.stderr:
         print('There was an error from heroku cli, check it out:')
         print(output.stderr)
 
     app_info = json.loads(output.stdout)
     app_state = app_info[0]['state']
-    if (app_state == 'up'):
+    if app_state == 'up':
         print(f"App {APPNAME} is up. Ready to migrate.")
         return
     elif (app_state == 'starting') or (app_state == 'restarting'):

--- a/joplin/conftest.py
+++ b/joplin/conftest.py
@@ -37,6 +37,7 @@ def test_suite_cleanup_thing(request):
     yield
     # Teardown: Everything after yield will happen at the end of your pytest session
 
+
 def register_factories(factories):
     """
     lil loop to go through and register factory objects
@@ -59,39 +60,39 @@ def test_api_url():
     return 'https://joplin-pr-pytest.herokuapp.com/api/graphql'
 
 
-@pytest.fixture()
-def test_api_jwt_token(request, test_api_url):
-    # Requesting the jwt_token takes a long time.
-    # So we'll put it in the cache once we've retrieved it once for this session.
-    jwt_token = request.config.cache.get('test_api_jwt_token', None)
-    if jwt_token:
-        return jwt_token
-    transport = RequestsHTTPTransport(
-        url=test_api_url,
-        headers={
-            'Accept-Language': 'en',
-        },
-        verify=False,
-        retries=3,
-    )
-    client = Client(
-        transport=transport,
-        fetch_schema_from_transport=True,
-    )
-    jwt_token_query = gql('''
-        mutation TokenAuth($email: String!, $password: String!) {
-          tokenAuth(email: $email, password: $password) {
-            token
-          }
-        }
-    ''')
-    result = client.execute(jwt_token_query, variable_values=json.dumps({
-        'email': "apitest@austintexas.io",
-        'password': os.getenv("API_TEST_USER_PASSWORD"),
-    }))
-    jwt_token = result['tokenAuth']['token']
-    request.config.cache.set('test_api_jwt_token', jwt_token)
-    return jwt_token
+# @pytest.fixture()
+# def test_api_jwt_token(request, test_api_url):
+#     # Requesting the jwt_token takes a long time.
+#     # So we'll put it in the cache once we've retrieved it once for this session.
+#     jwt_token = request.config.cache.get('test_api_jwt_token', None)
+#     if jwt_token:
+#         return jwt_token
+#     transport = RequestsHTTPTransport(
+#         url=test_api_url,
+#         headers={
+#             'Accept-Language': 'en',
+#         },
+#         verify=False,
+#         retries=3,
+#     )
+#     client = Client(
+#         transport=transport,
+#         fetch_schema_from_transport=True,
+#     )
+#     jwt_token_query = gql('''
+#         mutation TokenAuth($email: String!, $password: String!) {
+#           tokenAuth(email: $email, password: $password) {
+#             token
+#           }
+#         }
+#     ''')
+#     result = client.execute(jwt_token_query, variable_values=json.dumps({
+#         'email': "apitest@austintexas.io",
+#         'password': os.getenv("API_TEST_USER_PASSWORD"),
+#     }))
+#     jwt_token = result['tokenAuth']['token']
+#     request.config.cache.set('test_api_jwt_token', jwt_token)
+#     return jwt_token
 
 
 @pytest.fixture()

--- a/joplin/importer/tests.py
+++ b/joplin/importer/tests.py
@@ -1,345 +1,345 @@
-import pytest
-from importer.page_importer import PageImporter
-from django.core.exceptions import ValidationError
-
-
-def test_parse_janis_preview_url(remote_pytest_preview_url, test_api_url):
-    preview_url = f'{remote_pytest_preview_url}/information/UGFnZVJldmlzaW9uTm9kZToyNjI4'
-
-    page_importer = PageImporter(preview_url, "placeholder_jwt_token")
-
-    assert page_importer.joplin_api_endpoint == test_api_url
-    assert page_importer.language == 'en'
-    assert page_importer.page_type == 'information'
-    assert page_importer.revision_id == 'UGFnZVJldmlzaW9uTm9kZToyNjI4'
-
-
-def test_parse_unregistered_preview_url():
-    preview_url = f'http://fake.base.url/en/preview/information/UGFnZVJldmlzaW9uTm9kZToyNjI4'
-
-    pytest.raises(ValidationError, PageImporter, preview_url, "placeholder_jwt_token")
-
-
-def test_parse_unregistered_preview_url_with_valid_CMS_API(test_api_url):
-    preview_url = f'http://fake.base.url/en/preview/information/UGFnZVJldmlzaW9uTm9kZToyNjI4?CMS_API={test_api_url}'
-
-    page_importer = PageImporter(preview_url, "placeholder_jwt_token")
-
-    assert page_importer.joplin_api_endpoint == test_api_url
-    assert page_importer.language == 'en'
-    assert page_importer.page_type == 'information'
-    assert page_importer.revision_id == 'UGFnZVJldmlzaW9uTm9kZToyNjI4'
-
-
-def test_parse_topic_page_dummy_data_janis_preview_url(remote_staging_preview_url, test_api_url):
-    preview_url = f'{remote_staging_preview_url}/topic/UGFnZVJldmlzaW9uTm9kZToxMg==?CMS_API={test_api_url}'
-
-    page_importer = PageImporter(preview_url, "placeholder_jwt_token")
-
-    assert page_importer.joplin_api_endpoint == test_api_url
-    assert page_importer.language == 'en'
-    assert page_importer.page_type == 'topic'
-    assert page_importer.revision_id == 'UGFnZVJldmlzaW9uTm9kZToxMg=='
-
-
-def test_parse_topic_collection_page_dummy_data_janis_preview_url(remote_staging_preview_url, test_api_url):
-    preview_url = f'{remote_staging_preview_url}/topiccollection/UGFnZVJldmlzaW9uTm9kZToxMw==?CMS_API={test_api_url}'
-
-    page_importer = PageImporter(preview_url, "placeholder_jwt_token")
-
-    assert page_importer.joplin_api_endpoint == test_api_url
-    assert page_importer.language == 'en'
-    assert page_importer.page_type == 'topiccollection'
-    assert page_importer.revision_id == 'UGFnZVJldmlzaW9uTm9kZToxMw=='
-
-
-def test_parse_information_page_dummy_data_janis_preview_url(remote_staging_preview_url, test_api_url):
-    preview_url = f'{remote_staging_preview_url}/information/UGFnZVJldmlzaW9uTm9kZToxMQ==?CMS_API={test_api_url}'
-
-    page_importer = PageImporter(preview_url, "placeholder_jwt_token")
-
-    assert page_importer.joplin_api_endpoint == test_api_url
-    assert page_importer.language == 'en'
-    assert page_importer.page_type == 'information'
-    assert page_importer.revision_id == 'UGFnZVJldmlzaW9uTm9kZToxMQ=='
-
-
-def test_parse_service_page_dummy_data_janis_preview_url(remote_staging_preview_url, test_api_url):
-    preview_url = f'{remote_staging_preview_url}/services/UGFnZVJldmlzaW9uTm9kZTozNDQ4?CMS_API={test_api_url}'
-
-    page_importer = PageImporter(preview_url, "placeholder_jwt_token")
-
-    assert page_importer.joplin_api_endpoint == test_api_url
-    assert page_importer.language == 'en'
-    assert page_importer.page_type == 'services'
-    assert page_importer.revision_id == 'UGFnZVJldmlzaW9uTm9kZTozNDQ4'
-
-
-def test_parse_location_page_dummy_data_janis_preview_url(remote_staging_preview_url, test_api_url):
-    preview_url = f'{remote_staging_preview_url}/location/UGFnZVJldmlzaW9uTm9kZToyMw==?CMS_API={test_api_url}'
-
-    page_importer = PageImporter(preview_url, "placeholder_jwt_token")
-
-    assert page_importer.joplin_api_endpoint == test_api_url
-    assert page_importer.language == 'en'
-    assert page_importer.page_type == 'location'
-    assert page_importer.revision_id == 'UGFnZVJldmlzaW9uTm9kZToyMw=='
-
-
-# this test will start breaking once we no longer have this revision in the db
-# todo: figure out a good way to mock api responses
-# https://docs.python.org/3/library/unittest.mock.html
-# @patch('module.ClassName2')
-def test_get_dummy_topic_collection_page_from_revision(remote_staging_preview_url, test_api_url, test_api_jwt_token):
-    preview_url = f'{remote_staging_preview_url}/topiccollection/UGFnZVJldmlzaW9uTm9kZToz?CMS_API={test_api_url}'
-
-    page_dictionaries = PageImporter(preview_url, test_api_jwt_token).fetch_page_data().page_dictionaries
-
-    assert page_dictionaries['en']['title'] == 'topic collection title [en]'
-    assert page_dictionaries['en']['slug'] == 'topic-collection-title-en'
-    assert page_dictionaries['en']['description'] == 'topic collection description [en]'
-
-    # adding themes as a part of our topic collection query
-    # instead of importing/testing them separately
-    assert page_dictionaries['en']['theme'] == {
-        'slug': 'theme-slug-en',
-        'text': 'theme text [en]',
-        'description': 'theme description [en]'
-    }
-
-# this test will start breaking once we no longer have this revision in the db
-# todo: figure out a good way to mock api responses
-# https://docs.python.org/3/library/unittest.mock.html
-# @patch('module.ClassName2')
-def test_get_dummy_topic_page_from_revision(remote_staging_preview_url, test_api_url, test_api_jwt_token):
-    preview_url = f'{remote_staging_preview_url}/topic/UGFnZVJldmlzaW9uTm9kZToxMg==?CMS_API={test_api_url}'
-
-    page_dictionaries = PageImporter(preview_url, test_api_jwt_token).fetch_page_data().page_dictionaries
-
-    assert page_dictionaries['en']['title'] == 'topic title [en]'
-    assert page_dictionaries['en']['slug'] == 'topic-title-en'
-    assert page_dictionaries['en']['description'] == 'topic description [en]'
-    assert page_dictionaries['en']['topiccollections'] == {
-        'edges': [{
-            'node': {
-                'topiccollection': {
-                    'title': 'topic collection title [en]',
-                    'slug': 'topic-collection-title-en',
-                    'description': 'topic collection description [en]',
-                    'theme': {
-                        'slug': 'theme-slug-en',
-                        'text': 'theme text [en]',
-                        'description': 'theme description [en]'
-                    },
-                    'live_revision': {
-                        'id': 'UGFnZVJldmlzaW9uTm9kZToz'
-                    },
-                    'live': True
-                }
-            }
-        }]
-    }
-
-
-# this test will start breaking once we no longer have this revision in the db
-# todo: figure out a good way to mock api responses
-# https://docs.python.org/3/library/unittest.mock.html
-# @patch('module.ClassName2')
-def test_get_dummy_information_page_from_revision(remote_staging_preview_url, test_api_url, test_api_jwt_token):
-    preview_url = f'{remote_staging_preview_url}/information/UGFnZVJldmlzaW9uTm9kZToxMQ==?CMS_API={test_api_url}'
-
-    page_dictionaries = PageImporter(preview_url, test_api_jwt_token).fetch_page_data().page_dictionaries
-
-    assert page_dictionaries['en']['title'] == 'information page title [en]'
-    assert page_dictionaries['en']['slug'] == 'information-page-title-en'
-    assert page_dictionaries['en']['description'] == 'information page description [en]'
-    assert page_dictionaries['en']['topics'] == {
-        'edges': [{
-            'node': {
-                'topic': {
-                    'title': 'topic title [en]',
-                    'slug': 'topic-title-en',
-                    'description': 'topic description [en]',
-                    'topiccollections': {
-                        'edges': [{
-                            'node': {
-                                'topiccollection': {
-                                    'title': 'topic collection title [en]',
-                                    'slug': 'topic-collection-title-en',
-                                    'description': 'topic collection description [en]',
-                                    'theme': {
-                                        'slug': 'theme-slug-en',
-                                        'text': 'theme text [en]',
-                                        'description': 'theme description [en]'
-                                    },
-                                    'live_revision': {
-                                        'id': 'UGFnZVJldmlzaW9uTm9kZToz'
-                                    },
-                                    'live': True
-                                }
-                            }
-                        }]
-                    },
-                    'live_revision': {
-                        'id': 'UGFnZVJldmlzaW9uTm9kZToxMg=='
-                    },
-                    'live': True
-                }
-            }
-        }]
-    }
-    assert page_dictionaries['en']['additional_content'] == '<p>information page additional content [en]</p>'
-    #     todo contacts
-    assert not page_dictionaries['en']['coa_global']
-
-
-def test_get_dummy_service_page_from_revision(remote_staging_preview_url, test_api_url, test_api_jwt_token):
-    preview_url = f'{remote_staging_preview_url}/services/UGFnZVJldmlzaW9uTm9kZToxNQ==?CMS_API={test_api_url}'
-
-    page_dictionaries = PageImporter(preview_url, test_api_jwt_token).fetch_page_data().page_dictionaries
-    assert page_dictionaries['en']['title'] == 'Get your bulk items collected'
-    assert page_dictionaries['en']['slug'] == 'bulk-item-pickup'
-    assert page_dictionaries['en']['short_description'] == 'Twice a year, Austin residential trash and recycling customers can place large items out on the curb to be picked up. These items include appliances, furniture, and carpet.'
-    assert page_dictionaries['en']['dynamic_content'] == []
-    assert page_dictionaries['en']['steps'] == [
-        {'id': '874eddc1-4103-4bef-9337-067c34aa4a59',
-         'type': 'basic_step',
-         'value': '<p>Use the this tool to see what bulk items can be picked '
-                  'up. Bulk items are items that are too large for your trash '
-                  'cart, such as appliances, furniture, and '
-                  'carpet.</p><p></p><p><code>APPBLOCK: What do I do '
-                  'with</code></p>'},
-        {'id': 'c0db1d12-a3a8-4aa7-af96-9ee14747d165',
-         'type': 'basic_step',
-         'value': '<p>Consider donating your items before placing them on the '
-                  'curb for pickup.</p>'},
-        {'id': '9d5f52ec-88f8-437f-af68-1c6abbcb52bc',
-         'type': 'basic_step',
-         'value': '<p>Look up your bulk pickup weeks. We only collect bulk '
-                  'items from Austin residential trash and recycling customers '
-                  'twice a year, and customers have different pickup '
-                  'weeks.</p><p></p><p><code>APPBLOCK: Collection '
-                  'Schedule</code></p>'},
-        {'id': '7a3740ce-2607-4956-bc8f-65f9b5f9271f',
-         'type': 'basic_step',
-         'value': '<p>Review the bulk item pickup do’s and don’ts below.</p>'},
-        {'id': 'bc0a0262-f3a9-47bb-964c-8563b16c6caa',
-         'type': 'basic_step',
-         'value': '<p>Place bulk items at the curb in front of your house by '
-                  '6:30 am on the first day of your scheduled collection '
-                  'week.</p>'},
-        {'id': 'e3d91181-2e7e-43f6-81d0-25b6773e8830',
-         'type': 'basic_step',
-         'value': '<p>Separate items into three '
-                  'piles:</p><ul><li>Metal—includes appliances, doors must be '
-                  'removed</li><li>Passenger car tires—limit of eight tires per '
-                  'household, rims must be removed, no truck or tractor '
-                  'tires</li><li>Non-metal items—includes carpeting and '
-                  'nail-free lumber</li></ul>'},
-        {'id': '1cc6fc4b-9bbf-4c72-9c19-bec11233e731',
-         'type': 'basic_step',
-         'value': '<p>The three separate piles are collected by different '
-                  'trucks and may be collected at different times throughout '
-                  'the week.</p>'}
-    ]
-    assert page_dictionaries['en']['topics'] == {'edges': []}
-    assert page_dictionaries['en']['additional_content'] == '<h2>Bulk item pickup do’s and don’ts</h2><p>Do not put bulk items in bags, boxes, or other containers. Bags will be treated as extra trash and are subject to extra trash fees.</p><p>Do not place any items under low hanging tree limbs or power lines.</p><p>Do not place items in an alley in any area in front of a vacant lot or in front of a business. Items will not be collected from these areas.</p><p>To prevent damage to your property, keep bulk items 5 feet away from your:</p><ul><li>Trash cart</li><li>Mailbox</li><li>Fences or walls</li><li>Water meter</li><li>Telephone connection box</li><li>Parked cars</li></ul>'
-    assert not page_dictionaries['en']['coa_global']
-
-
-def test_get_dummy_location_page_from_revision(remote_staging_preview_url, test_api_url, test_api_jwt_token):
-    preview_url = f'{remote_staging_preview_url}/location/UGFnZVJldmlzaW9uTm9kZToyNA==?CMS_API={test_api_url}'
-
-    page_dictionaries = PageImporter(preview_url, test_api_jwt_token).fetch_page_data().page_dictionaries
-    assert page_dictionaries['en']['title'] == 'Location name [en]'
-    assert page_dictionaries['en']['slug'] == 'location-name-en'
-    assert not page_dictionaries['en']['coa_global']
-    assert page_dictionaries['en']['physical_street'] == '123 Fake St.'
-    assert page_dictionaries['en']['physical_unit'] == ''
-    assert page_dictionaries['en']['physical_city'] == 'Austin'
-    assert page_dictionaries['en']['physical_state'] == 'TX'
-    assert page_dictionaries['en']['physical_zip'] == '78745'
-    assert page_dictionaries['en']['mailing_street'] == '456 Fake mailing address'
-    assert page_dictionaries['en']['mailing_city'] == 'Austin'
-    assert page_dictionaries['en']['mailing_state'] == 'TX'
-    assert page_dictionaries['en']['mailing_zip'] == '78745'
-    assert page_dictionaries['en']['phone_number'] == '+15128675309'
-    assert page_dictionaries['en']['phone_description'] == 'Jenny'
-    assert page_dictionaries['en']['email'] == 'tommy@tut.one'
-    assert page_dictionaries['en']['nearest_bus_1'] == 1
-    assert page_dictionaries['en']['nearest_bus_2'] == 2
-    assert page_dictionaries['en']['nearest_bus_3'] == 3
-    assert page_dictionaries['en']['physical_location_photo'] is None
-    assert page_dictionaries['en']['related_services'] == {'edges': [{'node': {
-        'related_service': {'title': 'Service page with contact'}, 'hours_same_as_location': False,
-        'monday_start_time': '12:00:00', 'monday_end_time': '17:00:00', 'monday_start_time_2': None,
-        'monday_end_time_2': None, 'tuesday_start_time': '12:00:00', 'tuesday_end_time': '17:00:00',
-        'tuesday_start_time_2': None, 'tuesday_end_time_2': None, 'wednesday_start_time': '12:00:00',
-        'wednesday_end_time': '17:00:00', 'wednesday_start_time_2': None,
-        'wednesday_end_time_2': None, 'thursday_start_time': '12:00:00',
-        'thursday_end_time': '17:00:00', 'thursday_start_time_2': None, 'thursday_end_time_2': None,
-        'friday_start_time': '12:00:00', 'friday_end_time': '17:00:00', 'friday_start_time_2': None,
-        'friday_end_time_2': None, 'saturday_start_time': None, 'saturday_end_time': None,
-        'saturday_start_time_2': None, 'saturday_end_time_2': None, 'sunday_start_time': None,
-        'sunday_end_time': None, 'sunday_start_time_2': None, 'sunday_end_time_2': None,
-        'hours_exceptions': ''}}]}
-    assert page_dictionaries['en']['monday_start_time'] == '00:00:00'
-    assert page_dictionaries['en']['monday_end_time'] == '01:00:00'
-    assert page_dictionaries['en']['monday_start_time_2'] == '02:00:00'
-    assert page_dictionaries['en']['monday_end_time_2'] == '03:00:00'
-    assert page_dictionaries['en']['tuesday_start_time'] == '04:00:00'
-    assert page_dictionaries['en']['tuesday_end_time'] == '05:00:00'
-    assert page_dictionaries['en']['tuesday_start_time_2'] == '06:00:00'
-    assert page_dictionaries['en']['tuesday_end_time_2'] == '07:00:00'
-    assert page_dictionaries['en']['wednesday_start_time'] == '08:00:00'
-    assert page_dictionaries['en']['wednesday_end_time'] == '09:00:00'
-    assert page_dictionaries['en']['wednesday_start_time_2'] == '10:00:00'
-    assert page_dictionaries['en']['wednesday_end_time_2'] == '11:00:00'
-    assert page_dictionaries['en']['thursday_start_time'] == '12:00:00'
-    assert page_dictionaries['en']['thursday_end_time'] == '13:00:00'
-    assert page_dictionaries['en']['thursday_start_time_2'] == '14:00:00'
-    assert page_dictionaries['en']['thursday_end_time_2'] == '15:00:00'
-    assert page_dictionaries['en']['friday_start_time'] == '16:00:00'
-    assert page_dictionaries['en']['friday_end_time'] == '17:00:00'
-    assert page_dictionaries['en']['friday_start_time_2'] == '18:00:00'
-    assert page_dictionaries['en']['friday_end_time_2'] == '19:00:00'
-    assert page_dictionaries['en']['saturday_start_time'] == '20:00:00'
-    assert page_dictionaries['en']['saturday_end_time'] == '21:00:00'
-    assert page_dictionaries['en']['saturday_start_time_2'] == '22:00:00'
-    assert page_dictionaries['en']['saturday_end_time_2'] == '23:00:00'
-    assert page_dictionaries['en']['sunday_start_time'] is None
-    assert page_dictionaries['en']['sunday_end_time'] is None
-    assert page_dictionaries['en']['sunday_start_time_2'] is None
-    assert page_dictionaries['en']['sunday_end_time_2'] is None
-    assert page_dictionaries['en']['hours_exceptions'] == 'exceptions to hours'
-
-    assert page_dictionaries['en']['slug'] == 'location-name-en'
-    assert not page_dictionaries['en']['coa_global']
-
-
-def test_get_dummy_service_page_with_contact_from_revision(remote_staging_preview_url, test_api_url, test_api_jwt_token):
-    preview_url = f'{remote_staging_preview_url}/services/UGFnZVJldmlzaW9uTm9kZToyMA==?CMS_API={test_api_url}'
-
-    page_dictionaries = PageImporter(preview_url, test_api_jwt_token).fetch_page_data().page_dictionaries
-    assert page_dictionaries['en']['title'] == 'Service page with contact'
-    assert page_dictionaries['en']['slug'] == 'service-page-with-contact'
-    assert page_dictionaries['en']['contacts'] == {'edges': [{'node': {'contact':
-        {'name': 'Contact name',
-         'phone_number': {'edges': []},
-         'email': '',
-         'social_media': [],
-         'location_page': {'slug': 'location-name-en'}}}}]}
-
-
-def test_get_dummy_information_page_with_contact_from_revision(remote_staging_preview_url, test_api_url, test_api_jwt_token):
-    preview_url = f'{remote_staging_preview_url}/information/UGFnZVJldmlzaW9uTm9kZToyMg==?CMS_API={test_api_url}'
-
-    page_dictionaries = PageImporter(preview_url, test_api_jwt_token).fetch_page_data().page_dictionaries
-    assert page_dictionaries['en']['title'] == 'Information page with contact'
-    assert page_dictionaries['en']['slug'] == 'information-page-with-contact'
-    assert page_dictionaries['en']['contacts'] == {'edges': [{'node': {'contact':
-        {'name': 'Contact name',
-         'phone_number': {'edges': []},
-         'email': '',
-         'social_media': [],
-         'location_page': {'slug': 'location-name-en'}}}}]}
+# import pytest
+# from importer.page_importer import PageImporter
+# from django.core.exceptions import ValidationError
+#
+#
+# def test_parse_janis_preview_url(remote_pytest_preview_url, test_api_url):
+#     preview_url = f'{remote_pytest_preview_url}/information/UGFnZVJldmlzaW9uTm9kZToyNjI4'
+#
+#     page_importer = PageImporter(preview_url, "placeholder_jwt_token")
+#
+#     assert page_importer.joplin_api_endpoint == test_api_url
+#     assert page_importer.language == 'en'
+#     assert page_importer.page_type == 'information'
+#     assert page_importer.revision_id == 'UGFnZVJldmlzaW9uTm9kZToyNjI4'
+#
+#
+# def test_parse_unregistered_preview_url():
+#     preview_url = f'http://fake.base.url/en/preview/information/UGFnZVJldmlzaW9uTm9kZToyNjI4'
+#
+#     pytest.raises(ValidationError, PageImporter, preview_url, "placeholder_jwt_token")
+#
+#
+# def test_parse_unregistered_preview_url_with_valid_CMS_API(test_api_url):
+#     preview_url = f'http://fake.base.url/en/preview/information/UGFnZVJldmlzaW9uTm9kZToyNjI4?CMS_API={test_api_url}'
+#
+#     page_importer = PageImporter(preview_url, "placeholder_jwt_token")
+#
+#     assert page_importer.joplin_api_endpoint == test_api_url
+#     assert page_importer.language == 'en'
+#     assert page_importer.page_type == 'information'
+#     assert page_importer.revision_id == 'UGFnZVJldmlzaW9uTm9kZToyNjI4'
+#
+#
+# def test_parse_topic_page_dummy_data_janis_preview_url(remote_staging_preview_url, test_api_url):
+#     preview_url = f'{remote_staging_preview_url}/topic/UGFnZVJldmlzaW9uTm9kZToxMg==?CMS_API={test_api_url}'
+#
+#     page_importer = PageImporter(preview_url, "placeholder_jwt_token")
+#
+#     assert page_importer.joplin_api_endpoint == test_api_url
+#     assert page_importer.language == 'en'
+#     assert page_importer.page_type == 'topic'
+#     assert page_importer.revision_id == 'UGFnZVJldmlzaW9uTm9kZToxMg=='
+#
+#
+# def test_parse_topic_collection_page_dummy_data_janis_preview_url(remote_staging_preview_url, test_api_url):
+#     preview_url = f'{remote_staging_preview_url}/topiccollection/UGFnZVJldmlzaW9uTm9kZToxMw==?CMS_API={test_api_url}'
+#
+#     page_importer = PageImporter(preview_url, "placeholder_jwt_token")
+#
+#     assert page_importer.joplin_api_endpoint == test_api_url
+#     assert page_importer.language == 'en'
+#     assert page_importer.page_type == 'topiccollection'
+#     assert page_importer.revision_id == 'UGFnZVJldmlzaW9uTm9kZToxMw=='
+#
+#
+# def test_parse_information_page_dummy_data_janis_preview_url(remote_staging_preview_url, test_api_url):
+#     preview_url = f'{remote_staging_preview_url}/information/UGFnZVJldmlzaW9uTm9kZToxMQ==?CMS_API={test_api_url}'
+#
+#     page_importer = PageImporter(preview_url, "placeholder_jwt_token")
+#
+#     assert page_importer.joplin_api_endpoint == test_api_url
+#     assert page_importer.language == 'en'
+#     assert page_importer.page_type == 'information'
+#     assert page_importer.revision_id == 'UGFnZVJldmlzaW9uTm9kZToxMQ=='
+#
+#
+# def test_parse_service_page_dummy_data_janis_preview_url(remote_staging_preview_url, test_api_url):
+#     preview_url = f'{remote_staging_preview_url}/services/UGFnZVJldmlzaW9uTm9kZTozNDQ4?CMS_API={test_api_url}'
+#
+#     page_importer = PageImporter(preview_url, "placeholder_jwt_token")
+#
+#     assert page_importer.joplin_api_endpoint == test_api_url
+#     assert page_importer.language == 'en'
+#     assert page_importer.page_type == 'services'
+#     assert page_importer.revision_id == 'UGFnZVJldmlzaW9uTm9kZTozNDQ4'
+#
+#
+# def test_parse_location_page_dummy_data_janis_preview_url(remote_staging_preview_url, test_api_url):
+#     preview_url = f'{remote_staging_preview_url}/location/UGFnZVJldmlzaW9uTm9kZToyMw==?CMS_API={test_api_url}'
+#
+#     page_importer = PageImporter(preview_url, "placeholder_jwt_token")
+#
+#     assert page_importer.joplin_api_endpoint == test_api_url
+#     assert page_importer.language == 'en'
+#     assert page_importer.page_type == 'location'
+#     assert page_importer.revision_id == 'UGFnZVJldmlzaW9uTm9kZToyMw=='
+#
+#
+# # this test will start breaking once we no longer have this revision in the db
+# # todo: figure out a good way to mock api responses
+# # https://docs.python.org/3/library/unittest.mock.html
+# # @patch('module.ClassName2')
+# def test_get_dummy_topic_collection_page_from_revision(remote_staging_preview_url, test_api_url, test_api_jwt_token):
+#     preview_url = f'{remote_staging_preview_url}/topiccollection/UGFnZVJldmlzaW9uTm9kZToz?CMS_API={test_api_url}'
+#
+#     page_dictionaries = PageImporter(preview_url, test_api_jwt_token).fetch_page_data().page_dictionaries
+#
+#     assert page_dictionaries['en']['title'] == 'topic collection title [en]'
+#     assert page_dictionaries['en']['slug'] == 'topic-collection-title-en'
+#     assert page_dictionaries['en']['description'] == 'topic collection description [en]'
+#
+#     # adding themes as a part of our topic collection query
+#     # instead of importing/testing them separately
+#     assert page_dictionaries['en']['theme'] == {
+#         'slug': 'theme-slug-en',
+#         'text': 'theme text [en]',
+#         'description': 'theme description [en]'
+#     }
+#
+# # this test will start breaking once we no longer have this revision in the db
+# # todo: figure out a good way to mock api responses
+# # https://docs.python.org/3/library/unittest.mock.html
+# # @patch('module.ClassName2')
+# def test_get_dummy_topic_page_from_revision(remote_staging_preview_url, test_api_url, test_api_jwt_token):
+#     preview_url = f'{remote_staging_preview_url}/topic/UGFnZVJldmlzaW9uTm9kZToxMg==?CMS_API={test_api_url}'
+#
+#     page_dictionaries = PageImporter(preview_url, test_api_jwt_token).fetch_page_data().page_dictionaries
+#
+#     assert page_dictionaries['en']['title'] == 'topic title [en]'
+#     assert page_dictionaries['en']['slug'] == 'topic-title-en'
+#     assert page_dictionaries['en']['description'] == 'topic description [en]'
+#     assert page_dictionaries['en']['topiccollections'] == {
+#         'edges': [{
+#             'node': {
+#                 'topiccollection': {
+#                     'title': 'topic collection title [en]',
+#                     'slug': 'topic-collection-title-en',
+#                     'description': 'topic collection description [en]',
+#                     'theme': {
+#                         'slug': 'theme-slug-en',
+#                         'text': 'theme text [en]',
+#                         'description': 'theme description [en]'
+#                     },
+#                     'live_revision': {
+#                         'id': 'UGFnZVJldmlzaW9uTm9kZToz'
+#                     },
+#                     'live': True
+#                 }
+#             }
+#         }]
+#     }
+#
+#
+# # this test will start breaking once we no longer have this revision in the db
+# # todo: figure out a good way to mock api responses
+# # https://docs.python.org/3/library/unittest.mock.html
+# # @patch('module.ClassName2')
+# def test_get_dummy_information_page_from_revision(remote_staging_preview_url, test_api_url, test_api_jwt_token):
+#     preview_url = f'{remote_staging_preview_url}/information/UGFnZVJldmlzaW9uTm9kZToxMQ==?CMS_API={test_api_url}'
+#
+#     page_dictionaries = PageImporter(preview_url, test_api_jwt_token).fetch_page_data().page_dictionaries
+#
+#     assert page_dictionaries['en']['title'] == 'information page title [en]'
+#     assert page_dictionaries['en']['slug'] == 'information-page-title-en'
+#     assert page_dictionaries['en']['description'] == 'information page description [en]'
+#     assert page_dictionaries['en']['topics'] == {
+#         'edges': [{
+#             'node': {
+#                 'topic': {
+#                     'title': 'topic title [en]',
+#                     'slug': 'topic-title-en',
+#                     'description': 'topic description [en]',
+#                     'topiccollections': {
+#                         'edges': [{
+#                             'node': {
+#                                 'topiccollection': {
+#                                     'title': 'topic collection title [en]',
+#                                     'slug': 'topic-collection-title-en',
+#                                     'description': 'topic collection description [en]',
+#                                     'theme': {
+#                                         'slug': 'theme-slug-en',
+#                                         'text': 'theme text [en]',
+#                                         'description': 'theme description [en]'
+#                                     },
+#                                     'live_revision': {
+#                                         'id': 'UGFnZVJldmlzaW9uTm9kZToz'
+#                                     },
+#                                     'live': True
+#                                 }
+#                             }
+#                         }]
+#                     },
+#                     'live_revision': {
+#                         'id': 'UGFnZVJldmlzaW9uTm9kZToxMg=='
+#                     },
+#                     'live': True
+#                 }
+#             }
+#         }]
+#     }
+#     assert page_dictionaries['en']['additional_content'] == '<p>information page additional content [en]</p>'
+#     #     todo contacts
+#     assert not page_dictionaries['en']['coa_global']
+#
+#
+# def test_get_dummy_service_page_from_revision(remote_staging_preview_url, test_api_url, test_api_jwt_token):
+#     preview_url = f'{remote_staging_preview_url}/services/UGFnZVJldmlzaW9uTm9kZToxNQ==?CMS_API={test_api_url}'
+#
+#     page_dictionaries = PageImporter(preview_url, test_api_jwt_token).fetch_page_data().page_dictionaries
+#     assert page_dictionaries['en']['title'] == 'Get your bulk items collected'
+#     assert page_dictionaries['en']['slug'] == 'bulk-item-pickup'
+#     assert page_dictionaries['en']['short_description'] == 'Twice a year, Austin residential trash and recycling customers can place large items out on the curb to be picked up. These items include appliances, furniture, and carpet.'
+#     assert page_dictionaries['en']['dynamic_content'] == []
+#     assert page_dictionaries['en']['steps'] == [
+#         {'id': '874eddc1-4103-4bef-9337-067c34aa4a59',
+#          'type': 'basic_step',
+#          'value': '<p>Use the this tool to see what bulk items can be picked '
+#                   'up. Bulk items are items that are too large for your trash '
+#                   'cart, such as appliances, furniture, and '
+#                   'carpet.</p><p></p><p><code>APPBLOCK: What do I do '
+#                   'with</code></p>'},
+#         {'id': 'c0db1d12-a3a8-4aa7-af96-9ee14747d165',
+#          'type': 'basic_step',
+#          'value': '<p>Consider donating your items before placing them on the '
+#                   'curb for pickup.</p>'},
+#         {'id': '9d5f52ec-88f8-437f-af68-1c6abbcb52bc',
+#          'type': 'basic_step',
+#          'value': '<p>Look up your bulk pickup weeks. We only collect bulk '
+#                   'items from Austin residential trash and recycling customers '
+#                   'twice a year, and customers have different pickup '
+#                   'weeks.</p><p></p><p><code>APPBLOCK: Collection '
+#                   'Schedule</code></p>'},
+#         {'id': '7a3740ce-2607-4956-bc8f-65f9b5f9271f',
+#          'type': 'basic_step',
+#          'value': '<p>Review the bulk item pickup do’s and don’ts below.</p>'},
+#         {'id': 'bc0a0262-f3a9-47bb-964c-8563b16c6caa',
+#          'type': 'basic_step',
+#          'value': '<p>Place bulk items at the curb in front of your house by '
+#                   '6:30 am on the first day of your scheduled collection '
+#                   'week.</p>'},
+#         {'id': 'e3d91181-2e7e-43f6-81d0-25b6773e8830',
+#          'type': 'basic_step',
+#          'value': '<p>Separate items into three '
+#                   'piles:</p><ul><li>Metal—includes appliances, doors must be '
+#                   'removed</li><li>Passenger car tires—limit of eight tires per '
+#                   'household, rims must be removed, no truck or tractor '
+#                   'tires</li><li>Non-metal items—includes carpeting and '
+#                   'nail-free lumber</li></ul>'},
+#         {'id': '1cc6fc4b-9bbf-4c72-9c19-bec11233e731',
+#          'type': 'basic_step',
+#          'value': '<p>The three separate piles are collected by different '
+#                   'trucks and may be collected at different times throughout '
+#                   'the week.</p>'}
+#     ]
+#     assert page_dictionaries['en']['topics'] == {'edges': []}
+#     assert page_dictionaries['en']['additional_content'] == '<h2>Bulk item pickup do’s and don’ts</h2><p>Do not put bulk items in bags, boxes, or other containers. Bags will be treated as extra trash and are subject to extra trash fees.</p><p>Do not place any items under low hanging tree limbs or power lines.</p><p>Do not place items in an alley in any area in front of a vacant lot or in front of a business. Items will not be collected from these areas.</p><p>To prevent damage to your property, keep bulk items 5 feet away from your:</p><ul><li>Trash cart</li><li>Mailbox</li><li>Fences or walls</li><li>Water meter</li><li>Telephone connection box</li><li>Parked cars</li></ul>'
+#     assert not page_dictionaries['en']['coa_global']
+#
+#
+# def test_get_dummy_location_page_from_revision(remote_staging_preview_url, test_api_url, test_api_jwt_token):
+#     preview_url = f'{remote_staging_preview_url}/location/UGFnZVJldmlzaW9uTm9kZToyNA==?CMS_API={test_api_url}'
+#
+#     page_dictionaries = PageImporter(preview_url, test_api_jwt_token).fetch_page_data().page_dictionaries
+#     assert page_dictionaries['en']['title'] == 'Location name [en]'
+#     assert page_dictionaries['en']['slug'] == 'location-name-en'
+#     assert not page_dictionaries['en']['coa_global']
+#     assert page_dictionaries['en']['physical_street'] == '123 Fake St.'
+#     assert page_dictionaries['en']['physical_unit'] == ''
+#     assert page_dictionaries['en']['physical_city'] == 'Austin'
+#     assert page_dictionaries['en']['physical_state'] == 'TX'
+#     assert page_dictionaries['en']['physical_zip'] == '78745'
+#     assert page_dictionaries['en']['mailing_street'] == '456 Fake mailing address'
+#     assert page_dictionaries['en']['mailing_city'] == 'Austin'
+#     assert page_dictionaries['en']['mailing_state'] == 'TX'
+#     assert page_dictionaries['en']['mailing_zip'] == '78745'
+#     assert page_dictionaries['en']['phone_number'] == '+15128675309'
+#     assert page_dictionaries['en']['phone_description'] == 'Jenny'
+#     assert page_dictionaries['en']['email'] == 'tommy@tut.one'
+#     assert page_dictionaries['en']['nearest_bus_1'] == 1
+#     assert page_dictionaries['en']['nearest_bus_2'] == 2
+#     assert page_dictionaries['en']['nearest_bus_3'] == 3
+#     assert page_dictionaries['en']['physical_location_photo'] is None
+#     assert page_dictionaries['en']['related_services'] == {'edges': [{'node': {
+#         'related_service': {'title': 'Service page with contact'}, 'hours_same_as_location': False,
+#         'monday_start_time': '12:00:00', 'monday_end_time': '17:00:00', 'monday_start_time_2': None,
+#         'monday_end_time_2': None, 'tuesday_start_time': '12:00:00', 'tuesday_end_time': '17:00:00',
+#         'tuesday_start_time_2': None, 'tuesday_end_time_2': None, 'wednesday_start_time': '12:00:00',
+#         'wednesday_end_time': '17:00:00', 'wednesday_start_time_2': None,
+#         'wednesday_end_time_2': None, 'thursday_start_time': '12:00:00',
+#         'thursday_end_time': '17:00:00', 'thursday_start_time_2': None, 'thursday_end_time_2': None,
+#         'friday_start_time': '12:00:00', 'friday_end_time': '17:00:00', 'friday_start_time_2': None,
+#         'friday_end_time_2': None, 'saturday_start_time': None, 'saturday_end_time': None,
+#         'saturday_start_time_2': None, 'saturday_end_time_2': None, 'sunday_start_time': None,
+#         'sunday_end_time': None, 'sunday_start_time_2': None, 'sunday_end_time_2': None,
+#         'hours_exceptions': ''}}]}
+#     assert page_dictionaries['en']['monday_start_time'] == '00:00:00'
+#     assert page_dictionaries['en']['monday_end_time'] == '01:00:00'
+#     assert page_dictionaries['en']['monday_start_time_2'] == '02:00:00'
+#     assert page_dictionaries['en']['monday_end_time_2'] == '03:00:00'
+#     assert page_dictionaries['en']['tuesday_start_time'] == '04:00:00'
+#     assert page_dictionaries['en']['tuesday_end_time'] == '05:00:00'
+#     assert page_dictionaries['en']['tuesday_start_time_2'] == '06:00:00'
+#     assert page_dictionaries['en']['tuesday_end_time_2'] == '07:00:00'
+#     assert page_dictionaries['en']['wednesday_start_time'] == '08:00:00'
+#     assert page_dictionaries['en']['wednesday_end_time'] == '09:00:00'
+#     assert page_dictionaries['en']['wednesday_start_time_2'] == '10:00:00'
+#     assert page_dictionaries['en']['wednesday_end_time_2'] == '11:00:00'
+#     assert page_dictionaries['en']['thursday_start_time'] == '12:00:00'
+#     assert page_dictionaries['en']['thursday_end_time'] == '13:00:00'
+#     assert page_dictionaries['en']['thursday_start_time_2'] == '14:00:00'
+#     assert page_dictionaries['en']['thursday_end_time_2'] == '15:00:00'
+#     assert page_dictionaries['en']['friday_start_time'] == '16:00:00'
+#     assert page_dictionaries['en']['friday_end_time'] == '17:00:00'
+#     assert page_dictionaries['en']['friday_start_time_2'] == '18:00:00'
+#     assert page_dictionaries['en']['friday_end_time_2'] == '19:00:00'
+#     assert page_dictionaries['en']['saturday_start_time'] == '20:00:00'
+#     assert page_dictionaries['en']['saturday_end_time'] == '21:00:00'
+#     assert page_dictionaries['en']['saturday_start_time_2'] == '22:00:00'
+#     assert page_dictionaries['en']['saturday_end_time_2'] == '23:00:00'
+#     assert page_dictionaries['en']['sunday_start_time'] is None
+#     assert page_dictionaries['en']['sunday_end_time'] is None
+#     assert page_dictionaries['en']['sunday_start_time_2'] is None
+#     assert page_dictionaries['en']['sunday_end_time_2'] is None
+#     assert page_dictionaries['en']['hours_exceptions'] == 'exceptions to hours'
+#
+#     assert page_dictionaries['en']['slug'] == 'location-name-en'
+#     assert not page_dictionaries['en']['coa_global']
+#
+#
+# def test_get_dummy_service_page_with_contact_from_revision(remote_staging_preview_url, test_api_url, test_api_jwt_token):
+#     preview_url = f'{remote_staging_preview_url}/services/UGFnZVJldmlzaW9uTm9kZToyMA==?CMS_API={test_api_url}'
+#
+#     page_dictionaries = PageImporter(preview_url, test_api_jwt_token).fetch_page_data().page_dictionaries
+#     assert page_dictionaries['en']['title'] == 'Service page with contact'
+#     assert page_dictionaries['en']['slug'] == 'service-page-with-contact'
+#     assert page_dictionaries['en']['contacts'] == {'edges': [{'node': {'contact':
+#         {'name': 'Contact name',
+#          'phone_number': {'edges': []},
+#          'email': '',
+#          'social_media': [],
+#          'location_page': {'slug': 'location-name-en'}}}}]}
+#
+#
+# def test_get_dummy_information_page_with_contact_from_revision(remote_staging_preview_url, test_api_url, test_api_jwt_token):
+#     preview_url = f'{remote_staging_preview_url}/information/UGFnZVJldmlzaW9uTm9kZToyMg==?CMS_API={test_api_url}'
+#
+#     page_dictionaries = PageImporter(preview_url, test_api_jwt_token).fetch_page_data().page_dictionaries
+#     assert page_dictionaries['en']['title'] == 'Information page with contact'
+#     assert page_dictionaries['en']['slug'] == 'information-page-with-contact'
+#     assert page_dictionaries['en']['contacts'] == {'edges': [{'node': {'contact':
+#         {'name': 'Contact name',
+#          'phone_number': {'edges': []},
+#          'email': '',
+#          'social_media': [],
+#          'location_page': {'slug': 'location-name-en'}}}}]}

--- a/joplin/pages/department_page/tests.py
+++ b/joplin/pages/department_page/tests.py
@@ -30,7 +30,8 @@ def test_department_page_with_department_group(home_page, expected_publish_url_b
     assert janis_publish_url == f'{expected_publish_url_base}/{page.slug}/'
 
 
-@pytest.mark.django_db
+@pytest.mark.skip("importer test")
+# @pytest.mark.django_db
 def test_create_department_page_from_api(remote_staging_preview_url, test_api_url, test_api_jwt_token):
     url = f'{remote_staging_preview_url}/department/UGFnZVJldmlzaW9uTm9kZToyNg==?CMS_API={test_api_url}'
     page = PageImporter(url, test_api_jwt_token).fetch_page_data().create_page()

--- a/joplin/pages/event_page/tests.py
+++ b/joplin/pages/event_page/tests.py
@@ -68,7 +68,8 @@ def test_create_event_page_with_city_location():
     assert page.location_blocks.stream_data == expected_location_blocks
 
 
-@pytest.mark.django_db
+# @pytest.mark.django_db
+@pytest.mark.skip("importer test")
 def test_import_event_page_with_city_location(remote_staging_preview_url, test_api_url, test_api_jwt_token):
     url = f'{remote_staging_preview_url}/event/UGFnZVJldmlzaW9uTm9kZTo0NA==?CMS_API={test_api_url}'
     page = PageImporter(url, test_api_jwt_token).fetch_page_data().create_page()
@@ -88,7 +89,8 @@ def test_create_event_page_with_remote_location():
     assert page.location_blocks.stream_data == expected_location_blocks
 
 
-@pytest.mark.django_db
+# @pytest.mark.django_db
+@pytest.mark.skip("importer test")
 def test_import_event_page_with_remote_location(remote_staging_preview_url, test_api_url, test_api_jwt_token):
     url = f'{remote_staging_preview_url}/event/UGFnZVJldmlzaW9uTm9kZTo0Ng==?CMS_API={test_api_url}'
     page = PageImporter(url, test_api_jwt_token).fetch_page_data().create_page()
@@ -129,7 +131,8 @@ def test_create_event_page_with_fees():
         assert actual_fee.fee == Decimal(expected_fee['fee'])
 
 
-@pytest.mark.django_db
+# @pytest.mark.django_db
+@pytest.mark.skip("importer test")
 def test_import_event_page_with_fees(remote_staging_preview_url, test_api_url, test_api_jwt_token):
     url = f'{remote_staging_preview_url}/event/UGFnZVJldmlzaW9uTm9kZTo3Nw==?CMS_API={test_api_url}'
     page = PageImporter(url, test_api_jwt_token).fetch_page_data().create_page()

--- a/joplin/pages/form_container/tests.py
+++ b/joplin/pages/form_container/tests.py
@@ -3,7 +3,8 @@ from importer.page_importer import PageImporter
 from pages.form_container.models import FormContainer
 
 
-@pytest.mark.django_db
+# @pytest.mark.django_db
+@pytest.mark.skip("importer test")
 def test_create_form_container_from_api(remote_staging_preview_url, test_api_url, test_api_jwt_token):
     url = f'{remote_staging_preview_url}/form/UGFnZVJldmlzaW9uTm9kZToyOQ==?CMS_API={test_api_url}'
     page = PageImporter(url, test_api_jwt_token).fetch_page_data().create_page()

--- a/joplin/pages/information_page/tests.py
+++ b/joplin/pages/information_page/tests.py
@@ -118,7 +118,8 @@ def test_import_from_page_dictionary_twice():
 # when importing the same page twice, with a different revision id
 # we should just return the id of the previously imported page
 # todo: decide if this is how we want this to work
-@pytest.mark.django_db
+# @pytest.mark.django_db
+@pytest.mark.skip("importer test")
 def test_import_from_page_dictionary_twice_different_revisions():
     first_revision_id = 'first_revision_id'
     second_revision_id = 'second_revision_id'
@@ -136,7 +137,8 @@ def test_import_from_page_dictionary_twice_different_revisions():
 
 # when importing a page with an existing topic,
 # we should use the existing topic for the page
-@pytest.mark.django_db
+# @pytest.mark.django_db
+@pytest.mark.skip("importer test")
 def test_import_from_page_dictionary_existing_topic():
     revision_id = 'UGFnZVJldmlzaW9uTm9kZToxMQ=='
     topic_page_revision_id = page_dictionaries()['en']['topics']['edges'][0]['node']['topic']['live_revision']['id']
@@ -154,7 +156,8 @@ def test_import_from_page_dictionary_existing_topic():
     assert topics_on_page == topic_pages
 
 
-@pytest.mark.django_db
+@pytest.mark.skip("importer test")
+#@pytest.mark.django_db
 def test_create_information_page_with_contact_from_api(remote_staging_preview_url, test_api_url, test_api_jwt_token):
     url = f'{remote_staging_preview_url}/information/UGFnZVJldmlzaW9uTm9kZToyMg==?CMS_API={test_api_url}'
     page = PageImporter(url, test_api_jwt_token).fetch_page_data().create_page()
@@ -163,7 +166,8 @@ def test_create_information_page_with_contact_from_api(remote_staging_preview_ur
     assert page.contact.name == 'Contact name'
 
 
-@pytest.mark.django_db
+# @pytest.mark.django_db
+@pytest.mark.skip("importer test")
 def test_get_live_page_from_api(remote_staging_preview_url, test_api_url, test_api_jwt_token):
     url = f'{remote_staging_preview_url}/information/UGFnZVJldmlzaW9uTm9kZTo0Mg==?CMS_API={test_api_url}'
     page = PageImporter(url, test_api_jwt_token).fetch_page_data().create_page()
@@ -173,7 +177,8 @@ def test_get_live_page_from_api(remote_staging_preview_url, test_api_url, test_a
     assert page.live
 
 
-@pytest.mark.django_db
+# @pytest.mark.django_db
+@pytest.mark.skip("importer test")
 def test_get_draft_page_from_api(remote_staging_preview_url, test_api_url, test_api_jwt_token):
     url = f'{remote_staging_preview_url}/information/UGFnZVJldmlzaW9uTm9kZTo0MA==?CMS_API={test_api_url}'
     page = PageImporter(url, test_api_jwt_token).fetch_page_data().create_page()

--- a/joplin/pages/information_page/tests.py
+++ b/joplin/pages/information_page/tests.py
@@ -10,6 +10,7 @@ from importer.create_from_importer import create_page_from_importer
 create_topic_page_from_importer_dictionaries = lambda page_dictionaries, revision_id=None: create_page_from_importer('topics', page_dictionaries, revision_id)
 create_information_page_from_importer_dictionaries = lambda page_dictionaries, revision_id=None: create_page_from_importer('information', page_dictionaries, revision_id)
 
+
 def page_dictionaries():
     return decamelize({
         'en': {
@@ -98,7 +99,8 @@ def page_dictionaries():
 
 # when importing the same page twice, we should just
 # return the id of the previously imported page
-@pytest.mark.django_db
+# @pytest.mark.django_db
+@pytest.mark.skip("importer test")
 def test_import_from_page_dictionary_twice():
     revision_id = 'UGFnZVJldmlzaW9uTm9kZToxMQ=='
 

--- a/joplin/pages/location_page/tests.py
+++ b/joplin/pages/location_page/tests.py
@@ -6,7 +6,8 @@ import pages.location_page.fixtures as fixtures
 from pages.location_page.factories import LocationPageFactory
 
 
-@pytest.mark.django_db
+# @pytest.mark.django_db
+@pytest.mark.skip("importer test")
 def test_create_location_page_from_api(remote_staging_preview_url, test_api_url, test_api_jwt_token):
     url = f'{remote_staging_preview_url}/location/UGFnZVJldmlzaW9uTm9kZToyNA==?CMS_API={test_api_url}'
     page = PageImporter(url, test_api_jwt_token).fetch_page_data().create_page()

--- a/joplin/pages/service_page/tests.py
+++ b/joplin/pages/service_page/tests.py
@@ -8,14 +8,16 @@ import pages.location_page.fixtures as location_page_fixtures
 import pages.topic_page.fixtures as topic_page_fixtures
 
 
-@pytest.mark.django_db
+# @pytest.mark.django_db
+@pytest.mark.skip("importer test")
 def test_create_service_page_from_api(remote_staging_preview_url, test_api_url, test_api_jwt_token):
     url = f'{remote_staging_preview_url}/services/UGFnZVJldmlzaW9uTm9kZToxNQ==?CMS_API={test_api_url}'
     page = PageImporter(url, test_api_jwt_token).fetch_page_data().create_page()
     assert isinstance(page, ServicePage)
 
 
-@pytest.mark.django_db
+# @pytest.mark.django_db
+@pytest.mark.skip("importer test")
 def test_create_service_page_with_contact_from_api(remote_staging_preview_url, test_api_url, test_api_jwt_token):
     url = f'{remote_staging_preview_url}/services/UGFnZVJldmlzaW9uTm9kZToyMA==?CMS_API={test_api_url}'
     page = PageImporter(url, test_api_jwt_token).fetch_page_data().create_page()
@@ -24,7 +26,8 @@ def test_create_service_page_with_contact_from_api(remote_staging_preview_url, t
     assert page.contact.name == 'Contact name'
 
 
-@pytest.mark.django_db
+# @pytest.mark.django_db
+@pytest.mark.skip("importer test")
 def test_create_service_page_with_department_from_api(remote_staging_preview_url, test_api_url, test_api_jwt_token):
     url = f'{remote_staging_preview_url}/services/UGFnZVJldmlzaW9uTm9kZTozNg==?CMS_API={test_api_url}'
     page = PageImporter(url, test_api_jwt_token).fetch_page_data().create_page()
@@ -141,7 +144,8 @@ def test_create_service_page_with_step_with_2_locations():
         assert step["value"] == expected_steps[i]["value"]
 
 
-@pytest.mark.django_db
+# @pytest.mark.django_db
+@pytest.mark.skip("importer test")
 def test_import_step_with_1_already_existing_location(remote_staging_preview_url, test_api_url, test_api_jwt_token):
     location_page = location_page_fixtures.title()
     url = f'{remote_staging_preview_url}/services/UGFnZVJldmlzaW9uTm9kZTo1OA==?CMS_API={test_api_url}'
@@ -152,7 +156,8 @@ def test_import_step_with_1_already_existing_location(remote_staging_preview_url
     assert page.steps.stream_data[0]["value"]["locations"][0] == location_page.pk
 
 
-@pytest.mark.django_db
+# @pytest.mark.django_db
+@pytest.mark.skip("importer test")
 def test_import_step_with_1_new_location(remote_staging_preview_url, test_api_url, test_api_jwt_token):
     url = f'{remote_staging_preview_url}/services/UGFnZVJldmlzaW9uTm9kZTo1OA==?CMS_API={test_api_url}'
     page = PageImporter(url, test_api_jwt_token).fetch_page_data().create_page()
@@ -163,7 +168,8 @@ def test_import_step_with_1_new_location(remote_staging_preview_url, test_api_ur
     assert not page.steps
 
 
-@pytest.mark.django_db
+# @pytest.mark.django_db
+@pytest.mark.skip("importer test")
 def test_import_step_with_1_already_existing_location_1_new_location(remote_staging_preview_url, test_api_url, test_api_jwt_token):
     location_page = location_page_fixtures.title()
     url = f'{remote_staging_preview_url}/services/UGFnZVJldmlzaW9uTm9kZTo2Mg==?CMS_API={test_api_url}'
@@ -175,7 +181,8 @@ def test_import_step_with_1_already_existing_location_1_new_location(remote_stag
     assert page.steps.stream_data[0]["value"]["locations"][0] == location_page.pk
 
 
-@pytest.mark.django_db
+# @pytest.mark.django_db
+@pytest.mark.skip("importer test")
 def test_import_step_with_2_already_existing_locations(remote_staging_preview_url, test_api_url, test_api_jwt_token):
     location_page_1 = location_page_fixtures.title()
     location_page_2 = location_page_fixtures.live_library()
@@ -187,7 +194,7 @@ def test_import_step_with_2_already_existing_locations(remote_staging_preview_ur
     assert page.steps.stream_data[0]["value"]["locations"][1] == location_page_2.pk
 
 
-@pytest.mark.django_db
+@pytest.mark.skip("importer test")
 def test_import_step_with_1_imported_and_some_unimported_internal_links(remote_staging_preview_url, test_api_url, test_api_jwt_token):
     # this fixture has the same slug as the first link of the page we're importing,
     # let's create it so the importer can link to it
@@ -204,7 +211,7 @@ def test_import_step_with_1_imported_and_some_unimported_internal_links(remote_s
     assert not page.live
 
 
-@pytest.mark.django_db
+@pytest.mark.skip("importer test")
 def test_import_step_with_1_imported_internal_link(remote_staging_preview_url, test_api_url, test_api_jwt_token):
     topic_page_fixtures.title()
     expected_steps = components.step_with_one_imported_internal_link()
@@ -219,7 +226,8 @@ def test_import_step_with_1_imported_internal_link(remote_staging_preview_url, t
         assert step["value"] == expected_steps[i]["value"]
 
 
-@pytest.mark.django_db
+# @pytest.mark.django_db
+@pytest.mark.skip("importer test")
 def test_do_not_import_english_as_spanish(remote_staging_preview_url, test_api_url, test_api_jwt_token):
     url = f'{remote_staging_preview_url}/services/UGFnZVJldmlzaW9uTm9kZTo3MA==?CMS_API={test_api_url}'
     page = PageImporter(url, test_api_jwt_token).fetch_page_data().create_page()
@@ -232,7 +240,8 @@ def test_do_not_import_english_as_spanish(remote_staging_preview_url, test_api_u
     assert page.slug_es is None
 
 
-@pytest.mark.django_db
+# @pytest.mark.django_db
+@pytest.mark.skip("importer test")
 def test_import_page_with_step_with_location_followed_by_basic_step(remote_staging_preview_url, test_api_url, test_api_jwt_token):
     url = f'{remote_staging_preview_url}/services/UGFnZVJldmlzaW9uTm9kZTo3Ng==?CMS_API={test_api_url}'
     page = PageImporter(url, test_api_jwt_token).fetch_page_data().create_page()


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description

Commenting out / marking "do not run" on importer tests, since they take time and we don't use importer on typical branches. 

If for some reason we bring back importer (turbo janis to prod janis for example), we can include the tests again. 


<!--- include a summary of the change and what it fixes. -->

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->

<!--- If there is a relevant Janis PR, link it here -->
<!--- [Janis Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
