### PR TITLE
5054 update search

### DIFF
--- a/joplin/pages/event_page/models.py
+++ b/joplin/pages/event_page/models.py
@@ -153,13 +153,13 @@ class EventPage(JanisBasePage):
             location_value = location['value']
             location_type = location['type']
 
-            if location_type == "remote_location":
+            if location_type == "remote_non_COA_location":
                 english_name = location_value['name_en']
                 if translation.get_language() == 'en':
                     return english_name
                 elif translation.get_language() == 'es':
                     return location_value['name_es'] or english_name
-            elif location_type == "city_location":
+            elif location_type == "city_of_Austin_location":
                 return LocationPage.objects.get(id=location_value['location_page']).title
         return ""
 

--- a/joplin/pages/event_page/models.py
+++ b/joplin/pages/event_page/models.py
@@ -161,6 +161,10 @@ class EventPage(JanisBasePage):
                     return location_value['name_es'] or english_name
             elif location_type == "city_of_Austin_location":
                 return LocationPage.objects.get(id=location_value['location_page']).title
+            elif location_type == "virtual_event":
+                if translation.get_language() == 'es':
+                    return "Evento Virtual"
+                return "Virtual Event"
         return ""
 
     @property
@@ -173,7 +177,7 @@ class EventPage(JanisBasePage):
             "endTime": self.end_time and self.end_time.isoformat(),
             "eventIsFree": self.event_is_free,
             "registrationUrl": self.registration_url,
-            "locationName": self.location_name,
+            "locationNameSearch": self.location_name,
             "eventUrl": self.janis_urls()[0],
             "feesRange": self.fees_range,
         })


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description

<!--- include a summary of the change and what it fixes. -->
After the event location names were updated, we needed to update the keys searched for in the search results. Also location names are handled in search on the joplin, but they are parsed on the frontend for general events display. I changed the name on the search results to prevent confusion/breaking on the frontend.

Virtual Events location gets returned based on language. 
 
<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->

<!--- If there is a relevant Janis PR, link it here -->
[Janis Related Pull Request Link](https://github.com/cityofaustin/janis/pull/908)

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 
https://joplin-pr-5054-events-search.herokuapp.com/admin/pages/search/

I have added some events to the joplin, see that you can search for them in janis:

https://janis-v3-5054-events-search.netlify.app/en/search/?page=1&q=party
admin@austintexas.io pw:x



# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
