### PR TITLE
5089 - add bold to rtf on official doc pages

### DIFF
--- a/joplin/pages/official_documents_page/models.py
+++ b/joplin/pages/official_documents_page/models.py
@@ -22,7 +22,7 @@ class OfficialDocumentPage(JanisBasePage):
     date = models.DateField(verbose_name="Document date", null=True, blank=True)
     authoring_office = models.CharField(verbose_name="Authoring office of document", max_length=DEFAULT_MAX_LENGTH,
                                         blank=True)
-    summary = RichTextField(verbose_name="Document summary", blank=True, features=['link'])
+    summary = RichTextField(verbose_name="Document summary", blank=True, features=['link', 'bold'])
     body = models.TextField(verbose_name="Document text", blank=True)
     name = models.CharField(verbose_name="Name of Document", max_length=DEFAULT_MAX_LENGTH, blank=True)
     document = models.ForeignKey(Document, null=True, blank=True, on_delete=models.SET_NULL, related_name='+',


### PR DESCRIPTION
<!--- Remember to connect this PR to a relevant issue on Zenhub! -->

# Description

OPO needs to be able to bold type in the description. Adds it as an option for the rich text field. 

<!--- include a summary of the change and what it fixes. -->

<!--- Fixes # paste issue link here, but really you should connect it on Zenhub! <3 -->

<!--- If there is a relevant Janis PR, link it here -->
<!--- [Janis Related Pull Request Link]() -->

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How can this be tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- deployed links if you have them --> 

https://joplin-pr-5089-bold-rtf.herokuapp.com/admin/pages/27/edit/#tab-content

and there is a janis connected: https://janis-v3-5089-bold-rtf.netlify.app/
https://janis-v3-5089-bold-rtf.netlify.app/kitchen-sink-department/what-a-bold-document/

# Checklist:
- [ ] Request reviewers
- [ ] Slack-out message for review
- [ ] Link this PR in the issue
- [ ] Moved card to *review* in zenhub
